### PR TITLE
Add CI workflow for unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Run tests
+        run: uv run --extra test pytest tests/ -v


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs the test suite on push to main and on PRs
- Tests across Python 3.10, 3.11, 3.12, and 3.13 using uv
- Uses `astral-sh/setup-uv` for fast dependency resolution

## Test plan
- [ ] Verify workflow runs on this PR
- [ ] Confirm all 211+ tests pass across all Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)