### PR TITLE
Strip backticks from IDs in derive parser (fixes #10)

### DIFF
--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -303,10 +303,10 @@ def parse_proposals(response):
     for match in new_pattern.finditer(response):
         proposal = {
             "kind": match.group(1).lower(),
-            "id": match.group(2),
+            "id": match.group(2).strip("`"),
             "text": match.group(3).strip(),
-            "antecedents": [a.strip() for a in match.group(4).split(",")],
-            "unless": [u.strip() for u in match.group(5).split(",")]
+            "antecedents": [a.strip().strip("`") for a in match.group(4).split(",")],
+            "unless": [u.strip().strip("`") for u in match.group(5).split(",")]
                       if match.group(5) else [],
             "label": match.group(6).strip(),
         }

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -169,6 +169,22 @@ Second gated belief
     assert len(proposals) == 2
 
 
+def test_parse_proposals_strips_backticks():
+    response = """
+### DERIVE `cross-validated-readiness`
+Production readiness is cross-validated
+- Antecedents: `product:production-readiness`, `code:full-stack-reliability`
+- Unless: `blocker:critical-bug`
+- Label: cross-validated
+"""
+    proposals = parse_proposals(response)
+    assert len(proposals) == 1
+    p = proposals[0]
+    assert p["id"] == "cross-validated-readiness"
+    assert p["antecedents"] == ["product:production-readiness", "code:full-stack-reliability"]
+    assert p["unless"] == ["blocker:critical-bug"]
+
+
 def test_validate_proposals_missing_antecedent():
     nodes = {"fact-a": {}, "fact-b": {}}
     proposals = [


### PR DESCRIPTION
## Summary
- Adds backtick stripping to the v0.10+ derive format parser for proposal IDs, antecedents, and outlist references
- Matches the old v0.9 parser's behavior which already stripped backticks
- Fixes 33 derived beliefs that were permanently OUT due to backtick-wrapped references not matching node IDs

## Test plan
- [x] New test: `test_parse_proposals_strips_backticks` — verifies backticks stripped from ID, antecedents, and outlist
- [x] Full suite: 269 tests pass

Generated with [Claude Code](https://claude.com/claude-code)