### PR TITLE
Add sync-agent command for updating beliefs after initial import

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -664,6 +664,65 @@ def import_agent(
         )
 
 
+def sync_agent(
+    agent_name: str,
+    beliefs_file: str,
+    nogoods_file: str | None = None,
+    only_in: bool = False,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Sync another agent's beliefs into the local RMS (remote wins).
+
+    Accepts beliefs.md (markdown) or network.json (JSON export) files.
+    Updates existing beliefs, adds new ones, retracts removed ones.
+
+    Returns: {"agent": str, "beliefs_added": int, "beliefs_updated": int, ...}
+    """
+    beliefs_path = Path(beliefs_file)
+    if not beliefs_path.exists():
+        raise FileNotFoundError(f"File not found: {beliefs_file}")
+
+    if beliefs_path.suffix == ".json":
+        from .import_agent import sync_agent_json as _sync_agent_json
+        import json as json_mod
+
+        data = json_mod.loads(beliefs_path.read_text())
+
+        with _with_network(db_path, write=True) as net:
+            return _sync_agent_json(
+                net,
+                agent_name=agent_name,
+                data=data,
+                only_in=only_in,
+                source_path=str(beliefs_path),
+            )
+
+    from .import_agent import sync_agent as _sync_agent
+
+    beliefs_text = beliefs_path.read_text()
+
+    nogoods_text = None
+    if nogoods_file:
+        nogoods_path = Path(nogoods_file)
+        if not nogoods_path.exists():
+            raise FileNotFoundError(f"Nogoods file not found: {nogoods_file}")
+        nogoods_text = nogoods_path.read_text()
+    else:
+        auto_nogoods = beliefs_path.parent / "nogoods.md"
+        if auto_nogoods.exists():
+            nogoods_text = auto_nogoods.read_text()
+
+    with _with_network(db_path, write=True) as net:
+        return _sync_agent(
+            net,
+            agent_name=agent_name,
+            beliefs_text=beliefs_text,
+            nogoods_text=nogoods_text,
+            only_in=only_in,
+            source_path=str(beliefs_path),
+        )
+
+
 def import_json(json_file: str, db_path: str = DEFAULT_DB) -> dict:
     """Import a network from a JSON file (produced by export).
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -394,6 +394,38 @@ def cmd_import_agent(args):
     print(f"\n  To revoke all: reasons retract {result['active_node']}")
 
 
+def cmd_sync_agent(args):
+    try:
+        result = api.sync_agent(
+            agent_name=args.agent_name,
+            beliefs_file=args.beliefs_file,
+            nogoods_file=args.nogoods_file,
+            only_in=args.only_in,
+            db_path=args.db,
+        )
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Agent '{result['agent']}' synced:")
+    if result['created_premise']:
+        print(f"  Created premise: {result['active_node']}")
+    if result['beliefs_added']:
+        print(f"  Added:     {result['beliefs_added']} new beliefs")
+    if result['beliefs_updated']:
+        print(f"  Updated:   {result['beliefs_updated']} beliefs")
+    if result['beliefs_removed']:
+        print(f"  Removed:   {result['beliefs_removed']} beliefs (retracted)")
+    if result['beliefs_retracted']:
+        print(f"  Retracted: {result['beliefs_retracted']} (OUT/STALE in source)")
+    if result['beliefs_unchanged']:
+        print(f"  Unchanged: {result['beliefs_unchanged']}")
+    if result.get('beliefs_propagated'):
+        print(f"  Propagated: {result['beliefs_propagated']} (truth values recomputed)")
+    if result['nogoods_imported']:
+        print(f"  Nogoods:   {result['nogoods_imported']}")
+
+
 def cmd_import_beliefs(args):
     try:
         result = api.import_beliefs(
@@ -945,6 +977,13 @@ def main():
     p.add_argument("--nogoods", dest="nogoods_file", help="Path to nogoods.md (auto-detected if next to beliefs.md)")
     p.add_argument("--only-in", action="store_true", help="Only import beliefs with status IN")
 
+    # sync-agent
+    p = sub.add_parser("sync-agent", help="Sync another agent's beliefs (remote wins)")
+    p.add_argument("agent_name", help="Agent name (must match previous import)")
+    p.add_argument("beliefs_file", help="Path to the agent's beliefs.md or network.json")
+    p.add_argument("--nogoods", dest="nogoods_file", help="Path to nogoods.md (auto-detected if next to beliefs.md)")
+    p.add_argument("--only-in", action="store_true", help="Only sync beliefs with status IN")
+
     # import-beliefs
     p = sub.add_parser("import-beliefs", help="Import a beliefs.md registry")
     p.add_argument("beliefs_file", help="Path to beliefs.md")
@@ -1031,6 +1070,7 @@ def main():
         "derive": cmd_derive,
         "accept": cmd_accept,
         "import-agent": cmd_import_agent,
+        "sync-agent": cmd_sync_agent,
         "import-beliefs": cmd_import_beliefs,
         "import-json": cmd_import_json,
         "export": cmd_export,

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -17,12 +17,14 @@ Usage:
     reasons sync-agent aap-expert ~/git/aap-expert/beliefs.md
 """
 
-from pathlib import Path
-
 from . import Justification, Nogood
 from .import_beliefs import parse_beliefs, parse_nogoods
 from .network import Network
 
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
 def _fixup_dependents(network):
     """Re-register dependents for all nodes.
@@ -70,169 +72,6 @@ def _ensure_agent_nodes(network, agent_name, source_path=""):
     return active_id, inactive_id, created_premise
 
 
-def import_agent(
-    network: Network,
-    agent_name: str,
-    beliefs_text: str,
-    nogoods_text: str | None = None,
-    only_in: bool = False,
-    source_path: str = "",
-) -> dict:
-    """Import another agent's beliefs into the network with namespacing.
-
-    Each belief is prefixed with 'agent_name:' to avoid ID collisions.
-    A premise node 'agent_name:active' is created along with a relay node
-    'agent_name:inactive' (IN when active is OUT). Imported beliefs have
-    inactive in their outlist — retracting active cascades everything OUT.
-
-    Beliefs that are OUT/STALE in the source are imported as bare premises
-    with no justification, so recompute_all cannot resurrect them.
-
-    Args:
-        network: The local RMS network to import into.
-        agent_name: Name of the agent (used as namespace prefix).
-        beliefs_text: Contents of the agent's beliefs.md file.
-        nogoods_text: Contents of the agent's nogoods.md file (optional).
-        only_in: If True, only import beliefs with status IN.
-        source_path: Path to the beliefs file (for provenance).
-
-    Returns:
-        Summary dict with counts.
-    """
-    prefix = f"{agent_name}:"
-    active_id, inactive_id, created_premise = _ensure_agent_nodes(
-        network, agent_name, source_path
-    )
-
-    claims = parse_beliefs(beliefs_text)
-
-    if only_in:
-        claims = [c for c in claims if c["status"] == "IN"]
-
-    # Build claim lookup for dependency resolution
-    claim_by_id = {c["id"]: c for c in claims}
-
-    # Topological sort so dependencies are added before dependents
-    ordered = []
-    added = set()
-    remaining = list(claims)
-
-    max_passes = len(remaining) + 1
-    for _ in range(max_passes):
-        if not remaining:
-            break
-        next_remaining = []
-        for c in remaining:
-            deps_in_registry = [d for d in c["depends_on"] if d in claim_by_id]
-            if all(d in added for d in deps_in_registry):
-                ordered.append(c)
-                added.add(c["id"])
-            else:
-                next_remaining.append(c)
-        if len(next_remaining) == len(remaining):
-            ordered.extend(next_remaining)
-            break
-        remaining = next_remaining
-
-    imported = 0
-    skipped = 0
-    retracted = 0
-    retract_after = []
-
-    for claim in ordered:
-        node_id = f"{prefix}{claim['id']}"
-
-        if node_id in network.nodes:
-            skipped += 1
-            continue
-
-        is_out = claim["status"] in ("STALE", "OUT")
-
-        if is_out:
-            justifications = []
-        else:
-            antecedents = []
-            for dep_id in claim["depends_on"]:
-                prefixed_dep = f"{prefix}{dep_id}"
-                if dep_id in claim_by_id:
-                    antecedents.append(prefixed_dep)
-
-            outlist = [inactive_id]
-            for out_id in claim.get("unless", []):
-                prefixed_out = f"{prefix}{out_id}"
-                if out_id in claim_by_id:
-                    outlist.append(prefixed_out)
-
-            justifications = [
-                Justification(
-                    type="SL",
-                    antecedents=antecedents,
-                    outlist=outlist,
-                    label=f"imported from agent: {agent_name}",
-                )
-            ]
-
-        metadata = {
-            "agent": agent_name,
-            "original_id": claim["id"],
-            "imported_from": source_path,
-        }
-        if claim["type"]:
-            metadata["beliefs_type"] = claim["type"]
-
-        network.add_node(
-            id=node_id,
-            text=claim["text"],
-            justifications=justifications if justifications else None,
-            source=claim["source"],
-            source_hash=claim["source_hash"],
-            date=claim["date"],
-            metadata=metadata,
-        )
-        imported += 1
-
-        if is_out:
-            retract_after.append(node_id)
-
-    # Import nogoods (remapped to prefixed IDs)
-    nogoods_imported = 0
-    if nogoods_text:
-        nogoods = parse_nogoods(nogoods_text)
-        for ng in nogoods:
-            prefixed_nodes = [f"{prefix}{a}" for a in ng["affects"]]
-            valid_nodes = [n for n in prefixed_nodes if n in network.nodes]
-            nogood_id = f"{prefix}{ng['id']}"
-            existing_ids = {n.id for n in network.nogoods}
-            if len(valid_nodes) >= 2 and nogood_id not in existing_ids:
-                nogood = Nogood(
-                    id=nogood_id,
-                    nodes=valid_nodes,
-                    discovered=ng["discovered"],
-                    resolution=ng["resolution"],
-                )
-                network.nogoods.append(nogood)
-                nogoods_imported += 1
-
-    _fixup_dependents(network)
-    propagated = len(network.recompute_all())
-
-    for node_id in retract_after:
-        network.retract(node_id)
-        retracted += 1
-
-    return {
-        "agent": agent_name,
-        "prefix": prefix,
-        "active_node": active_id,
-        "created_premise": created_premise,
-        "claims_imported": imported,
-        "claims_skipped": skipped,
-        "claims_retracted": retracted,
-        "claims_propagated": propagated,
-        "nogoods_imported": nogoods_imported,
-    }
-
-
 def _justifications_match(old, new):
     """Check if two justification lists are equivalent."""
     if len(old) != len(new):
@@ -267,123 +106,171 @@ def _update_node_justifications(network, node_id, new_justifications):
                 network.nodes[out_id].dependents.add(node_id)
 
 
-def import_agent_json(
-    network: Network,
-    agent_name: str,
-    data: dict,
-    only_in: bool = False,
-    source_path: str = "",
-) -> dict:
-    """Import an agent's beliefs from JSON export with namespacing.
+# ---------------------------------------------------------------------------
+# Format normalization — both formats produce the same claim structure:
+#   {id, text, is_out, source, source_hash, date, metadata, raw_justifications}
+# where raw_justifications = [{type, antecedents, outlist, label}] with
+# unprefixed IDs.  Filtering (which antecedents/outlist to keep) is done
+# here so the shared logic just prefixes everything.
+# ---------------------------------------------------------------------------
 
-    JSON format preserves full justification structure including outlists,
-    providing lossless import of non-monotonic relationships.
+def _normalize_markdown(beliefs_text, only_in=False):
+    """Convert markdown beliefs to normalized claim dicts."""
+    claims = parse_beliefs(beliefs_text)
+    if only_in:
+        claims = [c for c in claims if c["status"] == "IN"]
 
-    Uses agent:inactive in outlist (not agent:active in antecedents) so
-    per-belief retraction works. OUT beliefs are imported as bare premises.
-    """
-    prefix = f"{agent_name}:"
-    active_id, inactive_id, created_premise = _ensure_agent_nodes(
-        network, agent_name, source_path
-    )
+    claim_ids = {c["id"] for c in claims}
 
+    normalized = []
+    for c in claims:
+        is_out = c["status"] in ("STALE", "OUT")
+        meta = {}
+        if c["type"]:
+            meta["beliefs_type"] = c["type"]
+
+        if is_out:
+            raw_justs = []
+        else:
+            antecedents = [d for d in c["depends_on"] if d in claim_ids]
+            outlist = [o for o in c.get("unless", []) if o in claim_ids]
+            raw_justs = [{"type": "SL", "antecedents": antecedents,
+                          "outlist": outlist, "label": None}]
+
+        normalized.append({
+            "id": c["id"],
+            "text": c["text"],
+            "is_out": is_out,
+            "source": c["source"],
+            "source_hash": c["source_hash"],
+            "date": c["date"],
+            "metadata": meta,
+            "raw_justifications": raw_justs,
+        })
+    return normalized
+
+
+def _normalize_json(data, only_in=False):
+    """Convert JSON nodes to normalized claim dicts."""
     nodes = data.get("nodes", {})
-
     if only_in:
         nodes = {k: v for k, v in nodes.items() if v.get("truth_value") == "IN"}
 
-    # Topological sort by antecedent references
+    node_ids = set(nodes.keys())
+
+    normalized = []
+    for nid, ndata in nodes.items():
+        is_out = ndata.get("truth_value") == "OUT"
+        meta = dict(ndata.get("metadata", {}))
+
+        if is_out:
+            raw_justs = []
+        else:
+            raw_justs = []
+            for j in ndata.get("justifications", []):
+                raw_justs.append({
+                    "type": j.get("type", "SL"),
+                    "antecedents": list(j.get("antecedents", [])),
+                    "outlist": [o for o in j.get("outlist", []) if o in node_ids],
+                    "label": j.get("label"),
+                })
+
+        normalized.append({
+            "id": nid,
+            "text": ndata.get("text", ""),
+            "is_out": is_out,
+            "source": ndata.get("source", ""),
+            "source_hash": ndata.get("source_hash", ""),
+            "date": ndata.get("date", ""),
+            "metadata": meta,
+            "raw_justifications": raw_justs,
+        })
+    return normalized
+
+
+def _normalize_nogoods_markdown(nogoods_text):
+    """Convert markdown nogoods to normalized dicts."""
+    if not nogoods_text:
+        return []
+    return [
+        {"id": ng["id"], "nodes": ng["affects"],
+         "discovered": ng["discovered"], "resolution": ng["resolution"]}
+        for ng in parse_nogoods(nogoods_text)
+    ]
+
+
+def _normalize_nogoods_json(data):
+    """Convert JSON nogoods to normalized dicts."""
+    return [
+        {"id": ng["id"], "nodes": ng.get("nodes", []),
+         "discovered": ng.get("discovered", ""), "resolution": ng.get("resolution", "")}
+        for ng in data.get("nogoods", [])
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Shared operations
+# ---------------------------------------------------------------------------
+
+def _topo_sort_claims(claims):
+    """Topological sort claims by antecedent dependencies."""
+    claim_ids = {c["id"] for c in claims}
     ordered = []
     added = set()
-    remaining = dict(nodes)
-
+    remaining = list(claims)
     max_passes = len(remaining) + 1
     for _ in range(max_passes):
         if not remaining:
             break
-        next_remaining = {}
-        for nid, ndata in remaining.items():
-            all_antes = []
-            for j in ndata.get("justifications", []):
-                all_antes.extend(j.get("antecedents", []))
-            deps_in_set = [a for a in all_antes if a in nodes]
-            if all(d in added for d in deps_in_set):
-                ordered.append((nid, ndata))
-                added.add(nid)
+        next_remaining = []
+        for c in remaining:
+            deps = set()
+            for j in c["raw_justifications"]:
+                deps.update(a for a in j["antecedents"] if a in claim_ids)
+            if all(d in added for d in deps):
+                ordered.append(c)
+                added.add(c["id"])
             else:
-                next_remaining[nid] = ndata
+                next_remaining.append(c)
         if len(next_remaining) == len(remaining):
-            ordered.extend(next_remaining.items())
+            ordered.extend(next_remaining)
             break
         remaining = next_remaining
+    return ordered
 
-    imported = 0
-    skipped = 0
-    retracted = 0
-    retract_after = []
 
-    for nid, ndata in ordered:
-        node_id = f"{prefix}{nid}"
+def _build_justifications(claim, prefix, inactive_id, agent_name):
+    """Build Justification objects from a normalized claim."""
+    if claim["is_out"]:
+        return []
 
-        if node_id in network.nodes:
-            skipped += 1
-            continue
+    justs = []
+    for rj in claim["raw_justifications"]:
+        antecedents = [f"{prefix}{a}" for a in rj["antecedents"]]
+        outlist = [inactive_id] + [f"{prefix}{o}" for o in rj["outlist"]]
+        label = rj["label"] or f"imported from agent: {agent_name}"
+        justs.append(Justification(
+            type=rj["type"], antecedents=antecedents,
+            outlist=outlist, label=label,
+        ))
 
-        is_out = ndata.get("truth_value") == "OUT"
+    if not justs:
+        justs = [Justification(
+            type="SL", antecedents=[], outlist=[inactive_id],
+            label=f"imported from agent: {agent_name}",
+        )]
 
-        if is_out:
-            justifications = []
-        else:
-            justifications = []
-            for j in ndata.get("justifications", []):
-                antecedents = [f"{prefix}{a}" for a in j.get("antecedents", [])]
-                outlist = [inactive_id]
-                outlist.extend(
-                    f"{prefix}{o}" for o in j.get("outlist", []) if o in nodes
-                )
-                justifications.append(Justification(
-                    type=j.get("type", "SL"),
-                    antecedents=antecedents,
-                    outlist=outlist,
-                    label=j.get("label", f"imported from agent: {agent_name}"),
-                ))
+    return justs
 
-            if not justifications:
-                justifications = [Justification(
-                    type="SL",
-                    antecedents=[],
-                    outlist=[inactive_id],
-                    label=f"imported from agent: {agent_name}",
-                )]
 
-        metadata = ndata.get("metadata", {}).copy()
-        metadata.update({
-            "agent": agent_name,
-            "original_id": nid,
-            "imported_from": source_path,
-        })
-
-        network.add_node(
-            id=node_id,
-            text=ndata.get("text", ""),
-            justifications=justifications if justifications else None,
-            source=ndata.get("source", ""),
-            source_hash=ndata.get("source_hash", ""),
-            date=ndata.get("date", ""),
-            metadata=metadata,
-        )
-        imported += 1
-
-        if is_out:
-            retract_after.append(node_id)
-
-    # Import nogoods
-    nogoods_imported = 0
-    for ng in data.get("nogoods", []):
-        prefixed_nodes = [f"{prefix}{n}" for n in ng.get("nodes", [])]
+def _import_nogoods(network, prefix, nogoods):
+    """Import normalized nogoods into the network."""
+    count = 0
+    existing_ids = {n.id for n in network.nogoods}
+    for ng in nogoods:
+        prefixed_nodes = [f"{prefix}{n}" for n in ng["nodes"]]
         valid_nodes = [n for n in prefixed_nodes if n in network.nodes]
         nogood_id = f"{prefix}{ng['id']}"
-        existing_ids = {n.id for n in network.nogoods}
         if len(valid_nodes) >= 2 and nogood_id not in existing_ids:
             network.nogoods.append(Nogood(
                 id=nogood_id,
@@ -391,7 +278,60 @@ def import_agent_json(
                 discovered=ng.get("discovered", ""),
                 resolution=ng.get("resolution", ""),
             ))
-            nogoods_imported += 1
+            existing_ids.add(nogood_id)
+            count += 1
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Shared import / sync logic
+# ---------------------------------------------------------------------------
+
+def _import_claims(network, agent_name, claims, source_path, nogoods):
+    """Import normalized claims into the network."""
+    prefix = f"{agent_name}:"
+    active_id, inactive_id, created_premise = _ensure_agent_nodes(
+        network, agent_name, source_path
+    )
+
+    ordered = _topo_sort_claims(claims)
+
+    imported = 0
+    skipped = 0
+    retracted = 0
+    retract_after = []
+
+    for claim in ordered:
+        node_id = f"{prefix}{claim['id']}"
+
+        if node_id in network.nodes:
+            skipped += 1
+            continue
+
+        justifications = _build_justifications(claim, prefix, inactive_id, agent_name)
+
+        metadata = claim["metadata"].copy()
+        metadata.update({
+            "agent": agent_name,
+            "original_id": claim["id"],
+            "imported_from": source_path,
+        })
+
+        network.add_node(
+            id=node_id,
+            text=claim["text"],
+            justifications=justifications if justifications else None,
+            source=claim["source"],
+            source_hash=claim["source_hash"],
+            date=claim["date"],
+            metadata=metadata,
+        )
+        imported += 1
+
+        if claim["is_out"]:
+            retract_after.append(node_id)
+
+    nogoods_imported = _import_nogoods(network, prefix, nogoods)
 
     _fixup_dependents(network)
     propagated = len(network.recompute_all())
@@ -413,32 +353,13 @@ def import_agent_json(
     }
 
 
-def sync_agent(
-    network: Network,
-    agent_name: str,
-    beliefs_text: str,
-    nogoods_text: str | None = None,
-    only_in: bool = False,
-    source_path: str = "",
-) -> dict:
-    """Sync another agent's beliefs into the network (remote wins).
-
-    Compares the remote beliefs against existing local agent nodes:
-    - New beliefs in remote → added
-    - Beliefs removed from remote → retracted
-    - Changed text/justifications/truth values → updated
-    - _retracted flag cleared when remote says IN
-    """
+def _sync_claims(network, agent_name, claims, source_path, nogoods):
+    """Sync normalized claims into the network (remote wins)."""
     prefix = f"{agent_name}:"
     active_id, inactive_id, created_premise = _ensure_agent_nodes(
         network, agent_name, source_path
     )
 
-    claims = parse_beliefs(beliefs_text)
-    if only_in:
-        claims = [c for c in claims if c["status"] == "IN"]
-
-    claim_by_id = {c["id"]: c for c in claims}
     remote_ids = {f"{prefix}{c['id']}" for c in claims}
 
     infra_ids = {active_id, inactive_id}
@@ -447,26 +368,7 @@ def sync_agent(
         if nid.startswith(prefix) and nid not in infra_ids
     }
 
-    # Topological sort
-    ordered = []
-    added_set = set()
-    remaining = list(claims)
-    max_passes = len(remaining) + 1
-    for _ in range(max_passes):
-        if not remaining:
-            break
-        next_remaining = []
-        for c in remaining:
-            deps_in_registry = [d for d in c["depends_on"] if d in claim_by_id]
-            if all(d in added_set for d in deps_in_registry):
-                ordered.append(c)
-                added_set.add(c["id"])
-            else:
-                next_remaining.append(c)
-        if len(next_remaining) == len(remaining):
-            ordered.extend(next_remaining)
-            break
-        remaining = next_remaining
+    ordered = _topo_sort_claims(claims)
 
     beliefs_added = 0
     beliefs_updated = 0
@@ -476,7 +378,7 @@ def sync_agent(
 
     for claim in ordered:
         node_id = f"{prefix}{claim['id']}"
-        is_out = claim["status"] in ("STALE", "OUT")
+        is_out = claim["is_out"]
 
         if node_id in network.nodes:
             node = network.nodes[node_id]
@@ -496,8 +398,9 @@ def sync_agent(
                 node.date = claim["date"]
                 changed = True
 
-            if claim["type"]:
-                node.metadata["beliefs_type"] = claim["type"]
+            for k, v in claim["metadata"].items():
+                if not k.startswith("_"):
+                    node.metadata[k] = v
             node.metadata["imported_from"] = source_path
 
             if is_out:
@@ -506,24 +409,9 @@ def sync_agent(
                     changed = True
                 retract_after.append(node_id)
             else:
-                antecedents = []
-                for dep_id in claim["depends_on"]:
-                    if dep_id in claim_by_id:
-                        antecedents.append(f"{prefix}{dep_id}")
-
-                outlist = [inactive_id]
-                for out_id in claim.get("unless", []):
-                    if out_id in claim_by_id:
-                        outlist.append(f"{prefix}{out_id}")
-
-                new_justs = [
-                    Justification(
-                        type="SL",
-                        antecedents=antecedents,
-                        outlist=outlist,
-                        label=f"imported from agent: {agent_name}",
-                    )
-                ]
+                new_justs = _build_justifications(
+                    claim, prefix, inactive_id, agent_name
+                )
                 if not _justifications_match(node.justifications, new_justs):
                     _update_node_justifications(network, node_id, new_justs)
                     changed = True
@@ -541,35 +429,16 @@ def sync_agent(
             else:
                 beliefs_unchanged += 1
         else:
-            if is_out:
-                justifications = []
-            else:
-                antecedents = []
-                for dep_id in claim["depends_on"]:
-                    if dep_id in claim_by_id:
-                        antecedents.append(f"{prefix}{dep_id}")
+            justifications = _build_justifications(
+                claim, prefix, inactive_id, agent_name
+            )
 
-                outlist = [inactive_id]
-                for out_id in claim.get("unless", []):
-                    if out_id in claim_by_id:
-                        outlist.append(f"{prefix}{out_id}")
-
-                justifications = [
-                    Justification(
-                        type="SL",
-                        antecedents=antecedents,
-                        outlist=outlist,
-                        label=f"imported from agent: {agent_name}",
-                    )
-                ]
-
-            metadata = {
+            metadata = claim["metadata"].copy()
+            metadata.update({
                 "agent": agent_name,
                 "original_id": claim["id"],
                 "imported_from": source_path,
-            }
-            if claim["type"]:
-                metadata["beliefs_type"] = claim["type"]
+            })
 
             network.add_node(
                 id=node_id,
@@ -585,7 +454,6 @@ def sync_agent(
             if is_out:
                 retract_after.append(node_id)
 
-    # Retract beliefs removed from remote (skip already-retracted)
     beliefs_removed = 0
     removed_ids = local_agent_ids - remote_ids
     for node_id in sorted(removed_ids):
@@ -599,7 +467,6 @@ def sync_agent(
 
     _fixup_dependents(network)
 
-    # Assert nodes that remote says should be IN
     for node_id in assert_after:
         node = network.nodes[node_id]
         node.metadata.pop("_retracted", None)
@@ -608,7 +475,6 @@ def sync_agent(
 
     propagated = len(network.recompute_all())
 
-    # Retract OUT beliefs after recompute
     beliefs_retracted = 0
     for node_id in retract_after:
         if node_id in network.nodes:
@@ -619,24 +485,7 @@ def sync_agent(
                 node.metadata["_retracted"] = True
             beliefs_retracted += 1
 
-    # Nogoods
-    nogoods_imported = 0
-    if nogoods_text:
-        nogoods = parse_nogoods(nogoods_text)
-        for ng in nogoods:
-            prefixed_nodes = [f"{prefix}{a}" for a in ng["affects"]]
-            valid_nodes = [n for n in prefixed_nodes if n in network.nodes]
-            nogood_id = f"{prefix}{ng['id']}"
-            existing_ids = {n.id for n in network.nogoods}
-            if len(valid_nodes) >= 2 and nogood_id not in existing_ids:
-                nogood = Nogood(
-                    id=nogood_id,
-                    nodes=valid_nodes,
-                    discovered=ng["discovered"],
-                    resolution=ng["resolution"],
-                )
-                network.nogoods.append(nogood)
-                nogoods_imported += 1
+    nogoods_imported = _import_nogoods(network, prefix, nogoods)
 
     return {
         "agent": agent_name,
@@ -651,6 +500,71 @@ def sync_agent(
         "beliefs_propagated": propagated,
         "nogoods_imported": nogoods_imported,
     }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def import_agent(
+    network: Network,
+    agent_name: str,
+    beliefs_text: str,
+    nogoods_text: str | None = None,
+    only_in: bool = False,
+    source_path: str = "",
+) -> dict:
+    """Import another agent's beliefs into the network with namespacing.
+
+    Each belief is prefixed with 'agent_name:' to avoid ID collisions.
+    A premise node 'agent_name:active' is created along with a relay node
+    'agent_name:inactive' (IN when active is OUT). Imported beliefs have
+    inactive in their outlist — retracting active cascades everything OUT.
+
+    Beliefs that are OUT/STALE in the source are imported as bare premises
+    with no justification, so recompute_all cannot resurrect them.
+    """
+    claims = _normalize_markdown(beliefs_text, only_in)
+    nogoods = _normalize_nogoods_markdown(nogoods_text)
+    return _import_claims(network, agent_name, claims, source_path, nogoods)
+
+
+def import_agent_json(
+    network: Network,
+    agent_name: str,
+    data: dict,
+    only_in: bool = False,
+    source_path: str = "",
+) -> dict:
+    """Import an agent's beliefs from JSON export with namespacing.
+
+    JSON format preserves full justification structure including outlists,
+    providing lossless import of non-monotonic relationships.
+    """
+    claims = _normalize_json(data, only_in)
+    nogoods = _normalize_nogoods_json(data)
+    return _import_claims(network, agent_name, claims, source_path, nogoods)
+
+
+def sync_agent(
+    network: Network,
+    agent_name: str,
+    beliefs_text: str,
+    nogoods_text: str | None = None,
+    only_in: bool = False,
+    source_path: str = "",
+) -> dict:
+    """Sync another agent's beliefs into the network (remote wins).
+
+    Compares the remote beliefs against existing local agent nodes:
+    - New beliefs in remote -> added
+    - Beliefs removed from remote -> retracted
+    - Changed text/justifications/truth values -> updated
+    - _retracted flag cleared when remote says IN
+    """
+    claims = _normalize_markdown(beliefs_text, only_in)
+    nogoods = _normalize_nogoods_markdown(nogoods_text)
+    return _sync_claims(network, agent_name, claims, source_path, nogoods)
 
 
 def sync_agent_json(
@@ -665,233 +579,6 @@ def sync_agent_json(
     Same semantics as sync_agent but for JSON format which preserves
     full justification structure including outlists.
     """
-    prefix = f"{agent_name}:"
-    active_id, inactive_id, created_premise = _ensure_agent_nodes(
-        network, agent_name, source_path
-    )
-
-    nodes = data.get("nodes", {})
-    if only_in:
-        nodes = {k: v for k, v in nodes.items() if v.get("truth_value") == "IN"}
-
-    remote_ids = {f"{prefix}{nid}" for nid in nodes}
-
-    infra_ids = {active_id, inactive_id}
-    local_agent_ids = {
-        nid for nid in network.nodes
-        if nid.startswith(prefix) and nid not in infra_ids
-    }
-
-    # Topological sort
-    ordered = []
-    added_set = set()
-    remaining = dict(nodes)
-    max_passes = len(remaining) + 1
-    for _ in range(max_passes):
-        if not remaining:
-            break
-        next_remaining = {}
-        for nid, ndata in remaining.items():
-            all_antes = []
-            for j in ndata.get("justifications", []):
-                all_antes.extend(j.get("antecedents", []))
-            deps_in_set = [a for a in all_antes if a in nodes]
-            if all(d in added_set for d in deps_in_set):
-                ordered.append((nid, ndata))
-                added_set.add(nid)
-            else:
-                next_remaining[nid] = ndata
-        if len(next_remaining) == len(remaining):
-            ordered.extend(next_remaining.items())
-            break
-        remaining = next_remaining
-
-    beliefs_added = 0
-    beliefs_updated = 0
-    beliefs_unchanged = 0
-    retract_after = []
-    assert_after = []
-
-    for nid, ndata in ordered:
-        node_id = f"{prefix}{nid}"
-        is_out = ndata.get("truth_value") == "OUT"
-
-        if node_id in network.nodes:
-            node = network.nodes[node_id]
-            changed = False
-
-            new_text = ndata.get("text", "")
-            if node.text != new_text:
-                node.text = new_text
-                changed = True
-
-            new_source = ndata.get("source", "")
-            if new_source and node.source != new_source:
-                node.source = new_source
-                changed = True
-            new_hash = ndata.get("source_hash", "")
-            if new_hash and node.source_hash != new_hash:
-                node.source_hash = new_hash
-                changed = True
-            new_date = ndata.get("date", "")
-            if new_date and node.date != new_date:
-                node.date = new_date
-                changed = True
-
-            remote_meta = ndata.get("metadata", {})
-            for k, v in remote_meta.items():
-                if not k.startswith("_"):
-                    node.metadata[k] = v
-            node.metadata["imported_from"] = source_path
-
-            if is_out:
-                if not _justifications_match(node.justifications, []):
-                    _update_node_justifications(network, node_id, [])
-                    changed = True
-                retract_after.append(node_id)
-            else:
-                justifications = []
-                for j in ndata.get("justifications", []):
-                    antecedents = [f"{prefix}{a}" for a in j.get("antecedents", [])]
-                    outlist = [inactive_id]
-                    outlist.extend(
-                        f"{prefix}{o}" for o in j.get("outlist", []) if o in nodes
-                    )
-                    justifications.append(Justification(
-                        type=j.get("type", "SL"),
-                        antecedents=antecedents,
-                        outlist=outlist,
-                        label=j.get("label", f"imported from agent: {agent_name}"),
-                    ))
-                if not justifications:
-                    justifications = [Justification(
-                        type="SL",
-                        antecedents=[],
-                        outlist=[inactive_id],
-                        label=f"imported from agent: {agent_name}",
-                    )]
-                if not _justifications_match(node.justifications, justifications):
-                    _update_node_justifications(network, node_id, justifications)
-                    changed = True
-
-                if node.metadata.get("_retracted"):
-                    node.metadata.pop("_retracted", None)
-                    changed = True
-
-                if node.truth_value == "OUT":
-                    assert_after.append(node_id)
-                    changed = True
-
-            if changed:
-                beliefs_updated += 1
-            else:
-                beliefs_unchanged += 1
-        else:
-            if is_out:
-                justifications = []
-            else:
-                justifications = []
-                for j in ndata.get("justifications", []):
-                    antecedents = [f"{prefix}{a}" for a in j.get("antecedents", [])]
-                    outlist = [inactive_id]
-                    outlist.extend(
-                        f"{prefix}{o}" for o in j.get("outlist", []) if o in nodes
-                    )
-                    justifications.append(Justification(
-                        type=j.get("type", "SL"),
-                        antecedents=antecedents,
-                        outlist=outlist,
-                        label=j.get("label", f"imported from agent: {agent_name}"),
-                    ))
-                if not justifications:
-                    justifications = [Justification(
-                        type="SL",
-                        antecedents=[],
-                        outlist=[inactive_id],
-                        label=f"imported from agent: {agent_name}",
-                    )]
-
-            metadata = ndata.get("metadata", {}).copy()
-            metadata.update({
-                "agent": agent_name,
-                "original_id": nid,
-                "imported_from": source_path,
-            })
-
-            network.add_node(
-                id=node_id,
-                text=ndata.get("text", ""),
-                justifications=justifications if justifications else None,
-                source=ndata.get("source", ""),
-                source_hash=ndata.get("source_hash", ""),
-                date=ndata.get("date", ""),
-                metadata=metadata,
-            )
-            beliefs_added += 1
-
-            if is_out:
-                retract_after.append(node_id)
-
-    # Retract beliefs removed from remote (skip already-retracted)
-    beliefs_removed = 0
-    removed_ids = local_agent_ids - remote_ids
-    for node_id in sorted(removed_ids):
-        node = network.nodes[node_id]
-        if node.truth_value == "IN":
-            network.retract(node_id)
-            beliefs_removed += 1
-        elif not node.metadata.get("_retracted"):
-            node.metadata["_retracted"] = True
-            beliefs_removed += 1
-
-    _fixup_dependents(network)
-
-    # Assert nodes that remote says should be IN
-    for node_id in assert_after:
-        node = network.nodes[node_id]
-        node.metadata.pop("_retracted", None)
-        if node.truth_value == "OUT":
-            network.assert_node(node_id)
-
-    propagated = len(network.recompute_all())
-
-    # Retract OUT beliefs after recompute
-    beliefs_retracted = 0
-    for node_id in retract_after:
-        if node_id in network.nodes:
-            node = network.nodes[node_id]
-            if node.truth_value != "OUT":
-                network.retract(node_id)
-            else:
-                node.metadata["_retracted"] = True
-            beliefs_retracted += 1
-
-    # Nogoods
-    nogoods_imported = 0
-    for ng in data.get("nogoods", []):
-        prefixed_nodes = [f"{prefix}{n}" for n in ng.get("nodes", [])]
-        valid_nodes = [n for n in prefixed_nodes if n in network.nodes]
-        nogood_id = f"{prefix}{ng['id']}"
-        existing_ids = {n.id for n in network.nogoods}
-        if len(valid_nodes) >= 2 and nogood_id not in existing_ids:
-            network.nogoods.append(Nogood(
-                id=nogood_id,
-                nodes=valid_nodes,
-                discovered=ng.get("discovered", ""),
-                resolution=ng.get("resolution", ""),
-            ))
-            nogoods_imported += 1
-
-    return {
-        "agent": agent_name,
-        "prefix": prefix,
-        "active_node": active_id,
-        "created_premise": created_premise,
-        "beliefs_added": beliefs_added,
-        "beliefs_updated": beliefs_updated,
-        "beliefs_removed": beliefs_removed,
-        "beliefs_retracted": beliefs_retracted,
-        "beliefs_unchanged": beliefs_unchanged,
-        "beliefs_propagated": propagated,
-        "nogoods_imported": nogoods_imported,
-    }
+    claims = _normalize_json(data, only_in)
+    nogoods = _normalize_nogoods_json(data)
+    return _sync_claims(network, agent_name, claims, source_path, nogoods)

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -233,6 +233,17 @@ def import_agent(
     }
 
 
+def _justifications_match(old, new):
+    """Check if two justification lists are equivalent."""
+    if len(old) != len(new):
+        return False
+    for a, b in zip(old, new):
+        if (a.type != b.type or a.antecedents != b.antecedents
+                or a.outlist != b.outlist or a.label != b.label):
+            return False
+    return True
+
+
 def _update_node_justifications(network, node_id, new_justifications):
     """Replace justifications on an existing node, fixing dependent registrations."""
     node = network.nodes[node_id]
@@ -490,9 +501,10 @@ def sync_agent(
             node.metadata["imported_from"] = source_path
 
             if is_out:
-                _update_node_justifications(network, node_id, [])
+                if not _justifications_match(node.justifications, []):
+                    _update_node_justifications(network, node_id, [])
+                    changed = True
                 retract_after.append(node_id)
-                changed = True
             else:
                 antecedents = []
                 for dep_id in claim["depends_on"]:
@@ -512,7 +524,9 @@ def sync_agent(
                         label=f"imported from agent: {agent_name}",
                     )
                 ]
-                _update_node_justifications(network, node_id, new_justs)
+                if not _justifications_match(node.justifications, new_justs):
+                    _update_node_justifications(network, node_id, new_justs)
+                    changed = True
 
                 if node.metadata.get("_retracted"):
                     node.metadata.pop("_retracted", None)
@@ -731,9 +745,10 @@ def sync_agent_json(
             node.metadata["imported_from"] = source_path
 
             if is_out:
-                _update_node_justifications(network, node_id, [])
+                if not _justifications_match(node.justifications, []):
+                    _update_node_justifications(network, node_id, [])
+                    changed = True
                 retract_after.append(node_id)
-                changed = True
             else:
                 justifications = []
                 for j in ndata.get("justifications", []):
@@ -755,7 +770,9 @@ def sync_agent_json(
                         outlist=[inactive_id],
                         label=f"imported from agent: {agent_name}",
                     )]
-                _update_node_justifications(network, node_id, justifications)
+                if not _justifications_match(node.justifications, justifications):
+                    _update_node_justifications(network, node_id, justifications)
+                    changed = True
 
                 if node.metadata.get("_retracted"):
                     node.metadata.pop("_retracted", None)

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -1,4 +1,4 @@
-"""Import another agent's beliefs into the local RMS network.
+"""Import and sync another agent's beliefs into the local RMS network.
 
 Creates namespaced nodes (agent:belief-id) so beliefs from multiple agents
 can coexist without collision. Each agent gets a premise node (agent:active)
@@ -14,6 +14,7 @@ Usage:
     reasons import-agent aap-expert ~/git/aap-expert/beliefs.md
     reasons import-agent rhel-expert ~/git/rhel-expert/network.json
     reasons import-agent rhel-expert ~/git/rhel-expert/beliefs.md --only-in
+    reasons sync-agent aap-expert ~/git/aap-expert/beliefs.md
 """
 
 from pathlib import Path
@@ -232,6 +233,29 @@ def import_agent(
     }
 
 
+def _update_node_justifications(network, node_id, new_justifications):
+    """Replace justifications on an existing node, fixing dependent registrations."""
+    node = network.nodes[node_id]
+
+    for j in node.justifications:
+        for ant_id in j.antecedents:
+            if ant_id in network.nodes:
+                network.nodes[ant_id].dependents.discard(node_id)
+        for out_id in j.outlist:
+            if out_id in network.nodes:
+                network.nodes[out_id].dependents.discard(node_id)
+
+    node.justifications = new_justifications
+
+    for j in new_justifications:
+        for ant_id in j.antecedents:
+            if ant_id in network.nodes:
+                network.nodes[ant_id].dependents.add(node_id)
+        for out_id in j.outlist:
+            if out_id in network.nodes:
+                network.nodes[out_id].dependents.add(node_id)
+
+
 def import_agent_json(
     network: Network,
     agent_name: str,
@@ -374,5 +398,473 @@ def import_agent_json(
         "claims_skipped": skipped,
         "claims_retracted": retracted,
         "claims_propagated": propagated,
+        "nogoods_imported": nogoods_imported,
+    }
+
+
+def sync_agent(
+    network: Network,
+    agent_name: str,
+    beliefs_text: str,
+    nogoods_text: str | None = None,
+    only_in: bool = False,
+    source_path: str = "",
+) -> dict:
+    """Sync another agent's beliefs into the network (remote wins).
+
+    Compares the remote beliefs against existing local agent nodes:
+    - New beliefs in remote → added
+    - Beliefs removed from remote → retracted
+    - Changed text/justifications/truth values → updated
+    - _retracted flag cleared when remote says IN
+    """
+    prefix = f"{agent_name}:"
+    active_id, inactive_id, created_premise = _ensure_agent_nodes(
+        network, agent_name, source_path
+    )
+
+    claims = parse_beliefs(beliefs_text)
+    if only_in:
+        claims = [c for c in claims if c["status"] == "IN"]
+
+    claim_by_id = {c["id"]: c for c in claims}
+    remote_ids = {f"{prefix}{c['id']}" for c in claims}
+
+    infra_ids = {active_id, inactive_id}
+    local_agent_ids = {
+        nid for nid in network.nodes
+        if nid.startswith(prefix) and nid not in infra_ids
+    }
+
+    # Topological sort
+    ordered = []
+    added_set = set()
+    remaining = list(claims)
+    max_passes = len(remaining) + 1
+    for _ in range(max_passes):
+        if not remaining:
+            break
+        next_remaining = []
+        for c in remaining:
+            deps_in_registry = [d for d in c["depends_on"] if d in claim_by_id]
+            if all(d in added_set for d in deps_in_registry):
+                ordered.append(c)
+                added_set.add(c["id"])
+            else:
+                next_remaining.append(c)
+        if len(next_remaining) == len(remaining):
+            ordered.extend(next_remaining)
+            break
+        remaining = next_remaining
+
+    beliefs_added = 0
+    beliefs_updated = 0
+    beliefs_unchanged = 0
+    retract_after = []
+    assert_after = []
+
+    for claim in ordered:
+        node_id = f"{prefix}{claim['id']}"
+        is_out = claim["status"] in ("STALE", "OUT")
+
+        if node_id in network.nodes:
+            node = network.nodes[node_id]
+            changed = False
+
+            if node.text != claim["text"]:
+                node.text = claim["text"]
+                changed = True
+
+            if claim["source"] and node.source != claim["source"]:
+                node.source = claim["source"]
+                changed = True
+            if claim["source_hash"] and node.source_hash != claim["source_hash"]:
+                node.source_hash = claim["source_hash"]
+                changed = True
+            if claim["date"] and node.date != claim["date"]:
+                node.date = claim["date"]
+                changed = True
+
+            if claim["type"]:
+                node.metadata["beliefs_type"] = claim["type"]
+            node.metadata["imported_from"] = source_path
+
+            if is_out:
+                _update_node_justifications(network, node_id, [])
+                retract_after.append(node_id)
+                changed = True
+            else:
+                antecedents = []
+                for dep_id in claim["depends_on"]:
+                    if dep_id in claim_by_id:
+                        antecedents.append(f"{prefix}{dep_id}")
+
+                outlist = [inactive_id]
+                for out_id in claim.get("unless", []):
+                    if out_id in claim_by_id:
+                        outlist.append(f"{prefix}{out_id}")
+
+                new_justs = [
+                    Justification(
+                        type="SL",
+                        antecedents=antecedents,
+                        outlist=outlist,
+                        label=f"imported from agent: {agent_name}",
+                    )
+                ]
+                _update_node_justifications(network, node_id, new_justs)
+
+                if node.metadata.get("_retracted"):
+                    node.metadata.pop("_retracted", None)
+                    changed = True
+
+                if node.truth_value == "OUT":
+                    assert_after.append(node_id)
+                    changed = True
+
+            if changed:
+                beliefs_updated += 1
+            else:
+                beliefs_unchanged += 1
+        else:
+            if is_out:
+                justifications = []
+            else:
+                antecedents = []
+                for dep_id in claim["depends_on"]:
+                    if dep_id in claim_by_id:
+                        antecedents.append(f"{prefix}{dep_id}")
+
+                outlist = [inactive_id]
+                for out_id in claim.get("unless", []):
+                    if out_id in claim_by_id:
+                        outlist.append(f"{prefix}{out_id}")
+
+                justifications = [
+                    Justification(
+                        type="SL",
+                        antecedents=antecedents,
+                        outlist=outlist,
+                        label=f"imported from agent: {agent_name}",
+                    )
+                ]
+
+            metadata = {
+                "agent": agent_name,
+                "original_id": claim["id"],
+                "imported_from": source_path,
+            }
+            if claim["type"]:
+                metadata["beliefs_type"] = claim["type"]
+
+            network.add_node(
+                id=node_id,
+                text=claim["text"],
+                justifications=justifications if justifications else None,
+                source=claim["source"],
+                source_hash=claim["source_hash"],
+                date=claim["date"],
+                metadata=metadata,
+            )
+            beliefs_added += 1
+
+            if is_out:
+                retract_after.append(node_id)
+
+    # Retract beliefs removed from remote
+    beliefs_removed = 0
+    removed_ids = local_agent_ids - remote_ids
+    for node_id in sorted(removed_ids):
+        network.retract(node_id)
+        beliefs_removed += 1
+
+    _fixup_dependents(network)
+
+    # Assert nodes that remote says should be IN
+    for node_id in assert_after:
+        node = network.nodes[node_id]
+        node.metadata.pop("_retracted", None)
+        if node.truth_value == "OUT":
+            network.assert_node(node_id)
+
+    propagated = len(network.recompute_all())
+
+    # Retract OUT beliefs after recompute
+    beliefs_retracted = 0
+    for node_id in retract_after:
+        if node_id in network.nodes:
+            node = network.nodes[node_id]
+            if node.truth_value != "OUT":
+                network.retract(node_id)
+            else:
+                node.metadata["_retracted"] = True
+            beliefs_retracted += 1
+
+    # Nogoods
+    nogoods_imported = 0
+    if nogoods_text:
+        nogoods = parse_nogoods(nogoods_text)
+        for ng in nogoods:
+            prefixed_nodes = [f"{prefix}{a}" for a in ng["affects"]]
+            valid_nodes = [n for n in prefixed_nodes if n in network.nodes]
+            nogood_id = f"{prefix}{ng['id']}"
+            existing_ids = {n.id for n in network.nogoods}
+            if len(valid_nodes) >= 2 and nogood_id not in existing_ids:
+                nogood = Nogood(
+                    id=nogood_id,
+                    nodes=valid_nodes,
+                    discovered=ng["discovered"],
+                    resolution=ng["resolution"],
+                )
+                network.nogoods.append(nogood)
+                nogoods_imported += 1
+
+    return {
+        "agent": agent_name,
+        "prefix": prefix,
+        "active_node": active_id,
+        "created_premise": created_premise,
+        "beliefs_added": beliefs_added,
+        "beliefs_updated": beliefs_updated,
+        "beliefs_removed": beliefs_removed,
+        "beliefs_retracted": beliefs_retracted,
+        "beliefs_unchanged": beliefs_unchanged,
+        "beliefs_propagated": propagated,
+        "nogoods_imported": nogoods_imported,
+    }
+
+
+def sync_agent_json(
+    network: Network,
+    agent_name: str,
+    data: dict,
+    only_in: bool = False,
+    source_path: str = "",
+) -> dict:
+    """Sync an agent's beliefs from JSON export (remote wins).
+
+    Same semantics as sync_agent but for JSON format which preserves
+    full justification structure including outlists.
+    """
+    prefix = f"{agent_name}:"
+    active_id, inactive_id, created_premise = _ensure_agent_nodes(
+        network, agent_name, source_path
+    )
+
+    nodes = data.get("nodes", {})
+    if only_in:
+        nodes = {k: v for k, v in nodes.items() if v.get("truth_value") == "IN"}
+
+    remote_ids = {f"{prefix}{nid}" for nid in nodes}
+
+    infra_ids = {active_id, inactive_id}
+    local_agent_ids = {
+        nid for nid in network.nodes
+        if nid.startswith(prefix) and nid not in infra_ids
+    }
+
+    # Topological sort
+    ordered = []
+    added_set = set()
+    remaining = dict(nodes)
+    max_passes = len(remaining) + 1
+    for _ in range(max_passes):
+        if not remaining:
+            break
+        next_remaining = {}
+        for nid, ndata in remaining.items():
+            all_antes = []
+            for j in ndata.get("justifications", []):
+                all_antes.extend(j.get("antecedents", []))
+            deps_in_set = [a for a in all_antes if a in nodes]
+            if all(d in added_set for d in deps_in_set):
+                ordered.append((nid, ndata))
+                added_set.add(nid)
+            else:
+                next_remaining[nid] = ndata
+        if len(next_remaining) == len(remaining):
+            ordered.extend(next_remaining.items())
+            break
+        remaining = next_remaining
+
+    beliefs_added = 0
+    beliefs_updated = 0
+    beliefs_unchanged = 0
+    retract_after = []
+    assert_after = []
+
+    for nid, ndata in ordered:
+        node_id = f"{prefix}{nid}"
+        is_out = ndata.get("truth_value") == "OUT"
+
+        if node_id in network.nodes:
+            node = network.nodes[node_id]
+            changed = False
+
+            new_text = ndata.get("text", "")
+            if node.text != new_text:
+                node.text = new_text
+                changed = True
+
+            new_source = ndata.get("source", "")
+            if new_source and node.source != new_source:
+                node.source = new_source
+                changed = True
+            new_hash = ndata.get("source_hash", "")
+            if new_hash and node.source_hash != new_hash:
+                node.source_hash = new_hash
+                changed = True
+            new_date = ndata.get("date", "")
+            if new_date and node.date != new_date:
+                node.date = new_date
+                changed = True
+
+            remote_meta = ndata.get("metadata", {})
+            for k, v in remote_meta.items():
+                if not k.startswith("_"):
+                    node.metadata[k] = v
+            node.metadata["imported_from"] = source_path
+
+            if is_out:
+                _update_node_justifications(network, node_id, [])
+                retract_after.append(node_id)
+                changed = True
+            else:
+                justifications = []
+                for j in ndata.get("justifications", []):
+                    antecedents = [f"{prefix}{a}" for a in j.get("antecedents", [])]
+                    outlist = [inactive_id]
+                    outlist.extend(
+                        f"{prefix}{o}" for o in j.get("outlist", []) if o in nodes
+                    )
+                    justifications.append(Justification(
+                        type=j.get("type", "SL"),
+                        antecedents=antecedents,
+                        outlist=outlist,
+                        label=j.get("label", f"imported from agent: {agent_name}"),
+                    ))
+                if not justifications:
+                    justifications = [Justification(
+                        type="SL",
+                        antecedents=[],
+                        outlist=[inactive_id],
+                        label=f"imported from agent: {agent_name}",
+                    )]
+                _update_node_justifications(network, node_id, justifications)
+
+                if node.metadata.get("_retracted"):
+                    node.metadata.pop("_retracted", None)
+                    changed = True
+
+                if node.truth_value == "OUT":
+                    assert_after.append(node_id)
+                    changed = True
+
+            if changed:
+                beliefs_updated += 1
+            else:
+                beliefs_unchanged += 1
+        else:
+            if is_out:
+                justifications = []
+            else:
+                justifications = []
+                for j in ndata.get("justifications", []):
+                    antecedents = [f"{prefix}{a}" for a in j.get("antecedents", [])]
+                    outlist = [inactive_id]
+                    outlist.extend(
+                        f"{prefix}{o}" for o in j.get("outlist", []) if o in nodes
+                    )
+                    justifications.append(Justification(
+                        type=j.get("type", "SL"),
+                        antecedents=antecedents,
+                        outlist=outlist,
+                        label=j.get("label", f"imported from agent: {agent_name}"),
+                    ))
+                if not justifications:
+                    justifications = [Justification(
+                        type="SL",
+                        antecedents=[],
+                        outlist=[inactive_id],
+                        label=f"imported from agent: {agent_name}",
+                    )]
+
+            metadata = ndata.get("metadata", {}).copy()
+            metadata.update({
+                "agent": agent_name,
+                "original_id": nid,
+                "imported_from": source_path,
+            })
+
+            network.add_node(
+                id=node_id,
+                text=ndata.get("text", ""),
+                justifications=justifications if justifications else None,
+                source=ndata.get("source", ""),
+                source_hash=ndata.get("source_hash", ""),
+                date=ndata.get("date", ""),
+                metadata=metadata,
+            )
+            beliefs_added += 1
+
+            if is_out:
+                retract_after.append(node_id)
+
+    # Retract beliefs removed from remote
+    beliefs_removed = 0
+    removed_ids = local_agent_ids - remote_ids
+    for node_id in sorted(removed_ids):
+        network.retract(node_id)
+        beliefs_removed += 1
+
+    _fixup_dependents(network)
+
+    # Assert nodes that remote says should be IN
+    for node_id in assert_after:
+        node = network.nodes[node_id]
+        node.metadata.pop("_retracted", None)
+        if node.truth_value == "OUT":
+            network.assert_node(node_id)
+
+    propagated = len(network.recompute_all())
+
+    # Retract OUT beliefs after recompute
+    beliefs_retracted = 0
+    for node_id in retract_after:
+        if node_id in network.nodes:
+            node = network.nodes[node_id]
+            if node.truth_value != "OUT":
+                network.retract(node_id)
+            else:
+                node.metadata["_retracted"] = True
+            beliefs_retracted += 1
+
+    # Nogoods
+    nogoods_imported = 0
+    for ng in data.get("nogoods", []):
+        prefixed_nodes = [f"{prefix}{n}" for n in ng.get("nodes", [])]
+        valid_nodes = [n for n in prefixed_nodes if n in network.nodes]
+        nogood_id = f"{prefix}{ng['id']}"
+        existing_ids = {n.id for n in network.nogoods}
+        if len(valid_nodes) >= 2 and nogood_id not in existing_ids:
+            network.nogoods.append(Nogood(
+                id=nogood_id,
+                nodes=valid_nodes,
+                discovered=ng.get("discovered", ""),
+                resolution=ng.get("resolution", ""),
+            ))
+            nogoods_imported += 1
+
+    return {
+        "agent": agent_name,
+        "prefix": prefix,
+        "active_node": active_id,
+        "created_premise": created_premise,
+        "beliefs_added": beliefs_added,
+        "beliefs_updated": beliefs_updated,
+        "beliefs_removed": beliefs_removed,
+        "beliefs_retracted": beliefs_retracted,
+        "beliefs_unchanged": beliefs_unchanged,
+        "beliefs_propagated": propagated,
         "nogoods_imported": nogoods_imported,
     }

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -571,12 +571,17 @@ def sync_agent(
             if is_out:
                 retract_after.append(node_id)
 
-    # Retract beliefs removed from remote
+    # Retract beliefs removed from remote (skip already-retracted)
     beliefs_removed = 0
     removed_ids = local_agent_ids - remote_ids
     for node_id in sorted(removed_ids):
-        network.retract(node_id)
-        beliefs_removed += 1
+        node = network.nodes[node_id]
+        if node.truth_value == "IN":
+            network.retract(node_id)
+            beliefs_removed += 1
+        elif not node.metadata.get("_retracted"):
+            node.metadata["_retracted"] = True
+            beliefs_removed += 1
 
     _fixup_dependents(network)
 
@@ -810,12 +815,17 @@ def sync_agent_json(
             if is_out:
                 retract_after.append(node_id)
 
-    # Retract beliefs removed from remote
+    # Retract beliefs removed from remote (skip already-retracted)
     beliefs_removed = 0
     removed_ids = local_agent_ids - remote_ids
     for node_id in sorted(removed_ids):
-        network.retract(node_id)
-        beliefs_removed += 1
+        node = network.nodes[node_id]
+        if node.truth_value == "IN":
+            network.retract(node_id)
+            beliefs_removed += 1
+        elif not node.metadata.get("_retracted"):
+            node.metadata["_retracted"] = True
+            beliefs_removed += 1
 
     _fixup_dependents(network)
 

--- a/tests/test_sync_agent.py
+++ b/tests/test_sync_agent.py
@@ -1,0 +1,379 @@
+"""Tests for sync-agent: updating beliefs after initial import (remote wins)."""
+
+import json
+
+import pytest
+
+from reasons_lib import api
+
+
+INITIAL_BELIEFS = """\
+## Beliefs
+
+### alpha-fact [IN] OBSERVATION
+Alpha is the first letter of the Greek alphabet
+- Source: alphabet.md
+- Date: 2026-03-28
+
+### beta-depends-alpha [IN] DERIVED
+Beta follows alpha in the alphabet
+- Source: alphabet.md
+- Date: 2026-03-28
+- Depends on: alpha-fact
+
+### gamma-stale [STALE] OBSERVATION
+Gamma is the fourth letter
+- Source: old.md
+- Stale reason: gamma is actually third
+"""
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "reasons.db")
+    api.init_db(db_path=db_path)
+    return db_path
+
+
+@pytest.fixture
+def initial_import(db, tmp_path):
+    """Import initial beliefs and return (db_path, tmp_path)."""
+    p = tmp_path / "beliefs.md"
+    p.write_text(INITIAL_BELIEFS)
+    api.import_agent("test-agent", str(p), db_path=db)
+    return db, tmp_path
+
+
+class TestSyncNoChanges:
+    def test_sync_unchanged(self, initial_import):
+        db, tmp_path = initial_import
+        p = tmp_path / "beliefs.md"
+        p.write_text(INITIAL_BELIEFS)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+
+        assert result["beliefs_added"] == 0
+        assert result["beliefs_removed"] == 0
+        assert result["beliefs_retracted"] == 1  # gamma-stale still OUT
+
+
+class TestSyncNewBeliefs:
+    def test_sync_adds_new_belief(self, initial_import):
+        db, tmp_path = initial_import
+
+        updated = INITIAL_BELIEFS + """
+### delta-new [IN] OBSERVATION
+Delta is the fourth letter
+- Source: alphabet.md
+- Date: 2026-04-18
+"""
+        p = tmp_path / "beliefs.md"
+        p.write_text(updated)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+        assert result["beliefs_added"] == 1
+
+        node = api.show_node("test-agent:delta-new", db_path=db)
+        assert node["truth_value"] == "IN"
+        assert node["metadata"]["agent"] == "test-agent"
+
+
+class TestSyncRemovedBeliefs:
+    def test_sync_retracts_removed_belief(self, initial_import):
+        db, tmp_path = initial_import
+
+        # Remove beta-depends-alpha from the remote
+        reduced = """\
+## Beliefs
+
+### alpha-fact [IN] OBSERVATION
+Alpha is the first letter of the Greek alphabet
+- Source: alphabet.md
+- Date: 2026-03-28
+
+### gamma-stale [STALE] OBSERVATION
+Gamma is the fourth letter
+- Source: old.md
+- Stale reason: gamma is actually third
+"""
+        p = tmp_path / "beliefs.md"
+        p.write_text(reduced)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+        assert result["beliefs_removed"] == 1
+
+        node = api.show_node("test-agent:beta-depends-alpha", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+
+class TestSyncUpdatedText:
+    def test_sync_updates_text(self, initial_import):
+        db, tmp_path = initial_import
+
+        updated = INITIAL_BELIEFS.replace(
+            "Alpha is the first letter of the Greek alphabet",
+            "Alpha (Α) is the first letter of the Greek alphabet",
+        )
+        p = tmp_path / "beliefs.md"
+        p.write_text(updated)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+        assert result["beliefs_updated"] >= 1
+
+        node = api.show_node("test-agent:alpha-fact", db_path=db)
+        assert "Α" in node["text"]
+
+
+class TestSyncTruthValueChanges:
+    def test_sync_in_to_out(self, initial_import):
+        """Remote changes a belief from IN to OUT."""
+        db, tmp_path = initial_import
+
+        updated = INITIAL_BELIEFS.replace(
+            "### alpha-fact [IN] OBSERVATION",
+            "### alpha-fact [OUT] OBSERVATION",
+        )
+        p = tmp_path / "beliefs.md"
+        p.write_text(updated)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+
+        node = api.show_node("test-agent:alpha-fact", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+        # Dependent should also go OUT
+        beta = api.show_node("test-agent:beta-depends-alpha", db_path=db)
+        assert beta["truth_value"] == "OUT"
+
+    def test_sync_out_to_in(self, initial_import):
+        """Remote changes a belief from STALE to IN (un-retract)."""
+        db, tmp_path = initial_import
+
+        # Verify gamma is OUT initially
+        node = api.show_node("test-agent:gamma-stale", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+        updated = INITIAL_BELIEFS.replace(
+            "### gamma-stale [STALE] OBSERVATION",
+            "### gamma-stale [IN] OBSERVATION",
+        )
+        p = tmp_path / "beliefs.md"
+        p.write_text(updated)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+
+        node = api.show_node("test-agent:gamma-stale", db_path=db)
+        assert node["truth_value"] == "IN"
+
+
+class TestSyncRetractedCleared:
+    def test_sync_clears_local_retraction(self, initial_import):
+        """If user retracted a belief locally but remote says IN, remote wins."""
+        db, tmp_path = initial_import
+
+        # Locally retract alpha-fact
+        api.retract_node("test-agent:alpha-fact", db_path=db)
+        node = api.show_node("test-agent:alpha-fact", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+        # Sync with unchanged remote (alpha-fact still IN)
+        p = tmp_path / "beliefs.md"
+        p.write_text(INITIAL_BELIEFS)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+
+        node = api.show_node("test-agent:alpha-fact", db_path=db)
+        assert node["truth_value"] == "IN"
+
+        # Dependent should also come back
+        beta = api.show_node("test-agent:beta-depends-alpha", db_path=db)
+        assert beta["truth_value"] == "IN"
+
+
+class TestSyncUpdatedDependencies:
+    def test_sync_changes_dependency(self, initial_import):
+        """Remote changes which node a belief depends on."""
+        db, tmp_path = initial_import
+
+        # Change beta to depend on gamma-stale instead of alpha-fact
+        updated = """\
+## Beliefs
+
+### alpha-fact [IN] OBSERVATION
+Alpha is the first letter of the Greek alphabet
+- Source: alphabet.md
+- Date: 2026-03-28
+
+### beta-depends-alpha [IN] DERIVED
+Beta follows gamma (updated)
+- Source: alphabet.md
+- Date: 2026-04-18
+- Depends on: gamma-stale
+
+### gamma-stale [IN] OBSERVATION
+Gamma is the third letter (corrected)
+- Source: new.md
+- Date: 2026-04-18
+"""
+        p = tmp_path / "beliefs.md"
+        p.write_text(updated)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+
+        node = api.show_node("test-agent:beta-depends-alpha", db_path=db)
+        j = node["justifications"][0]
+        assert "test-agent:gamma-stale" in j["antecedents"]
+        assert "test-agent:alpha-fact" not in j["antecedents"]
+        assert node["truth_value"] == "IN"
+
+
+class TestSyncJson:
+    def test_sync_json_adds_and_updates(self, db, tmp_path):
+        """JSON sync: initial import then sync with changes."""
+        initial_data = {
+            "nodes": {
+                "premise-a": {
+                    "text": "A premise",
+                    "truth_value": "IN",
+                    "justifications": [],
+                    "source": "test.md",
+                },
+                "derived-b": {
+                    "text": "Derived from A",
+                    "truth_value": "IN",
+                    "justifications": [{
+                        "type": "SL",
+                        "antecedents": ["premise-a"],
+                    }],
+                    "source": "test.md",
+                },
+            },
+            "nogoods": [],
+        }
+
+        p = tmp_path / "network.json"
+        p.write_text(json.dumps(initial_data))
+        api.import_agent("json-agent", str(p), db_path=db)
+
+        # Update: change text and add a new node
+        updated_data = {
+            "nodes": {
+                "premise-a": {
+                    "text": "A premise (updated)",
+                    "truth_value": "IN",
+                    "justifications": [],
+                    "source": "test.md",
+                },
+                "derived-b": {
+                    "text": "Derived from A",
+                    "truth_value": "IN",
+                    "justifications": [{
+                        "type": "SL",
+                        "antecedents": ["premise-a"],
+                    }],
+                    "source": "test.md",
+                },
+                "new-c": {
+                    "text": "A new belief",
+                    "truth_value": "IN",
+                    "justifications": [],
+                    "source": "test.md",
+                },
+            },
+            "nogoods": [],
+        }
+        p.write_text(json.dumps(updated_data))
+
+        result = api.sync_agent("json-agent", str(p), db_path=db)
+        assert result["beliefs_added"] == 1
+        assert result["beliefs_updated"] >= 1
+
+        node = api.show_node("json-agent:premise-a", db_path=db)
+        assert "(updated)" in node["text"]
+
+        new_node = api.show_node("json-agent:new-c", db_path=db)
+        assert new_node["truth_value"] == "IN"
+
+    def test_sync_json_removes_belief(self, db, tmp_path):
+        """JSON sync: removing a belief from remote retracts it locally."""
+        initial_data = {
+            "nodes": {
+                "fact-a": {
+                    "text": "Fact A",
+                    "truth_value": "IN",
+                    "justifications": [],
+                },
+                "fact-b": {
+                    "text": "Fact B",
+                    "truth_value": "IN",
+                    "justifications": [],
+                },
+            },
+            "nogoods": [],
+        }
+
+        p = tmp_path / "network.json"
+        p.write_text(json.dumps(initial_data))
+        api.import_agent("rm-agent", str(p), db_path=db)
+
+        # Remove fact-b from remote
+        updated_data = {
+            "nodes": {
+                "fact-a": {
+                    "text": "Fact A",
+                    "truth_value": "IN",
+                    "justifications": [],
+                },
+            },
+            "nogoods": [],
+        }
+        p.write_text(json.dumps(updated_data))
+
+        result = api.sync_agent("rm-agent", str(p), db_path=db)
+        assert result["beliefs_removed"] == 1
+
+        node = api.show_node("rm-agent:fact-b", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+    def test_sync_json_clears_retraction(self, db, tmp_path):
+        """JSON sync: remote IN overrides local retraction."""
+        data = {
+            "nodes": {
+                "fact-x": {
+                    "text": "Fact X",
+                    "truth_value": "IN",
+                    "justifications": [],
+                },
+            },
+            "nogoods": [],
+        }
+
+        p = tmp_path / "network.json"
+        p.write_text(json.dumps(data))
+        api.import_agent("clr-agent", str(p), db_path=db)
+
+        # Locally retract
+        api.retract_node("clr-agent:fact-x", db_path=db)
+        node = api.show_node("clr-agent:fact-x", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+        # Sync with remote still saying IN
+        result = api.sync_agent("clr-agent", str(p), db_path=db)
+
+        node = api.show_node("clr-agent:fact-x", db_path=db)
+        assert node["truth_value"] == "IN"
+
+
+class TestSyncFirstTime:
+    def test_sync_works_as_initial_import(self, db, tmp_path):
+        """Sync on a fresh agent (no prior import) should work like import."""
+        p = tmp_path / "beliefs.md"
+        p.write_text(INITIAL_BELIEFS)
+
+        result = api.sync_agent("fresh-agent", str(p), db_path=db)
+        assert result["created_premise"] is True
+        assert result["beliefs_added"] == 3
+        assert result["beliefs_removed"] == 0
+
+        node = api.show_node("fresh-agent:alpha-fact", db_path=db)
+        assert node["truth_value"] == "IN"

--- a/tests/test_sync_agent.py
+++ b/tests/test_sync_agent.py
@@ -364,6 +364,55 @@ class TestSyncJson:
         assert node["truth_value"] == "IN"
 
 
+class TestSyncCountingAccuracy:
+    def test_unchanged_beliefs_counted_correctly(self, initial_import):
+        """When nothing changes, beliefs_updated should be 0."""
+        db, tmp_path = initial_import
+        p = tmp_path / "beliefs.md"
+        p.write_text(INITIAL_BELIEFS)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+        assert result["beliefs_updated"] == 0
+        assert result["beliefs_unchanged"] >= 2  # alpha-fact, beta-depends-alpha
+
+    def test_justification_only_change_counted_as_update(self, initial_import):
+        """Changing only dependencies (not text) should count as an update."""
+        db, tmp_path = initial_import
+
+        # Add a new premise, then change beta to depend on it instead of alpha
+        # (text stays the same, only depends_on changes)
+        updated = """\
+## Beliefs
+
+### alpha-fact [IN] OBSERVATION
+Alpha is the first letter of the Greek alphabet
+- Source: alphabet.md
+- Date: 2026-03-28
+
+### new-premise [IN] OBSERVATION
+A new premise
+- Source: alphabet.md
+- Date: 2026-04-18
+
+### beta-depends-alpha [IN] DERIVED
+Beta follows alpha in the alphabet
+- Source: alphabet.md
+- Date: 2026-03-28
+- Depends on: new-premise
+
+### gamma-stale [STALE] OBSERVATION
+Gamma is the fourth letter
+- Source: old.md
+- Stale reason: gamma is actually third
+"""
+        p = tmp_path / "beliefs.md"
+        p.write_text(updated)
+
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+        assert result["beliefs_added"] == 1  # new-premise
+        assert result["beliefs_updated"] >= 1  # beta's justification changed
+
+
 class TestSyncFirstTime:
     def test_sync_works_as_initial_import(self, db, tmp_path):
         """Sync on a fresh agent (no prior import) should work like import."""

--- a/tests/test_sync_agent.py
+++ b/tests/test_sync_agent.py
@@ -377,3 +377,93 @@ class TestSyncFirstTime:
 
         node = api.show_node("fresh-agent:alpha-fact", db_path=db)
         assert node["truth_value"] == "IN"
+
+
+class TestSyncIdempotency:
+    def test_resync_removed_no_double_count(self, initial_import):
+        """Re-syncing after a removal should not re-count removed beliefs."""
+        db, tmp_path = initial_import
+
+        reduced = """\
+## Beliefs
+
+### alpha-fact [IN] OBSERVATION
+Alpha is the first letter of the Greek alphabet
+- Source: alphabet.md
+- Date: 2026-03-28
+
+### gamma-stale [STALE] OBSERVATION
+Gamma is the fourth letter
+- Source: old.md
+- Stale reason: gamma is actually third
+"""
+        p = tmp_path / "beliefs.md"
+        p.write_text(reduced)
+
+        result1 = api.sync_agent("test-agent", str(p), db_path=db)
+        assert result1["beliefs_removed"] == 1
+
+        # Second sync — removal already happened
+        result2 = api.sync_agent("test-agent", str(p), db_path=db)
+        assert result2["beliefs_removed"] == 0
+
+    def test_sync_twice_unchanged_is_stable(self, initial_import):
+        """Two consecutive syncs with the same data should both be no-ops."""
+        db, tmp_path = initial_import
+        p = tmp_path / "beliefs.md"
+        p.write_text(INITIAL_BELIEFS)
+
+        api.sync_agent("test-agent", str(p), db_path=db)
+        result = api.sync_agent("test-agent", str(p), db_path=db)
+
+        assert result["beliefs_added"] == 0
+        assert result["beliefs_removed"] == 0
+
+
+class TestSyncAgentRevocation:
+    def test_synced_beliefs_still_cascade_on_agent_revocation(self, initial_import):
+        """After sync, revoking agent:active should still cascade OUT all beliefs.
+
+        Regression: assert_node during sync must not detach beliefs from
+        their justifications (which include inactive_id in outlist).
+        """
+        db, tmp_path = initial_import
+        p = tmp_path / "beliefs.md"
+        p.write_text(INITIAL_BELIEFS)
+
+        # Sync (no-op but exercises the update path)
+        api.sync_agent("test-agent", str(p), db_path=db)
+
+        # Verify justifications still have inactive in outlist
+        node = api.show_node("test-agent:alpha-fact", db_path=db)
+        assert any("test-agent:inactive" in j["outlist"] for j in node["justifications"])
+
+        # Revoke the agent
+        api.retract_node("test-agent:active", db_path=db)
+
+        node = api.show_node("test-agent:alpha-fact", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+        beta = api.show_node("test-agent:beta-depends-alpha", db_path=db)
+        assert beta["truth_value"] == "OUT"
+
+    def test_synced_restored_belief_still_cascades(self, initial_import):
+        """After sync restores a locally-retracted belief, agent revocation still works."""
+        db, tmp_path = initial_import
+
+        # Locally retract alpha
+        api.retract_node("test-agent:alpha-fact", db_path=db)
+
+        # Sync restores it (remote says IN)
+        p = tmp_path / "beliefs.md"
+        p.write_text(INITIAL_BELIEFS)
+        api.sync_agent("test-agent", str(p), db_path=db)
+
+        node = api.show_node("test-agent:alpha-fact", db_path=db)
+        assert node["truth_value"] == "IN"
+
+        # Now revoke the agent — everything should go OUT
+        api.retract_node("test-agent:active", db_path=db)
+
+        node = api.show_node("test-agent:alpha-fact", db_path=db)
+        assert node["truth_value"] == "OUT"


### PR DESCRIPTION
## Summary
- Adds sync-agent command that updates beliefs after initial import-agent (remote wins)
- New beliefs added, removed beliefs retracted, changed text/justifications/truth values updated
- Clears _retracted flag when remote says IN, overriding local retractions
- Works with both markdown and JSON formats
- Includes _update_node_justifications() helper for safely replacing justifications

## Test plan
- [x] 12 new tests in tests/test_sync_agent.py
- [x] All 299 tests pass (0 regressions)

Generated with [Claude Code](https://claude.com/claude-code)