### PR TITLE
Run propagate after import-agent (fixes #9)

### DIFF
--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -323,19 +323,11 @@ def cmd_trace(args):
 
 
 def cmd_propagate(args):
-    # Propagate is a special case — not in api.py since it's a maintenance operation
     from .storage import Storage
     store = Storage(args.db)
     net = store.load()
 
-    changed = []
-    for node in net.nodes.values():
-        if node.justifications:
-            old = node.truth_value
-            new = net._compute_truth(node)
-            if old != new:
-                node.truth_value = new
-                changed.append(node.id)
+    changed = net.recompute_all()
 
     store.save(net)
     store.close()

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -395,6 +395,8 @@ def cmd_import_agent(args):
         print(f"  Skipped:   {result['claims_skipped']} (already in network)")
     if result['claims_retracted']:
         print(f"  Retracted: {result['claims_retracted']} (STALE/OUT in source)")
+    if result.get('claims_propagated'):
+        print(f"  Propagated: {result['claims_propagated']} (truth values recomputed)")
     if result['nogoods_imported']:
         print(f"  Nogoods:   {result['nogoods_imported']}")
     print(f"\n  To revoke all: reasons retract {result['active_node']}")

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -165,18 +165,7 @@ def import_agent(
                 network.nogoods.append(nogood)
                 nogoods_imported += 1
 
-    # Recompute truth values from the justification graph.
-    # Imported truth values (IN/OUT) may not match what the justifications
-    # actually support, since the source snapshot can diverge from the
-    # imported dependency structure.
-    propagated = 0
-    for node in network.nodes.values():
-        if node.justifications:
-            old = node.truth_value
-            new = network._compute_truth(node)
-            if old != new:
-                node.truth_value = new
-                propagated += 1
+    propagated = len(network.recompute_all())
 
     return {
         "agent": agent_name,

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -165,6 +165,19 @@ def import_agent(
                 network.nogoods.append(nogood)
                 nogoods_imported += 1
 
+    # Recompute truth values from the justification graph.
+    # Imported truth values (IN/OUT) may not match what the justifications
+    # actually support, since the source snapshot can diverge from the
+    # imported dependency structure.
+    propagated = 0
+    for node in network.nodes.values():
+        if node.justifications:
+            old = node.truth_value
+            new = network._compute_truth(node)
+            if old != new:
+                node.truth_value = new
+                propagated += 1
+
     return {
         "agent": agent_name,
         "prefix": prefix,
@@ -173,5 +186,6 @@ def import_agent(
         "claims_imported": imported,
         "claims_skipped": skipped,
         "claims_retracted": retracted,
+        "claims_propagated": propagated,
         "nogoods_imported": nogoods_imported,
     }

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -616,18 +616,24 @@ class Network:
     def recompute_all(self) -> list[str]:
         """Recompute truth values for all derived nodes from the justification graph.
 
-        Returns list of node IDs whose truth values changed.
+        Iterates to a fixpoint so cascading changes propagate regardless of
+        node insertion order.  Returns list of node IDs whose truth values changed.
         """
-        changed = []
-        for nid, node in self.nodes.items():
-            if node.justifications:
-                old = node.truth_value
-                new = self._compute_truth(node)
-                if old != new:
-                    node.truth_value = new
-                    changed.append(nid)
-                    self._log("recompute", nid, new)
-        return changed
+        all_changed: set[str] = set()
+        while True:
+            changed_this_pass = []
+            for nid, node in self.nodes.items():
+                if node.justifications:
+                    old = node.truth_value
+                    new = self._compute_truth(node)
+                    if old != new:
+                        node.truth_value = new
+                        changed_this_pass.append(nid)
+                        self._log("recompute", nid, new)
+            if not changed_this_pass:
+                break
+            all_changed.update(changed_this_pass)
+        return list(all_changed)
 
     def _propagate(self, changed_id: str) -> list[str]:
         """BFS propagation of truth value changes through dependents."""

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -620,7 +620,8 @@ class Network:
         node insertion order.  Returns list of node IDs whose truth values changed.
         """
         all_changed: set[str] = set()
-        while True:
+        max_iterations = len(self.nodes) + 1
+        for _ in range(max_iterations):
             changed_this_pass = []
             for nid, node in self.nodes.items():
                 if node.justifications:

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -613,6 +613,22 @@ class Network:
         """Return all node IDs currently IN."""
         return [nid for nid, node in self.nodes.items() if node.truth_value == "IN"]
 
+    def recompute_all(self) -> list[str]:
+        """Recompute truth values for all derived nodes from the justification graph.
+
+        Returns list of node IDs whose truth values changed.
+        """
+        changed = []
+        for nid, node in self.nodes.items():
+            if node.justifications:
+                old = node.truth_value
+                new = self._compute_truth(node)
+                if old != new:
+                    node.truth_value = new
+                    changed.append(nid)
+                    self._log("recompute", nid, new)
+        return changed
+
     def _propagate(self, changed_id: str) -> list[str]:
         """BFS propagation of truth value changes through dependents."""
         changed = []

--- a/tests/test_import_agent.py
+++ b/tests/test_import_agent.py
@@ -96,17 +96,17 @@ def test_import_agent_retract_premise_cascades(db, beliefs_file):
     api.import_agent("test-agent", beliefs_file, db_path=db)
 
     result = api.what_if_retract("test-agent:active", db_path=db)
-    # All IN beliefs (alpha-fact, beta-depends-alpha) should cascade OUT
-    # gamma-stale is already OUT so not affected
-    assert result["total_affected"] == 2
+    # All IN beliefs cascade OUT: alpha-fact, beta-depends-alpha, gamma-stale
+    # (gamma-stale was propagated IN after import since its justification is satisfied)
+    assert result["total_affected"] == 3
 
 
 def test_import_agent_retract_premise_actually_cascades(db, beliefs_file):
     api.import_agent("test-agent", beliefs_file, db_path=db)
 
     result = api.retract_node("test-agent:active", db_path=db)
-    # active + alpha-fact + beta-depends-alpha
-    assert len(result["changed"]) == 3
+    # active + alpha-fact + beta-depends-alpha + gamma-stale
+    assert len(result["changed"]) == 4
 
     # Verify they're all OUT now
     alpha = api.show_node("test-agent:alpha-fact", db_path=db)
@@ -164,6 +164,33 @@ def test_import_multiple_agents(db, beliefs_file):
     b = api.show_node("agent-b:alpha-fact", db_path=db)
     assert a["truth_value"] == "OUT"
     assert b["truth_value"] == "IN"
+
+
+def test_import_agent_propagates_truth_values(db, tmp_path):
+    """OUT beliefs with all antecedents IN should flip IN after propagation."""
+    beliefs_text = """\
+## Beliefs
+
+### base-fact [IN] OBSERVATION
+A base fact
+- Source: test.md
+- Date: 2026-04-17
+
+### derived-out [OUT] DERIVED
+Derived but marked OUT in source snapshot
+- Source: test.md
+- Date: 2026-04-17
+- Depends on: base-fact
+"""
+    p = tmp_path / "propagate_beliefs.md"
+    p.write_text(beliefs_text)
+
+    result = api.import_agent("prop-agent", str(p), db_path=db)
+
+    assert result["claims_propagated"] >= 1
+
+    node = api.show_node("prop-agent:derived-out", db_path=db)
+    assert node["truth_value"] == "IN"
 
 
 def test_import_agent_nogoods(db, beliefs_file):


### PR DESCRIPTION
## Summary
- Adds a propagation pass after `import-agent` completes, recomputing all derived truth values from the actual justification graph
- Fixes the bug where 212 beliefs were incorrectly OUT after import because source snapshot truth values overrode justification logic
- Reports propagation count in CLI output (`Propagated: N (truth values recomputed)`)
- Updates existing cascade tests to reflect correct behavior (gamma-stale now correctly IN after import)

## Test plan
- [x] New test: `test_import_agent_propagates_truth_values` — OUT belief with satisfied justification flips IN
- [x] Updated cascade tests to match corrected truth values
- [x] Full suite: 268 tests pass

Generated with [Claude Code](https://claude.com/claude-code)