### PR TITLE
Fix import-agent: active premise defeats per-belief retraction (#16)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -557,7 +557,7 @@ def export_network(db_path: str = DEFAULT_DB) -> dict:
                     "source": n.source,
                     "source_hash": n.source_hash,
                     "date": n.date,
-                    "metadata": n.metadata,
+                    "metadata": {k: v for k, v in n.metadata.items() if not k.startswith("_")},
                 }
                 for nid, n in sorted(net.nodes.items())
             },

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -2,12 +2,13 @@
 
 Creates namespaced nodes (agent:belief-id) so beliefs from multiple agents
 can coexist without collision. Each agent gets a premise node (agent:active)
-that all its beliefs depend on — retracting it cascades OUT every belief
-from that agent.
+and a relay node (agent:inactive) that provides a kill switch — retracting
+agent:active makes agent:inactive go IN, which cascades OUT every belief
+from that agent via outlist.
 
-This implements multi-agent belief tracking at the file level: read another
-agent's beliefs.md or network.json, import them with provenance, and let
-the local RMS handle truth maintenance across agents.
+The agent:active premise is NOT placed in antecedents (which would provide
+an always-valid fallback defeating per-belief retraction). Instead,
+agent:inactive is placed in the outlist of each imported belief.
 
 Usage:
     reasons import-agent aap-expert ~/git/aap-expert/beliefs.md
@@ -22,6 +23,52 @@ from .import_beliefs import parse_beliefs, parse_nogoods
 from .network import Network
 
 
+def _fixup_dependents(network):
+    """Re-register dependents for all nodes.
+
+    Outlist nodes may have been added after the nodes that reference them,
+    so add_node couldn't register the dependency at creation time.
+    """
+    for node in network.nodes.values():
+        for j in node.justifications:
+            for ant_id in j.antecedents:
+                if ant_id in network.nodes:
+                    network.nodes[ant_id].dependents.add(node.id)
+            for out_id in j.outlist:
+                if out_id in network.nodes:
+                    network.nodes[out_id].dependents.add(node.id)
+
+
+def _ensure_agent_nodes(network, agent_name, source_path=""):
+    """Create agent:active and agent:inactive nodes if they don't exist.
+
+    Returns (active_id, inactive_id, created_premise).
+    """
+    active_id = f"{agent_name}:active"
+    inactive_id = f"{agent_name}:inactive"
+
+    created_premise = False
+    if active_id not in network.nodes:
+        network.add_node(
+            id=active_id,
+            text=f"Agent '{agent_name}' beliefs are trusted",
+            source=source_path,
+            metadata={"agent": agent_name, "role": "agent_premise"},
+        )
+        created_premise = True
+
+    if inactive_id not in network.nodes:
+        network.add_node(
+            id=inactive_id,
+            text=f"Agent '{agent_name}' kill switch — IN when active is OUT",
+            justifications=[Justification(type="SL", antecedents=[], outlist=[active_id])],
+            source=source_path,
+            metadata={"agent": agent_name, "role": "agent_inactive"},
+        )
+
+    return active_id, inactive_id, created_premise
+
+
 def import_agent(
     network: Network,
     agent_name: str,
@@ -33,9 +80,12 @@ def import_agent(
     """Import another agent's beliefs into the network with namespacing.
 
     Each belief is prefixed with 'agent_name:' to avoid ID collisions.
-    A premise node 'agent_name:active' is created — all imported beliefs
-    depend on it via SL justification. Retracting 'agent_name:active'
-    cascades OUT every belief from that agent.
+    A premise node 'agent_name:active' is created along with a relay node
+    'agent_name:inactive' (IN when active is OUT). Imported beliefs have
+    inactive in their outlist — retracting active cascades everything OUT.
+
+    Beliefs that are OUT/STALE in the source are imported as bare premises
+    with no justification, so recompute_all cannot resurrect them.
 
     Args:
         network: The local RMS network to import into.
@@ -49,19 +99,9 @@ def import_agent(
         Summary dict with counts.
     """
     prefix = f"{agent_name}:"
-    active_id = f"{agent_name}:active"
-
-    # Create or reuse the agent premise node
-    if active_id not in network.nodes:
-        network.add_node(
-            id=active_id,
-            text=f"Agent '{agent_name}' beliefs are trusted",
-            source=source_path,
-            metadata={"agent": agent_name, "role": "agent_premise"},
-        )
-        created_premise = True
-    else:
-        created_premise = False
+    active_id, inactive_id, created_premise = _ensure_agent_nodes(
+        network, agent_name, source_path
+    )
 
     claims = parse_beliefs(beliefs_text)
 
@@ -96,7 +136,7 @@ def import_agent(
     imported = 0
     skipped = 0
     retracted = 0
-    updated = 0
+    retract_after = []
 
     for claim in ordered:
         node_id = f"{prefix}{claim['id']}"
@@ -105,29 +145,31 @@ def import_agent(
             skipped += 1
             continue
 
-        # Build antecedents: always include the agent:active premise,
-        # plus any remapped depends_on from within this agent's beliefs
-        antecedents = [active_id]
-        for dep_id in claim["depends_on"]:
-            prefixed_dep = f"{prefix}{dep_id}"
-            if dep_id in claim_by_id:
-                antecedents.append(prefixed_dep)
+        is_out = claim["status"] in ("STALE", "OUT")
 
-        # Build outlist: remap unless references to namespaced IDs
-        outlist = []
-        for out_id in claim.get("unless", []):
-            prefixed_out = f"{prefix}{out_id}"
-            if out_id in claim_by_id:
-                outlist.append(prefixed_out)
+        if is_out:
+            justifications = []
+        else:
+            antecedents = []
+            for dep_id in claim["depends_on"]:
+                prefixed_dep = f"{prefix}{dep_id}"
+                if dep_id in claim_by_id:
+                    antecedents.append(prefixed_dep)
 
-        justifications = [
-            Justification(
-                type="SL",
-                antecedents=antecedents,
-                outlist=outlist,
-                label=f"imported from agent: {agent_name}",
-            )
-        ]
+            outlist = [inactive_id]
+            for out_id in claim.get("unless", []):
+                prefixed_out = f"{prefix}{out_id}"
+                if out_id in claim_by_id:
+                    outlist.append(prefixed_out)
+
+            justifications = [
+                Justification(
+                    type="SL",
+                    antecedents=antecedents,
+                    outlist=outlist,
+                    label=f"imported from agent: {agent_name}",
+                )
+            ]
 
         metadata = {
             "agent": agent_name,
@@ -140,7 +182,7 @@ def import_agent(
         network.add_node(
             id=node_id,
             text=claim["text"],
-            justifications=justifications,
+            justifications=justifications if justifications else None,
             source=claim["source"],
             source_hash=claim["source_hash"],
             date=claim["date"],
@@ -148,10 +190,8 @@ def import_agent(
         )
         imported += 1
 
-        # STALE and OUT claims get retracted after adding
-        if claim["status"] in ("STALE", "OUT"):
-            network.retract(node_id)
-            retracted += 1
+        if is_out:
+            retract_after.append(node_id)
 
     # Import nogoods (remapped to prefixed IDs)
     nogoods_imported = 0
@@ -172,7 +212,12 @@ def import_agent(
                 network.nogoods.append(nogood)
                 nogoods_imported += 1
 
+    _fixup_dependents(network)
     propagated = len(network.recompute_all())
+
+    for node_id in retract_after:
+        network.retract(node_id)
+        retracted += 1
 
     return {
         "agent": agent_name,
@@ -198,20 +243,14 @@ def import_agent_json(
 
     JSON format preserves full justification structure including outlists,
     providing lossless import of non-monotonic relationships.
+
+    Uses agent:inactive in outlist (not agent:active in antecedents) so
+    per-belief retraction works. OUT beliefs are imported as bare premises.
     """
     prefix = f"{agent_name}:"
-    active_id = f"{agent_name}:active"
-
-    if active_id not in network.nodes:
-        network.add_node(
-            id=active_id,
-            text=f"Agent '{agent_name}' beliefs are trusted",
-            source=source_path,
-            metadata={"agent": agent_name, "role": "agent_premise"},
-        )
-        created_premise = True
-    else:
-        created_premise = False
+    active_id, inactive_id, created_premise = _ensure_agent_nodes(
+        network, agent_name, source_path
+    )
 
     nodes = data.get("nodes", {})
 
@@ -246,6 +285,7 @@ def import_agent_json(
     imported = 0
     skipped = 0
     retracted = 0
+    retract_after = []
 
     for nid, ndata in ordered:
         node_id = f"{prefix}{nid}"
@@ -254,27 +294,32 @@ def import_agent_json(
             skipped += 1
             continue
 
-        # Rebuild justifications with namespaced references
-        justifications = []
-        for j in ndata.get("justifications", []):
-            antecedents = [active_id]
-            for a in j.get("antecedents", []):
-                antecedents.append(f"{prefix}{a}")
-            outlist = [f"{prefix}{o}" for o in j.get("outlist", []) if o in nodes]
-            justifications.append(Justification(
-                type=j.get("type", "SL"),
-                antecedents=antecedents,
-                outlist=outlist,
-                label=j.get("label", f"imported from agent: {agent_name}"),
-            ))
+        is_out = ndata.get("truth_value") == "OUT"
 
-        is_premise = not ndata.get("justifications")
-        if not justifications and not (is_premise and ndata.get("truth_value") == "OUT"):
-            justifications = [Justification(
-                type="SL",
-                antecedents=[active_id],
-                label=f"imported from agent: {agent_name}",
-            )]
+        if is_out:
+            justifications = []
+        else:
+            justifications = []
+            for j in ndata.get("justifications", []):
+                antecedents = [f"{prefix}{a}" for a in j.get("antecedents", [])]
+                outlist = [inactive_id]
+                outlist.extend(
+                    f"{prefix}{o}" for o in j.get("outlist", []) if o in nodes
+                )
+                justifications.append(Justification(
+                    type=j.get("type", "SL"),
+                    antecedents=antecedents,
+                    outlist=outlist,
+                    label=j.get("label", f"imported from agent: {agent_name}"),
+                ))
+
+            if not justifications:
+                justifications = [Justification(
+                    type="SL",
+                    antecedents=[],
+                    outlist=[inactive_id],
+                    label=f"imported from agent: {agent_name}",
+                )]
 
         metadata = ndata.get("metadata", {}).copy()
         metadata.update({
@@ -294,9 +339,8 @@ def import_agent_json(
         )
         imported += 1
 
-        if ndata.get("truth_value") == "OUT":
-            network.retract(node_id)
-            retracted += 1
+        if is_out:
+            retract_after.append(node_id)
 
     # Import nogoods
     nogoods_imported = 0
@@ -314,7 +358,12 @@ def import_agent_json(
             ))
             nogoods_imported += 1
 
+    _fixup_dependents(network)
     propagated = len(network.recompute_all())
+
+    for node_id in retract_after:
+        network.retract(node_id)
+        retracted += 1
 
     return {
         "agent": agent_name,

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -87,6 +87,7 @@ class Network:
 
         node = self.nodes[node_id]
         if node.truth_value == "OUT":
+            node.metadata["_retracted"] = True
             return []
 
         node.truth_value = "OUT"

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -90,6 +90,7 @@ class Network:
             return []
 
         node.truth_value = "OUT"
+        node.metadata["_retracted"] = True
         if reason:
             node.metadata["retract_reason"] = reason
         changed = [node_id]
@@ -112,6 +113,7 @@ class Network:
             return []
 
         node.truth_value = "IN"
+        node.metadata.pop("_retracted", None)
         changed = [node_id]
         self._log("assert", node_id, "IN")
 
@@ -624,7 +626,7 @@ class Network:
         for _ in range(max_iterations):
             changed_this_pass = []
             for nid, node in self.nodes.items():
-                if node.justifications:
+                if node.justifications and not node.metadata.get("_retracted"):
                     old = node.truth_value
                     new = self._compute_truth(node)
                     if old != new:
@@ -651,6 +653,8 @@ class Network:
                     continue
 
                 dep = self.nodes[dep_id]
+                if dep.metadata.get("_retracted"):
+                    continue
                 old_value = dep.truth_value
                 new_value = self._compute_truth(dep)
 

--- a/tests/test_import_agent.py
+++ b/tests/test_import_agent.py
@@ -86,10 +86,12 @@ def test_import_agent_remaps_dependencies(db, beliefs_file):
     node = api.show_node("test-agent:beta-depends-alpha", db_path=db)
     assert node["truth_value"] == "IN"
 
-    # Should depend on both the agent premise and the remapped alpha
+    # Should depend on remapped alpha (not active — active is no longer an antecedent)
     j = node["justifications"][0]
-    assert "test-agent:active" in j["antecedents"]
     assert "test-agent:alpha-fact" in j["antecedents"]
+    assert "test-agent:active" not in j["antecedents"]
+    # Kill switch via outlist
+    assert "test-agent:inactive" in j["outlist"]
 
 
 def test_import_agent_retract_premise_cascades(db, beliefs_file):
@@ -149,8 +151,8 @@ def test_import_multiple_agents(db, beliefs_file):
     api.import_agent("agent-b", beliefs_file, db_path=db)
 
     status = api.get_status(db_path=db)
-    # 2 premises + 2 * 3 beliefs = 8 total
-    assert status["total"] == 8
+    # 2 active + 2 inactive + 2 * 3 beliefs = 10 total
+    assert status["total"] == 10
 
     # Both agents have their own alpha-fact
     a = api.show_node("agent-a:alpha-fact", db_path=db)
@@ -166,8 +168,8 @@ def test_import_multiple_agents(db, beliefs_file):
     assert b["truth_value"] == "IN"
 
 
-def test_import_agent_propagates_truth_values(db, tmp_path):
-    """OUT beliefs with all antecedents IN should flip IN after propagation."""
+def test_import_agent_preserves_out_status(db, tmp_path):
+    """OUT beliefs from source stay OUT — not resurrected by recompute."""
     beliefs_text = """\
 ## Beliefs
 
@@ -187,10 +189,8 @@ Derived but marked OUT in source snapshot
 
     result = api.import_agent("prop-agent", str(p), db_path=db)
 
-    assert result["claims_propagated"] >= 1
-
     node = api.show_node("prop-agent:derived-out", db_path=db)
-    assert node["truth_value"] == "IN"
+    assert node["truth_value"] == "OUT"
 
 
 def test_import_agent_preserves_outlist(db, tmp_path):
@@ -229,7 +229,7 @@ Only true when blocker is OUT
 
 
 def test_import_agent_supersession_preserved(db, tmp_path):
-    """Supersession via outlist: v1 stays OUT when v2 is IN."""
+    """Supersession: v1 is OUT in source, imported as bare premise (stays OUT)."""
     beliefs_text = """\
 ## Beliefs
 
@@ -253,7 +253,8 @@ New security posture that supersedes v1
     v2 = api.show_node("sec-agent:security-v2", db_path=db)
     assert v2["truth_value"] == "IN"
     assert v1["truth_value"] == "OUT"
-    assert "sec-agent:security-v2" in v1["justifications"][0]["outlist"]
+    # v1 is OUT in source → imported as bare premise (no justification)
+    assert v1["justifications"] == []
 
 
 def test_import_agent_json(db, tmp_path):
@@ -298,8 +299,16 @@ def test_import_agent_json(db, tmp_path):
     node = api.show_node("json-agent:derived-b", db_path=db)
     j = node["justifications"][0]
     assert "json-agent:premise-a" in j["antecedents"]
+    assert "json-agent:active" not in j["antecedents"]
     assert "json-agent:blocker-c" in j["outlist"]
+    assert "json-agent:inactive" in j["outlist"]
+    # blocker-c is OUT → outlist satisfied → derived-b is IN
     assert node["truth_value"] == "IN"
+
+    # blocker-c is OUT in source → bare premise, retracted
+    blocker = api.show_node("json-agent:blocker-c", db_path=db)
+    assert blocker["truth_value"] == "OUT"
+    assert blocker["justifications"] == []
 
 
 def test_import_agent_json_outlist_blocks(db, tmp_path):
@@ -339,6 +348,104 @@ def test_import_agent_json_outlist_blocks(db, tmp_path):
 
     node = api.show_node("gate-agent:gated", db_path=db)
     assert node["truth_value"] == "OUT"
+
+
+def test_retracted_belief_survives_propagate(db, tmp_path):
+    """Regression: retracted imported beliefs must not resurrect on propagate.
+
+    This is the core bug from issue #16 — active premise as antecedent
+    provided an always-valid fallback that defeated per-belief retraction.
+    """
+    beliefs_text = """\
+## Beliefs
+
+### premise-a [IN] OBSERVATION
+A premise that will be retracted
+- Source: test.md
+- Date: 2026-04-18
+
+### derived-b [IN] DERIVED
+Depends on premise-a
+- Source: test.md
+- Date: 2026-04-18
+- Depends on: premise-a
+"""
+    p = tmp_path / "beliefs.md"
+    p.write_text(beliefs_text)
+
+    api.import_agent("fix-agent", str(p), db_path=db)
+
+    # Both should be IN after import
+    a = api.show_node("fix-agent:premise-a", db_path=db)
+    assert a["truth_value"] == "IN"
+    b = api.show_node("fix-agent:derived-b", db_path=db)
+    assert b["truth_value"] == "IN"
+
+    # Retract the premise — should cascade to derived
+    result = api.retract_node("fix-agent:premise-a", db_path=db)
+    assert "fix-agent:premise-a" in result["changed"]
+
+    # Run propagate (recompute_all) — retractions must stick
+    from reasons_lib.storage import Storage
+
+    store = Storage(db)
+    net = store.load()
+    net.recompute_all()
+    store.save(net)
+    store.close()
+
+    a = api.show_node("fix-agent:premise-a", db_path=db)
+    assert a["truth_value"] == "OUT", "retracted premise resurrected on propagate"
+
+    b = api.show_node("fix-agent:derived-b", db_path=db)
+    assert b["truth_value"] == "OUT", "dependent of retracted premise resurrected"
+
+
+def test_retracted_json_belief_survives_propagate(db, tmp_path):
+    """Same as above but via JSON import path."""
+    import json
+
+    data = {
+        "nodes": {
+            "premise-a": {
+                "text": "A premise",
+                "truth_value": "IN",
+                "justifications": [],
+            },
+            "derived-b": {
+                "text": "Depends on A",
+                "truth_value": "IN",
+                "justifications": [{
+                    "type": "SL",
+                    "antecedents": ["premise-a"],
+                }],
+            },
+        },
+        "nogoods": [],
+    }
+
+    p = tmp_path / "network.json"
+    p.write_text(json.dumps(data))
+
+    api.import_agent("jfix-agent", str(p), db_path=db)
+
+    # Retract the premise
+    api.retract_node("jfix-agent:premise-a", db_path=db)
+
+    # Run propagate — retractions must stick
+    from reasons_lib.storage import Storage
+
+    store = Storage(db)
+    net = store.load()
+    net.recompute_all()
+    store.save(net)
+    store.close()
+
+    a = api.show_node("jfix-agent:premise-a", db_path=db)
+    assert a["truth_value"] == "OUT", "retracted premise resurrected on propagate"
+
+    b = api.show_node("jfix-agent:derived-b", db_path=db)
+    assert b["truth_value"] == "OUT", "dependent of retracted premise resurrected"
 
 
 def test_import_agent_nogoods(db, beliefs_file):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -118,6 +118,37 @@ class TestRetraction:
         assert "b" not in changed
 
 
+    def test_retract_already_out_pins_retracted(self):
+        """Retracting an already-OUT node should still set _retracted.
+
+        If B is OUT because its antecedent A is OUT, explicitly retracting B
+        should pin it so it doesn't resurrect when A comes back.
+        """
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node(
+            "b", "Derived B",
+            justifications=[Justification(type="SL", antecedents=["a"])],
+        )
+
+        net.retract("a")
+        assert net.nodes["b"].truth_value == "OUT"
+
+        # B is already OUT — retract it explicitly to pin it
+        result = net.retract("b")
+        assert result == []  # no state change
+        assert net.nodes["b"].metadata.get("_retracted") is True
+
+        # Restore A — C would come back but B should stay pinned
+        net.assert_node("a")
+        assert net.nodes["a"].truth_value == "IN"
+        assert net.nodes["b"].truth_value == "OUT", "pinned node resurrected"
+
+        # recompute_all should also respect the pin
+        net.recompute_all()
+        assert net.nodes["b"].truth_value == "OUT", "recompute resurrected pinned node"
+
+
 class TestRestoration:
     """Restoration — re-asserting a node restores dependents."""
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -364,3 +364,48 @@ class TestDiamondDependency:
         assert net.nodes["b"].truth_value == "IN"
         assert net.nodes["c"].truth_value == "IN"
         assert net.nodes["d"].truth_value == "IN"
+
+    def test_diamond_with_retracted_intermediate(self):
+        """A → B, A → C, B+C → D. Retract B explicitly, then change A.
+
+        B is retracted (sticky) so propagation skips it. D should stay OUT
+        because B remains OUT. C should still respond to A's changes.
+        """
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node(
+            "b", "Derived B",
+            justifications=[Justification(type="SL", antecedents=["a"])],
+        )
+        net.add_node(
+            "c", "Derived C",
+            justifications=[Justification(type="SL", antecedents=["a"])],
+        )
+        net.add_node(
+            "d", "Derived D",
+            justifications=[Justification(type="SL", antecedents=["b", "c"])],
+        )
+
+        # Explicitly retract B — sticky
+        net.retract("b")
+        assert net.nodes["b"].truth_value == "OUT"
+        assert net.nodes["d"].truth_value == "OUT"  # B is OUT → D invalid
+
+        # Retract and restore A — C follows, B stays retracted, D stays OUT
+        net.retract("a")
+        assert net.nodes["c"].truth_value == "OUT"
+
+        net.assert_node("a")
+        assert net.nodes["c"].truth_value == "IN"
+        assert net.nodes["b"].truth_value == "OUT", "retracted B should not resurrect"
+        assert net.nodes["d"].truth_value == "OUT", "D needs B which is retracted"
+
+        # recompute_all should not resurrect B either
+        net.recompute_all()
+        assert net.nodes["b"].truth_value == "OUT", "recompute resurrected retracted B"
+        assert net.nodes["d"].truth_value == "OUT", "recompute resurrected D via B"
+
+        # Explicitly asserting B clears _retracted — D should come back
+        net.assert_node("b")
+        assert net.nodes["b"].truth_value == "IN"
+        assert net.nodes["d"].truth_value == "IN"


### PR DESCRIPTION
## Summary
- Move `agent:active` from antecedents to outlist via `agent:inactive` relay node — kill switch still works but no longer provides always-valid fallback
- Import OUT/STALE beliefs as bare premises so `recompute_all` cannot resurrect them
- Add `_retracted` metadata flag: `retract()` sets it, `assert_node()` clears it, `recompute_all()` and `_propagate()` skip flagged nodes
- Fix outlist dependency registration for nodes added out of topological order
- Filter `_`-prefixed metadata keys from JSON export

## Test plan
- [x] 287 tests pass (was 283)
- [x] Regression tests: retract imported belief, run propagate, verify it stays OUT (both markdown and JSON paths)
- [x] Diamond dependency with retracted intermediate node
- [x] Retract already-OUT node pins it against resurrection
- [x] Kill switch: retract active cascades all agent beliefs OUT
- [x] Restore active brings non-retracted beliefs back

Closes #16

:robot: Generated with [Claude Code](https://claude.com/claude-code)