### PR TITLE
Split retract/assert cascade output into Went OUT and Went IN

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -203,11 +203,14 @@ def retract_node(node_id: str, reason: str = "", db_path: str = DEFAULT_DB) -> d
         reason: Why this node is being retracted
         db_path: Path to database
 
-    Returns: {"changed": list[str]}
+    Returns: {"changed": list[str], "went_out": list[str], "went_in": list[str]}
     """
     with _with_network(db_path, write=True) as net:
+        before = {nid: n.truth_value for nid, n in net.nodes.items()}
         changed = net.retract(node_id, reason=reason)
-        return {"changed": changed}
+        went_out = [nid for nid in changed if before.get(nid) == "IN" and net.nodes[nid].truth_value == "OUT"]
+        went_in = [nid for nid in changed if before.get(nid) == "OUT" and net.nodes[nid].truth_value == "IN"]
+        return {"changed": changed, "went_out": went_out, "went_in": went_in}
 
 
 def what_if_retract(node_id: str, db_path: str = DEFAULT_DB) -> dict:
@@ -350,11 +353,14 @@ def _cascade_depth(net, target_id: str, retracted_id: str) -> int:
 def assert_node(node_id: str, db_path: str = DEFAULT_DB) -> dict:
     """Assert a node and cascade restoration.
 
-    Returns: {"changed": list[str]}
+    Returns: {"changed": list[str], "went_out": list[str], "went_in": list[str]}
     """
     with _with_network(db_path, write=True) as net:
+        before = {nid: n.truth_value for nid, n in net.nodes.items()}
         changed = net.assert_node(node_id)
-        return {"changed": changed}
+        went_out = [nid for nid in changed if before.get(nid) == "IN" and net.nodes[nid].truth_value == "OUT"]
+        went_in = [nid for nid in changed if before.get(nid) == "OUT" and net.nodes[nid].truth_value == "IN"]
+        return {"changed": changed, "went_out": went_out, "went_in": went_in}
 
 
 def get_status(db_path: str = DEFAULT_DB) -> dict:

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -41,6 +41,20 @@ def cmd_add(args):
         sys.exit(1)
 
 
+def _print_cascade(result):
+    """Print cascade results, splitting went_out from went_in."""
+    went_out = result.get("went_out", [])
+    went_in = result.get("went_in", [])
+    if went_out:
+        print(f"  Went OUT ({len(went_out)}):")
+        for nid in went_out:
+            print(f"    [-] {nid}")
+    if went_in:
+        print(f"  Went IN ({len(went_in)}):")
+        for nid in went_in:
+            print(f"    [+] {nid}")
+
+
 def cmd_retract(args):
     try:
         result = api.retract_node(args.node_id, reason=args.reason or "", db_path=args.db)
@@ -51,7 +65,8 @@ def cmd_retract(args):
     if not result["changed"]:
         print(f"{args.node_id} is already OUT")
     else:
-        print(f"Retracted: {', '.join(result['changed'])}")
+        print(f"Retracted {args.node_id}")
+        _print_cascade(result)
 
 
 def cmd_assert(args):
@@ -64,7 +79,8 @@ def cmd_assert(args):
     if not result["changed"]:
         print(f"{args.node_id} is already IN")
     else:
-        print(f"Asserted: {', '.join(result['changed'])}")
+        print(f"Asserted {args.node_id}")
+        _print_cascade(result)
 
 
 def _print_what_if_results(result, action, node_id):


### PR DESCRIPTION
## Summary

- `retract_node` and `assert_node` API functions now return `went_out` and `went_in` lists alongside the existing `changed` list (backwards compatible)
- CLI output for `reasons retract` and `reasons assert` now separates nodes that lost support (went OUT) from nodes that lost a blocker (went IN)
- Shared `_print_cascade` helper for both commands

## The problem

Previously `reasons retract foo` printed all cascade changes in a flat list:
```
Retracted: foo, derived-from-foo, gated-on-foo
```
This made it look like everything broke, when `gated-on-foo` actually *improved* (went IN because its blocker was removed).

## After

```
Retracted foo
  Went OUT (2):
    [-] foo
    [-] derived-from-foo
  Went IN (1):
    [+] gated-on-foo
```

## Test plan

- [x] Full test suite passes (267 tests)
- [x] Smoke tested with a network containing both SL and outlist dependencies

Generated with [Claude Code](https://claude.com/claude-code)