### PR TITLE
Preserve outlist in import, support JSON import-agent (fixes #11)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -608,7 +608,10 @@ def import_agent(
     only_in: bool = False,
     db_path: str = DEFAULT_DB,
 ) -> dict:
-    """Import another agent's beliefs.md into the local RMS with namespacing.
+    """Import another agent's beliefs into the local RMS with namespacing.
+
+    Accepts beliefs.md (markdown) or network.json (JSON export) files.
+    JSON files preserve full justification structure including outlists.
 
     Each belief is prefixed with 'agent_name:' and depends on a premise
     node 'agent_name:active'. Retracting that premise cascades OUT all
@@ -616,11 +619,26 @@ def import_agent(
 
     Returns: {"agent": str, "claims_imported": int, "claims_skipped": int, ...}
     """
-    from .import_agent import import_agent as _import_agent
-
     beliefs_path = Path(beliefs_file)
     if not beliefs_path.exists():
         raise FileNotFoundError(f"File not found: {beliefs_file}")
+
+    if beliefs_path.suffix == ".json":
+        from .import_agent import import_agent_json as _import_agent_json
+        import json as json_mod
+
+        data = json_mod.loads(beliefs_path.read_text())
+
+        with _with_network(db_path, write=True) as net:
+            return _import_agent_json(
+                net,
+                agent_name=agent_name,
+                data=data,
+                only_in=only_in,
+                source_path=str(beliefs_path),
+            )
+
+    from .import_agent import import_agent as _import_agent
 
     beliefs_text = beliefs_path.read_text()
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -925,7 +925,7 @@ def main():
     # import-agent
     p = sub.add_parser("import-agent", help="Import another agent's beliefs with namespacing")
     p.add_argument("agent_name", help="Agent name (used as namespace prefix)")
-    p.add_argument("beliefs_file", help="Path to the agent's beliefs.md")
+    p.add_argument("beliefs_file", help="Path to the agent's beliefs.md or network.json")
     p.add_argument("--nogoods", dest="nogoods_file", help="Path to nogoods.md (auto-detected if next to beliefs.md)")
     p.add_argument("--only-in", action="store_true", help="Only import beliefs with status IN")
 

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -260,7 +260,7 @@ def import_agent_json(
             antecedents = [active_id]
             for a in j.get("antecedents", []):
                 antecedents.append(f"{prefix}{a}")
-            outlist = [f"{prefix}{o}" for o in j.get("outlist", [])]
+            outlist = [f"{prefix}{o}" for o in j.get("outlist", []) if o in nodes]
             justifications.append(Justification(
                 type=j.get("type", "SL"),
                 antecedents=antecedents,

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -11,12 +11,13 @@ the local RMS handle truth maintenance across agents.
 
 Usage:
     reasons import-agent aap-expert ~/git/aap-expert/beliefs.md
+    reasons import-agent rhel-expert ~/git/rhel-expert/network.json
     reasons import-agent rhel-expert ~/git/rhel-expert/beliefs.md --only-in
 """
 
 from pathlib import Path
 
-from . import Justification
+from . import Justification, Nogood
 from .import_beliefs import parse_beliefs, parse_nogoods
 from .network import Network
 
@@ -109,14 +110,21 @@ def import_agent(
         antecedents = [active_id]
         for dep_id in claim["depends_on"]:
             prefixed_dep = f"{prefix}{dep_id}"
-            # Only add if the dependency exists in this import set
             if dep_id in claim_by_id:
                 antecedents.append(prefixed_dep)
+
+        # Build outlist: remap unless references to namespaced IDs
+        outlist = []
+        for out_id in claim.get("unless", []):
+            prefixed_out = f"{prefix}{out_id}"
+            if out_id in claim_by_id:
+                outlist.append(prefixed_out)
 
         justifications = [
             Justification(
                 type="SL",
                 antecedents=antecedents,
+                outlist=outlist,
                 label=f"imported from agent: {agent_name}",
             )
         ]
@@ -149,7 +157,6 @@ def import_agent(
     nogoods_imported = 0
     if nogoods_text:
         nogoods = parse_nogoods(nogoods_text)
-        from . import Nogood
         for ng in nogoods:
             prefixed_nodes = [f"{prefix}{a}" for a in ng["affects"]]
             valid_nodes = [n for n in prefixed_nodes if n in network.nodes]
@@ -164,6 +171,148 @@ def import_agent(
                 )
                 network.nogoods.append(nogood)
                 nogoods_imported += 1
+
+    propagated = len(network.recompute_all())
+
+    return {
+        "agent": agent_name,
+        "prefix": prefix,
+        "active_node": active_id,
+        "created_premise": created_premise,
+        "claims_imported": imported,
+        "claims_skipped": skipped,
+        "claims_retracted": retracted,
+        "claims_propagated": propagated,
+        "nogoods_imported": nogoods_imported,
+    }
+
+
+def import_agent_json(
+    network: Network,
+    agent_name: str,
+    data: dict,
+    only_in: bool = False,
+    source_path: str = "",
+) -> dict:
+    """Import an agent's beliefs from JSON export with namespacing.
+
+    JSON format preserves full justification structure including outlists,
+    providing lossless import of non-monotonic relationships.
+    """
+    prefix = f"{agent_name}:"
+    active_id = f"{agent_name}:active"
+
+    if active_id not in network.nodes:
+        network.add_node(
+            id=active_id,
+            text=f"Agent '{agent_name}' beliefs are trusted",
+            source=source_path,
+            metadata={"agent": agent_name, "role": "agent_premise"},
+        )
+        created_premise = True
+    else:
+        created_premise = False
+
+    nodes = data.get("nodes", {})
+
+    if only_in:
+        nodes = {k: v for k, v in nodes.items() if v.get("truth_value") == "IN"}
+
+    # Topological sort by antecedent references
+    ordered = []
+    added = set()
+    remaining = dict(nodes)
+
+    max_passes = len(remaining) + 1
+    for _ in range(max_passes):
+        if not remaining:
+            break
+        next_remaining = {}
+        for nid, ndata in remaining.items():
+            all_antes = []
+            for j in ndata.get("justifications", []):
+                all_antes.extend(j.get("antecedents", []))
+            deps_in_set = [a for a in all_antes if a in nodes]
+            if all(d in added for d in deps_in_set):
+                ordered.append((nid, ndata))
+                added.add(nid)
+            else:
+                next_remaining[nid] = ndata
+        if len(next_remaining) == len(remaining):
+            ordered.extend(next_remaining.items())
+            break
+        remaining = next_remaining
+
+    imported = 0
+    skipped = 0
+    retracted = 0
+
+    for nid, ndata in ordered:
+        node_id = f"{prefix}{nid}"
+
+        if node_id in network.nodes:
+            skipped += 1
+            continue
+
+        # Rebuild justifications with namespaced references
+        justifications = []
+        for j in ndata.get("justifications", []):
+            antecedents = [active_id]
+            for a in j.get("antecedents", []):
+                antecedents.append(f"{prefix}{a}")
+            outlist = [f"{prefix}{o}" for o in j.get("outlist", [])]
+            justifications.append(Justification(
+                type=j.get("type", "SL"),
+                antecedents=antecedents,
+                outlist=outlist,
+                label=j.get("label", f"imported from agent: {agent_name}"),
+            ))
+
+        is_premise = not ndata.get("justifications")
+        if not justifications and not (is_premise and ndata.get("truth_value") == "OUT"):
+            justifications = [Justification(
+                type="SL",
+                antecedents=[active_id],
+                label=f"imported from agent: {agent_name}",
+            )]
+
+        metadata = ndata.get("metadata", {}).copy()
+        metadata.update({
+            "agent": agent_name,
+            "original_id": nid,
+            "imported_from": source_path,
+        })
+
+        network.add_node(
+            id=node_id,
+            text=ndata.get("text", ""),
+            justifications=justifications if justifications else None,
+            source=ndata.get("source", ""),
+            source_hash=ndata.get("source_hash", ""),
+            date=ndata.get("date", ""),
+            metadata=metadata,
+        )
+        imported += 1
+
+        if ndata.get("truth_value") == "OUT":
+            network.retract(node_id)
+            retracted += 1
+
+    # Import nogoods
+    nogoods_imported = 0
+    for ng in data.get("nogoods", []):
+        prefixed_nodes = [f"{prefix}{n}" for n in ng.get("nodes", [])]
+        valid_nodes = [n for n in prefixed_nodes if n in network.nodes]
+        nogood_id = f"{prefix}{ng['id']}"
+        existing_ids = {n.id for n in network.nogoods}
+        if len(valid_nodes) >= 2 and nogood_id not in existing_ids:
+            network.nogoods.append(Nogood(
+                id=nogood_id,
+                nodes=valid_nodes,
+                discovered=ng.get("discovered", ""),
+                resolution=ng.get("resolution", ""),
+            ))
+            nogoods_imported += 1
 
     propagated = len(network.recompute_all())
 

--- a/reasons_lib/import_beliefs.py
+++ b/reasons_lib/import_beliefs.py
@@ -58,6 +58,7 @@ def parse_beliefs(text: str) -> list[dict]:
                 "source_hash": "",
                 "date": "",
                 "depends_on": [],
+                "unless": [],
                 "stale_reason": "",
                 "superseded_by": "",
             }
@@ -75,6 +76,9 @@ def parse_beliefs(text: str) -> list[dict]:
         elif line.startswith("- Depends on: "):
             deps = line[len("- Depends on: "):].strip()
             current["depends_on"] = [d.strip() for d in deps.split(",") if d.strip()]
+        elif line.startswith("- Unless: "):
+            unless = line[len("- Unless: "):].strip()
+            current["unless"] = [u.strip() for u in unless.split(",") if u.strip()]
         elif line.lower().startswith("- stale reason: "):
             current["stale_reason"] = line[line.index(": ") + 2:].strip()
         elif line.lower().startswith("- superseded by: "):
@@ -182,14 +186,16 @@ def import_into_network(
             skipped += 1
             continue
 
-        # Build justifications from depends_on
+        # Build justifications from depends_on and unless
         justifications = None
         deps_in_network = [d for d in claim["depends_on"] if d in claim_by_id]
-        if deps_in_network:
+        unless_in_network = [u for u in claim.get("unless", []) if u in claim_by_id]
+        if deps_in_network or unless_in_network:
             justifications = [
                 Justification(
                     type="SL",
                     antecedents=deps_in_network,
+                    outlist=unless_in_network,
                     label=f"imported from beliefs: {claim['type']}",
                 )
             ]

--- a/tests/test_import_agent.py
+++ b/tests/test_import_agent.py
@@ -193,6 +193,154 @@ Derived but marked OUT in source snapshot
     assert node["truth_value"] == "IN"
 
 
+def test_import_agent_preserves_outlist(db, tmp_path):
+    """Unless/outlist relationships should survive import with namespacing."""
+    beliefs_text = """\
+## Beliefs
+
+### base-fact [IN] OBSERVATION
+A base fact
+- Source: test.md
+- Date: 2026-04-17
+
+### blocker [IN] OBSERVATION
+A blocking condition
+- Source: test.md
+- Date: 2026-04-17
+
+### gated-belief [IN] DERIVED
+Only true when blocker is OUT
+- Source: test.md
+- Date: 2026-04-17
+- Depends on: base-fact
+- Unless: blocker
+"""
+    p = tmp_path / "outlist_beliefs.md"
+    p.write_text(beliefs_text)
+
+    api.import_agent("ol-agent", str(p), db_path=db)
+
+    node = api.show_node("ol-agent:gated-belief", db_path=db)
+    j = node["justifications"][0]
+    assert "ol-agent:base-fact" in j["antecedents"]
+    assert "ol-agent:blocker" in j["outlist"]
+    # blocker is IN, so gated-belief should be OUT
+    assert node["truth_value"] == "OUT"
+
+
+def test_import_agent_supersession_preserved(db, tmp_path):
+    """Supersession via outlist: v1 stays OUT when v2 is IN."""
+    beliefs_text = """\
+## Beliefs
+
+### security-v1 [OUT] OBSERVATION
+Old security posture
+- Source: test.md
+- Date: 2026-04-17
+- Unless: security-v2
+
+### security-v2 [IN] OBSERVATION
+New security posture that supersedes v1
+- Source: test.md
+- Date: 2026-04-17
+"""
+    p = tmp_path / "supersede_beliefs.md"
+    p.write_text(beliefs_text)
+
+    api.import_agent("sec-agent", str(p), db_path=db)
+
+    v1 = api.show_node("sec-agent:security-v1", db_path=db)
+    v2 = api.show_node("sec-agent:security-v2", db_path=db)
+    assert v2["truth_value"] == "IN"
+    assert v1["truth_value"] == "OUT"
+    assert "sec-agent:security-v2" in v1["justifications"][0]["outlist"]
+
+
+def test_import_agent_json(db, tmp_path):
+    """Import from JSON export preserves full justification structure."""
+    import json
+
+    data = {
+        "nodes": {
+            "premise-a": {
+                "text": "A premise",
+                "truth_value": "IN",
+                "justifications": [],
+                "source": "test.md",
+            },
+            "derived-b": {
+                "text": "Derived from A unless C",
+                "truth_value": "IN",
+                "justifications": [{
+                    "type": "SL",
+                    "antecedents": ["premise-a"],
+                    "outlist": ["blocker-c"],
+                    "label": "test justification",
+                }],
+                "source": "test.md",
+            },
+            "blocker-c": {
+                "text": "A blocker",
+                "truth_value": "OUT",
+                "justifications": [],
+                "source": "test.md",
+            },
+        },
+        "nogoods": [],
+    }
+
+    p = tmp_path / "network.json"
+    p.write_text(json.dumps(data))
+
+    result = api.import_agent("json-agent", str(p), db_path=db)
+    assert result["claims_imported"] == 3
+
+    node = api.show_node("json-agent:derived-b", db_path=db)
+    j = node["justifications"][0]
+    assert "json-agent:premise-a" in j["antecedents"]
+    assert "json-agent:blocker-c" in j["outlist"]
+    assert node["truth_value"] == "IN"
+
+
+def test_import_agent_json_outlist_blocks(db, tmp_path):
+    """JSON import: when outlist node is IN, gated belief stays OUT."""
+    import json
+
+    data = {
+        "nodes": {
+            "fact": {
+                "text": "A fact",
+                "truth_value": "IN",
+                "justifications": [],
+            },
+            "blocker": {
+                "text": "Active blocker",
+                "truth_value": "IN",
+                "justifications": [],
+            },
+            "gated": {
+                "text": "Gated on blocker being OUT",
+                "truth_value": "IN",
+                "justifications": [{
+                    "type": "SL",
+                    "antecedents": ["fact"],
+                    "outlist": ["blocker"],
+                    "label": "gated",
+                }],
+            },
+        },
+        "nogoods": [],
+    }
+
+    p = tmp_path / "network.json"
+    p.write_text(json.dumps(data))
+
+    api.import_agent("gate-agent", str(p), db_path=db)
+
+    node = api.show_node("gate-agent:gated", db_path=db)
+    assert node["truth_value"] == "OUT"
+
+
 def test_import_agent_nogoods(db, beliefs_file):
     result = api.import_agent("test-agent", beliefs_file, db_path=db)
     assert result["nogoods_imported"] == 1

--- a/tests/test_import_beliefs.py
+++ b/tests/test_import_beliefs.py
@@ -102,6 +102,21 @@ class TestParseBeliefs:
         assert by_id["derived-c"]["depends_on"] == ["premise-a", "premise-b"]
         assert by_id["premise-a"]["depends_on"] == []
 
+    def test_parses_unless(self):
+        text = """\
+### gated [IN] DERIVED
+A gated belief
+- Depends on: fact-a
+- Unless: blocker-x, blocker-y
+"""
+        claims = parse_beliefs(text)
+        assert claims[0]["unless"] == ["blocker-x", "blocker-y"]
+
+    def test_parses_unless_empty_default(self):
+        claims = parse_beliefs(SAMPLE_BELIEFS)
+        by_id = {c["id"]: c for c in claims}
+        assert by_id["premise-a"]["unless"] == []
+
     def test_parses_stale_metadata(self):
         claims = parse_beliefs(SAMPLE_BELIEFS)
         by_id = {c["id"]: c for c in claims}


### PR DESCRIPTION
## Summary
- `parse_beliefs()` now extracts `- Unless:` lines from beliefs.md
- `import-agent` preserves outlist/supersession relationships with proper namespacing
- `import-agent` auto-detects `.json` files and imports from JSON export format (lossless justification structure)
- OUT premise nodes in JSON import stay OUT instead of being overridden by recompute

## Test plan
- [x] `test_parses_unless` / `test_parses_unless_empty_default` — parse_beliefs extracts Unless field
- [x] `test_import_agent_preserves_outlist` — outlist wired with namespacing, gated belief stays OUT when blocker is IN
- [x] `test_import_agent_supersession_preserved` — v1 stays OUT when superseded by v2 via outlist
- [x] `test_import_agent_json` — JSON import preserves full justification structure including outlists
- [x] `test_import_agent_json_outlist_blocks` — JSON import correctly blocks gated beliefs
- [x] Full suite: 275 tests pass

Generated with [Claude Code](https://claude.com/claude-code)