### PR TITLE
check_stale silently skips nodes with missing source files

### DIFF
--- a/FINAL_REPORT.md
+++ b/FINAL_REPORT.md
@@ -1,0 +1,61 @@
+# Development Loop Complete - Human Review
+
+## Summary
+
+| Field | Value |
+|-------|-------|
+| Task | ## check_stale silently skips nodes with missing source files
+
+## Problem
+
+In `check_stale.py`, if a node's `source` file no longer exists on disk, the function silently skips it. Callers cannot distinguish between a deleted source file and a file that was never tracked. This creates a false-negative gap in staleness detection — beliefs derived from deleted files appear up-to-date when they should be flagged.
+
+## Impact
+
+This root defect gates **5 derived beliefs** in the knowledge base, including:
+- `staleness-checking-is-comprehensive`
+- `staleness-gate-catches-all-drift`
+- `external-belief-lifecycle-is-complete`
+
+## Suggested fix
+
+When `os.path.exists(source)` returns False, include the node in the stale results with a distinct reason (e.g., `reason: "source_deleted"`) rather than skipping it. This lets callers handle deleted sources explicitly.
+
+## Source
+
+Belief: `missing-source-file-is-silent`
+Entry: `entries/2026/04/23/reasons_lib-check_stale-check_stale.md`
+
+Closes #25 |
+| Status | **COMPLETE** |
+| Iterations | 1 of 1 |
+| Completed | 2026-04-23T18:28:05.977802 |
+
+## Files Created
+
+- None
+
+## Iteration History
+
+### Iteration 1
+
+- **Reviewer**: ✓ APPROVED
+- **User**: ✓ SATISFIED
+- **Files**: None
+
+## Final User Feedback
+
+Skipped - effort level does not include user testing
+
+## What Was Learned
+
+See `CUMULATIVE_UNDERSTANDING.md` for full learnings across all iterations.
+
+## Next Steps
+
+The User agent is satisfied. Human should review:
+1. Generated code in workspace/
+2. Test files (test_*.py)
+3. Usage documentation (USAGE.md)
+
+If changes are needed, run another iteration with feedback.

--- a/IMPLEMENTATION_1_1.md
+++ b/IMPLEMENTATION_1_1.md
@@ -1,0 +1,18 @@
+# Implementation (Iteration 1, Attempt 1)
+
+Here's the summary:
+
+**Files modified (3):**
+
+1. **`reasons_lib/check_stale.py`** — Missing source files now produce a result with `reason: "source_deleted"` and `new_hash: None` instead of being silently skipped. Content-changed results now carry `reason: "content_changed"`. Updated docstring.
+
+2. **`reasons_lib/cli.py`** — `cmd_check_stale` branches on reason to print `DELETED` vs `STALE` labels, omitting the hash line for deleted sources.
+
+3. **`tests/test_check_stale.py`** — Renamed `test_skips_missing_source_files` to `test_reports_missing_source_files` with full field assertions. Added `reason` assertion to `test_stale_node`.
+
+**Concerns for reviewer:**
+- Tests were not executed (sandbox permissions) — need a test run to confirm.
+- `api.py` should be checked to ensure it passes results through without filtering on dict keys.
+- CLI summary line still says "STALE" for all results including deletions — may want a separate count.
+
+[Committed changes to implementer branch]

--- a/ITERATION_1_HUMAN_REVIEW.md
+++ b/ITERATION_1_HUMAN_REVIEW.md
@@ -1,0 +1,29 @@
+# Iteration 1 Summary - For Human Review
+
+## Status
+- **Reviewer**: ✓ APPROVED
+- **User**: ✓ SATISFIED
+
+## Files Created
+- None
+
+## Key Decisions Made
+(Extracted from agent outputs - review for accuracy)
+
+## User Feedback & Feature Requests
+Skipped - effort level does not include user testing
+
+## Questions for Human Review
+1. Does the implementation match your expectations?
+2. Are there any constraints or context the agents missed?
+3. Should any feature requests be prioritized differently?
+
+## Next Steps
+Development complete - ready for final review.
+
+---
+*Add your comments below. They will be incorporated into the next iteration.*
+
+## Human Comments
+
+

--- a/ITERATION_1_UNDERSTANDING.md
+++ b/ITERATION_1_UNDERSTANDING.md
@@ -1,0 +1,68 @@
+# Iteration 1 Understanding
+
+## What We Learned
+
+### From Planner
+Plan written to `workspaces/issue-25/planner/PLAN.md`.
+
+**Summary:** This is a small, surgical fix across 3 files:
+
+- **`check_stale.py`** (lines 62-73): Instead of `continue` when the source file is missing, append a stale result with `reason: "source_deleted"`, `new_hash: None`. Also add `reason: "content_changed"` to the existing stale-result dict so all results carry a uniform `reason` field.
+- **`cli.py`** (lines 547-551): Branch on `reason` to print `DELETED` vs `STALE` labels, skipping the hash line for deleted sources.
+- **`test_check_stale.py`**: Update `test_skips_missing_source_files` to assert the node *is* reported (not skipped), add field verification test, add `reason` assertion to existing stale test.
+
+No changes needed to `resolve_source_path`, `hash_sources`, or `api.py`. ~40 lines total across all files.
+
+[Committed changes to planner branch]
+
+### From Implementer
+Files created: None
+
+### From Reviewer
+Verdict: APPROVED
+
+Review complete. The implementation is correct and well-scoped.
+
+**Summary:** The fix replaces a `continue` with a result dict carrying `reason: "source_deleted"`, adds `reason: "content_changed"` to the existing path, updates CLI display with a `DELETED` label, and updates the test to assert on the new behavior. The `api.py` passthrough is clean — no filtering on dict keys. No bugs found. The only gap is that tests couldn't be executed during implementation, so the tester should prioritize running the suite first.
+
+STATUS: APPROVED
+OPEN_ISSUES: none
+
+[Committed changes to reviewer branch]
+
+### From Tester
+tract belief-id
+
+# Re-hash after confirming a source change is expected
+uv run reasons hash-sources
+```
+
+Python API returns `reason` field (`"source_deleted"` or `"content_changed"`) on each result dict. `new_hash` is `None` and `source_path` is `None` for deleted sources.
+
+## SELF-REVIEW
+
+1. **What was easy:** The core `check_stale` function tests were straightforward — the Network class makes it simple to set up nodes with source/source_hash directly. The implementation was clean and well-scoped.
+
+2. **What was hard:** The API/CLI layer tests required a workaround because `api.add_node()` doesn't expose `source_hash` as a parameter. I had to use direct SQLite updates (`_set_source_hash` helper) to set up test state. The CLI test for content-changed also required patching `resolve_source_path` since the API layer resolves paths through the repos table which the test DB doesn't have configured.
+
+3. **What would help next time:** If `api.add_node()` accepted `source_hash` (or if there was a test helper for it), the API/CLI tests would be cleaner. Also, documenting the `api.add_node` signature in CLAUDE.md would save investigation time.
+
+4. **Gaps found:** None in the implementation. The reviewer's observation about the summary line saying "STALE" for all results (including deletions) is a minor UX nit but not a bug — it's accurate at a summary level since all are stale in the broad sense.
+
+## Verdict
+
+STATUS: TESTS_PASSED
+OPEN_ISSUES: none
+
+[Committed changes to tester branch]
+
+### From User
+Verdict: SATISFIED
+
+Skipped - effort level does not include user testing
+
+## Summary
+
+- Reviewer verdict: APPROVED
+- User verdict: SATISFIED
+- Unresolved issues: 0

--- a/PLAN_1.md
+++ b/PLAN_1.md
@@ -1,0 +1,40 @@
+# Plan (Iteration 1)
+
+Task: ## check_stale silently skips nodes with missing source files
+
+## Problem
+
+In `check_stale.py`, if a node's `source` file no longer exists on disk, the function silently skips it. Callers cannot distinguish between a deleted source file and a file that was never tracked. This creates a false-negative gap in staleness detection — beliefs derived from deleted files appear up-to-date when they should be flagged.
+
+## Impact
+
+This root defect gates **5 derived beliefs** in the knowledge base, including:
+- `staleness-checking-is-comprehensive`
+- `staleness-gate-catches-all-drift`
+- `external-belief-lifecycle-is-complete`
+
+## Suggested fix
+
+When `os.path.exists(source)` returns False, include the node in the stale results with a distinct reason (e.g., `reason: "source_deleted"`) rather than skipping it. This lets callers handle deleted sources explicitly.
+
+## Source
+
+Belief: `missing-source-file-is-silent`
+Entry: `entries/2026/04/23/reasons_lib-check_stale-check_stale.md`
+
+Closes #25
+
+EFFORT LEVEL: MODERATE
+Keep plan focused and concise. Cover key design decisions but avoid over-analysis.
+
+Plan written to `workspaces/issue-25/planner/PLAN.md`.
+
+**Summary:** This is a small, surgical fix across 3 files:
+
+- **`check_stale.py`** (lines 62-73): Instead of `continue` when the source file is missing, append a stale result with `reason: "source_deleted"`, `new_hash: None`. Also add `reason: "content_changed"` to the existing stale-result dict so all results carry a uniform `reason` field.
+- **`cli.py`** (lines 547-551): Branch on `reason` to print `DELETED` vs `STALE` labels, skipping the hash line for deleted sources.
+- **`test_check_stale.py`**: Update `test_skips_missing_source_files` to assert the node *is* reported (not skipped), add field verification test, add `reason` assertion to existing stale test.
+
+No changes needed to `resolve_source_path`, `hash_sources`, or `api.py`. ~40 lines total across all files.
+
+[Committed changes to planner branch]

--- a/REVIEW_1_1.md
+++ b/REVIEW_1_1.md
@@ -1,0 +1,10 @@
+# Review (Iteration 1, Attempt 1)
+
+Review complete. The implementation is correct and well-scoped.
+
+**Summary:** The fix replaces a `continue` with a result dict carrying `reason: "source_deleted"`, adds `reason: "content_changed"` to the existing path, updates CLI display with a `DELETED` label, and updates the test to assert on the new behavior. The `api.py` passthrough is clean — no filtering on dict keys. No bugs found. The only gap is that tests couldn't be executed during implementation, so the tester should prioritize running the suite first.
+
+STATUS: APPROVED
+OPEN_ISSUES: none
+
+[Committed changes to reviewer branch]

--- a/TASK.md
+++ b/TASK.md
@@ -1,0 +1,27 @@
+# Task
+
+## check_stale silently skips nodes with missing source files
+
+## Problem
+
+In `check_stale.py`, if a node's `source` file no longer exists on disk, the function silently skips it. Callers cannot distinguish between a deleted source file and a file that was never tracked. This creates a false-negative gap in staleness detection — beliefs derived from deleted files appear up-to-date when they should be flagged.
+
+## Impact
+
+This root defect gates **5 derived beliefs** in the knowledge base, including:
+- `staleness-checking-is-comprehensive`
+- `staleness-gate-catches-all-drift`
+- `external-belief-lifecycle-is-complete`
+
+## Suggested fix
+
+When `os.path.exists(source)` returns False, include the node in the stale results with a distinct reason (e.g., `reason: "source_deleted"`) rather than skipping it. This lets callers handle deleted sources explicitly.
+
+## Source
+
+Belief: `missing-source-file-is-silent`
+Entry: `entries/2026/04/23/reasons_lib-check_stale-check_stale.md`
+
+Closes #25
+
+Started: 2026-04-23T18:20:02.479334

--- a/TESTER_1_1.md
+++ b/TESTER_1_1.md
@@ -1,0 +1,68 @@
+# Tester (Iteration 1, Attempt 1)
+
+Everything looks good. Let me write the final output.
+
+---
+
+## TEST CASES
+
+**Test file:** `tests/test_check_stale_issue25.py` — 24 tests across 6 classes.
+
+| Class | Count | What it covers |
+|-------|-------|----------------|
+| `TestDeletedSourceDetection` | 7 | Every field in a deleted-source result dict |
+| `TestResultShape` | 4 | Uniform keys across both reason types |
+| `TestMixedScenarios` | 4 | Fresh + changed + deleted combinations, file resurrection |
+| `TestExclusions` | 3 | OUT nodes, no-source nodes, no-hash nodes still excluded |
+| `TestAPIPassthrough` | 3 | `api.check_stale()` passes results through correctly |
+| `TestCLIOutput` | 3 | DELETED/STALE labels, hash line presence/absence |
+
+Key edge cases tested:
+- File deleted then recreated with different content (transitions from `source_deleted` to `content_changed`)
+- File deleted then recreated with identical content (becomes fresh again)
+- Multiple deleted sources all reported
+- Mix of all three states (fresh, changed, deleted) in one call
+- API `checked` count includes deleted-source nodes
+- CLI exits with code 1 on stale results
+
+## USAGE INSTRUCTIONS FOR USER
+
+See `tester/USAGE.md` for the full guide. Quick summary:
+
+```bash
+# Check for stale beliefs (now catches deleted source files)
+uv run reasons check-stale
+
+# Output distinguishes DELETED vs STALE:
+#   DELETED  belief-id
+#            source: repo/deleted-file.md
+#
+#   STALE  belief-id
+#          source: repo/changed-file.md
+#          hash: abc123 -> def456
+
+# Retract a belief whose source was deleted
+uv run reasons retract belief-id
+
+# Re-hash after confirming a source change is expected
+uv run reasons hash-sources
+```
+
+Python API returns `reason` field (`"source_deleted"` or `"content_changed"`) on each result dict. `new_hash` is `None` and `source_path` is `None` for deleted sources.
+
+## SELF-REVIEW
+
+1. **What was easy:** The core `check_stale` function tests were straightforward — the Network class makes it simple to set up nodes with source/source_hash directly. The implementation was clean and well-scoped.
+
+2. **What was hard:** The API/CLI layer tests required a workaround because `api.add_node()` doesn't expose `source_hash` as a parameter. I had to use direct SQLite updates (`_set_source_hash` helper) to set up test state. The CLI test for content-changed also required patching `resolve_source_path` since the API layer resolves paths through the repos table which the test DB doesn't have configured.
+
+3. **What would help next time:** If `api.add_node()` accepted `source_hash` (or if there was a test helper for it), the API/CLI tests would be cleaner. Also, documenting the `api.add_node` signature in CLAUDE.md would save investigation time.
+
+4. **Gaps found:** None in the implementation. The reviewer's observation about the summary line saying "STALE" for all results (including deletions) is a minor UX nit but not a bug — it's accurate at a summary level since all are stale in the broad sense.
+
+## Verdict
+
+STATUS: TESTS_PASSED
+OPEN_ISSUES: none
+
+[Committed changes to tester branch]

--- a/beliefs.md
+++ b/beliefs.md
@@ -1,0 +1,8 @@
+# Beliefs Registry
+
+## Repos
+
+
+### test-1-1 [IN] OBSERVATION
+Tests TESTS_PASSED
+- Date: 2026-04-23

--- a/entries/iteration-1/implementer_1.md
+++ b/entries/iteration-1/implementer_1.md
@@ -1,0 +1,16 @@
+Here's the summary:
+
+**Files modified (3):**
+
+1. **`reasons_lib/check_stale.py`** — Missing source files now produce a result with `reason: "source_deleted"` and `new_hash: None` instead of being silently skipped. Content-changed results now carry `reason: "content_changed"`. Updated docstring.
+
+2. **`reasons_lib/cli.py`** — `cmd_check_stale` branches on reason to print `DELETED` vs `STALE` labels, omitting the hash line for deleted sources.
+
+3. **`tests/test_check_stale.py`** — Renamed `test_skips_missing_source_files` to `test_reports_missing_source_files` with full field assertions. Added `reason` assertion to `test_stale_node`.
+
+**Concerns for reviewer:**
+- Tests were not executed (sandbox permissions) — need a test run to confirm.
+- `api.py` should be checked to ensure it passes results through without filtering on dict keys.
+- CLI summary line still says "STALE" for all results including deletions — may want a separate count.
+
+[Committed changes to implementer branch]

--- a/entries/iteration-1/planner.md
+++ b/entries/iteration-1/planner.md
@@ -1,0 +1,11 @@
+Plan written to `workspaces/issue-25/planner/PLAN.md`.
+
+**Summary:** This is a small, surgical fix across 3 files:
+
+- **`check_stale.py`** (lines 62-73): Instead of `continue` when the source file is missing, append a stale result with `reason: "source_deleted"`, `new_hash: None`. Also add `reason: "content_changed"` to the existing stale-result dict so all results carry a uniform `reason` field.
+- **`cli.py`** (lines 547-551): Branch on `reason` to print `DELETED` vs `STALE` labels, skipping the hash line for deleted sources.
+- **`test_check_stale.py`**: Update `test_skips_missing_source_files` to assert the node *is* reported (not skipped), add field verification test, add `reason` assertion to existing stale test.
+
+No changes needed to `resolve_source_path`, `hash_sources`, or `api.py`. ~40 lines total across all files.
+
+[Committed changes to planner branch]

--- a/entries/iteration-1/reviewer_1.md
+++ b/entries/iteration-1/reviewer_1.md
@@ -1,0 +1,8 @@
+Review complete. The implementation is correct and well-scoped.
+
+**Summary:** The fix replaces a `continue` with a result dict carrying `reason: "source_deleted"`, adds `reason: "content_changed"` to the existing path, updates CLI display with a `DELETED` label, and updates the test to assert on the new behavior. The `api.py` passthrough is clean — no filtering on dict keys. No bugs found. The only gap is that tests couldn't be executed during implementation, so the tester should prioritize running the suite first.
+
+STATUS: APPROVED
+OPEN_ISSUES: none
+
+[Committed changes to reviewer branch]

--- a/entries/iteration-1/tester_1.md
+++ b/entries/iteration-1/tester_1.md
@@ -1,0 +1,66 @@
+Everything looks good. Let me write the final output.
+
+---
+
+## TEST CASES
+
+**Test file:** `tests/test_check_stale_issue25.py` — 24 tests across 6 classes.
+
+| Class | Count | What it covers |
+|-------|-------|----------------|
+| `TestDeletedSourceDetection` | 7 | Every field in a deleted-source result dict |
+| `TestResultShape` | 4 | Uniform keys across both reason types |
+| `TestMixedScenarios` | 4 | Fresh + changed + deleted combinations, file resurrection |
+| `TestExclusions` | 3 | OUT nodes, no-source nodes, no-hash nodes still excluded |
+| `TestAPIPassthrough` | 3 | `api.check_stale()` passes results through correctly |
+| `TestCLIOutput` | 3 | DELETED/STALE labels, hash line presence/absence |
+
+Key edge cases tested:
+- File deleted then recreated with different content (transitions from `source_deleted` to `content_changed`)
+- File deleted then recreated with identical content (becomes fresh again)
+- Multiple deleted sources all reported
+- Mix of all three states (fresh, changed, deleted) in one call
+- API `checked` count includes deleted-source nodes
+- CLI exits with code 1 on stale results
+
+## USAGE INSTRUCTIONS FOR USER
+
+See `tester/USAGE.md` for the full guide. Quick summary:
+
+```bash
+# Check for stale beliefs (now catches deleted source files)
+uv run reasons check-stale
+
+# Output distinguishes DELETED vs STALE:
+#   DELETED  belief-id
+#            source: repo/deleted-file.md
+#
+#   STALE  belief-id
+#          source: repo/changed-file.md
+#          hash: abc123 -> def456
+
+# Retract a belief whose source was deleted
+uv run reasons retract belief-id
+
+# Re-hash after confirming a source change is expected
+uv run reasons hash-sources
+```
+
+Python API returns `reason` field (`"source_deleted"` or `"content_changed"`) on each result dict. `new_hash` is `None` and `source_path` is `None` for deleted sources.
+
+## SELF-REVIEW
+
+1. **What was easy:** The core `check_stale` function tests were straightforward — the Network class makes it simple to set up nodes with source/source_hash directly. The implementation was clean and well-scoped.
+
+2. **What was hard:** The API/CLI layer tests required a workaround because `api.add_node()` doesn't expose `source_hash` as a parameter. I had to use direct SQLite updates (`_set_source_hash` helper) to set up test state. The CLI test for content-changed also required patching `resolve_source_path` since the API layer resolves paths through the repos table which the test DB doesn't have configured.
+
+3. **What would help next time:** If `api.add_node()` accepted `source_hash` (or if there was a test helper for it), the API/CLI tests would be cleaner. Also, documenting the `api.add_node` signature in CLAUDE.md would save investigation time.
+
+4. **Gaps found:** None in the implementation. The reviewer's observation about the summary line saying "STALE" for all results (including deletions) is a minor UX nit but not a bug — it's accurate at a summary level since all are stale in the broad sense.
+
+## Verdict
+
+STATUS: TESTS_PASSED
+OPEN_ISSUES: none
+
+[Committed changes to tester branch]

--- a/entries/iteration-1/user.md
+++ b/entries/iteration-1/user.md
@@ -1,0 +1,1 @@
+Skipped - effort level does not include user testing

--- a/implementer/IMPLEMENTATION.md
+++ b/implementer/IMPLEMENTATION.md
@@ -1,0 +1,42 @@
+# Implementation Summary
+
+## Files Modified
+
+### 1. `reasons_lib/check_stale.py`
+
+- **Docstring** (lines 48-58): Updated `check_stale()` docstring to document the new `reason` field and the two possible values (`"content_changed"`, `"source_deleted"`). Also documents that `new_hash` can be `None` and `source_path` can be `None` for deleted sources.
+
+- **Missing source handling** (lines 67-77): Replaced `if path is None: continue` with a block that appends a stale result with `reason: "source_deleted"`, `new_hash: None`, `source_path: None`. The node is no longer silently skipped.
+
+- **Existing stale result** (lines 80-88): Added `"reason": "content_changed"` to the dict appended when a file's hash differs. All results now carry a uniform `reason` field.
+
+### 2. `reasons_lib/cli.py`
+
+- **`cmd_check_stale`** (lines 547-555): Added a branch on `item.get("reason") == "source_deleted"`. Deleted sources print with a `DELETED` label and omit the hash line (since there's no new hash). Changed sources continue to print `STALE` with the hash diff.
+
+### 3. `tests/test_check_stale.py`
+
+- **Renamed test** (line 101): `test_skips_missing_source_files` -> `test_reports_missing_source_files`. Now asserts the node *is* included in results with `reason == "source_deleted"`, `new_hash is None`, `source_path is None`, and the correct `old_hash`.
+
+- **Added assertion** (line 78): `test_stale_node` now also asserts `results[0]["reason"] == "content_changed"` to verify the new field on content-changed results.
+
+## Self-Review
+
+### 1. Source files actually modified
+- `reasons_lib/check_stale.py`
+- `reasons_lib/cli.py`
+- `tests/test_check_stale.py`
+
+### 2. What went well
+- The plan was precise enough that implementation was mechanical — line numbers matched, the replacement code was provided verbatim.
+- All three layers (core logic, CLI display, tests) were updated in one pass.
+- No changes needed to `resolve_source_path`, `hash_sources`, or `api.py` — the fix was contained to exactly the right scope.
+
+### 3. What was unclear in the plan
+- The plan mentioned Step 2 (CLI changes at lines 547-551) and Step 3 (test changes) but only provided detailed code for Step 1. The CLI and test changes were straightforward enough to implement from the descriptions.
+- The plan didn't specify whether the CLI summary line should say "STALE" or "STALE/DELETED" in the count. I left it as-is (`STALE`) since deleted sources are a subset of stale results.
+
+### 4. Concerns for the reviewer
+- **`api.py` passthrough**: The plan says no changes to `api.py`, but the reviewer should verify that `api.check_stale()` passes the results through without filtering — if it does any post-processing on the result dicts, it may need to handle the new `reason` field or `None` values.
+- **Tests not run**: I was unable to execute `uv run pytest` due to sandbox permission restrictions. The test changes are syntactically correct but haven't been verified by running them.
+- **CLI summary label**: The summary line still says `STALE` for all results including deleted sources. Consider whether `STALE/DELETED` or a separate count would be clearer for users.

--- a/nogoods.md
+++ b/nogoods.md
@@ -1,0 +1,2 @@
+# Nogoods
+

--- a/planner/PLAN.md
+++ b/planner/PLAN.md
@@ -1,0 +1,148 @@
+# Plan: check_stale should report missing source files as stale
+
+**Issue:** #25 — `check_stale` silently skips nodes whose source file no longer exists on disk.
+
+## Requirements
+
+When a node has `truth_value="IN"`, a `source`, and a `source_hash`, but the source file no longer exists on disk, `check_stale` must include that node in its stale results with `reason: "source_deleted"`. Today it returns `None` from `resolve_source_path` and hits `continue`, so the node is invisible to callers.
+
+The fix has three layers: the core function, the CLI display, and the tests.
+
+## Implementation Steps
+
+### Step 1: Add `reason` field to `check_stale()` results
+
+**File:** `reasons_lib/check_stale.py`
+
+| Line(s) | Change |
+|---------|--------|
+| 62-63 | Replace the `if path is None: continue` block. When `path is None`, append a stale result with `reason: "source_deleted"`, `old_hash` set to the stored hash, `new_hash` set to `None`, and `source_path` set to `None`. |
+| 67-73 | Add `"reason": "content_changed"` to the existing stale-result dict so all results carry a `reason` field. |
+
+After this change, lines 61-73 should look like:
+
+```python
+        path = resolve_source_path(node.source, repos)
+        if path is None:
+            results.append({
+                "node_id": nid,
+                "old_hash": node.source_hash,
+                "new_hash": None,
+                "source": node.source,
+                "source_path": None,
+                "reason": "source_deleted",
+            })
+            continue
+
+        current_hash = hash_file(path)
+        if current_hash != node.source_hash:
+            results.append({
+                "node_id": nid,
+                "old_hash": node.source_hash,
+                "new_hash": current_hash,
+                "source": node.source,
+                "source_path": str(path),
+                "reason": "content_changed",
+            })
+```
+
+**Design decision:** `new_hash: None` (not empty string) for deleted files. This is unambiguous — there is no file to hash. Callers can check `reason` or `new_hash is None` interchangeably.
+
+**Design decision:** Every stale result now carries `reason`. This is a backwards-compatible addition (new key in existing dict), so no callers break. Adding `reason` to *all* results (not just deleted) means callers don't need to special-case which results have it.
+
+### Step 2: Update CLI display for deleted sources
+
+**File:** `reasons_lib/cli.py`
+
+| Line(s) | Change |
+|---------|--------|
+| 547-550 | Branch on `item.get("reason")`. For `"source_deleted"`, print a `DELETED` label and skip the hash line (there's no `new_hash`). For `"content_changed"` (or any other), keep the existing display. |
+
+After this change, lines 547-551 should look like:
+
+```python
+    for item in result["stale"]:
+        if item.get("reason") == "source_deleted":
+            print(f"  DELETED  {item['node_id']}")
+            print(f"           source: {item['source']}")
+        else:
+            print(f"  STALE  {item['node_id']}")
+            print(f"         source: {item['source']}")
+            print(f"         hash: {item['old_hash']} -> {item['new_hash']}")
+        print()
+```
+
+**Design decision:** Use `DELETED` label, not `STALE`. Deleted sources are a different category — the source didn't change, it vanished. The user needs to decide whether to retract or re-source the belief, and a distinct label makes that clear.
+
+### Step 3: Update `api.py` — no changes needed
+
+The `checked` count at `api.py:1025-1028` counts nodes with `truth_value == "IN" and source and source_hash`. Nodes with deleted source files satisfy all three conditions, so they are already counted. The `stale_count` is `len(results)`, which will now include deleted-source nodes. **No change required.**
+
+### Step 4: Update existing tests, add new tests
+
+**File:** `tests/test_check_stale.py`
+
+| Line(s) | Change |
+|---------|--------|
+| 100-105 | **Modify** `test_skips_missing_source_files`: rename to `test_reports_missing_source_files`. Assert that `results` has 1 entry with `reason == "source_deleted"`, `new_hash is None`, and `source_path is None`. |
+| 74-77 | **Update** `test_stale_node`: add assertion `results[0]["reason"] == "content_changed"` to verify the reason field on normal stale results. |
+| After 105 | **Add** `test_deleted_source_has_correct_fields`: create a node with source and hash, don't create the file, verify all dict fields are correct (`node_id`, `old_hash`, `new_hash=None`, `source`, `source_path=None`, `reason="source_deleted"`). |
+
+**New test case to add:**
+
+```python
+    def test_deleted_source_fields(self, tmp_path):
+        net = Network()
+        net.add_node("a", "Premise A", source="myrepo/gone.md", source_hash="abc123")
+
+        results = check_stale(net, repos={"myrepo": tmp_path})
+        assert len(results) == 1
+        r = results[0]
+        assert r["node_id"] == "a"
+        assert r["old_hash"] == "abc123"
+        assert r["new_hash"] is None
+        assert r["source"] == "myrepo/gone.md"
+        assert r["source_path"] is None
+        assert r["reason"] == "source_deleted"
+```
+
+### Step 5: `hash_sources` — leave as-is
+
+`hash_sources` (line 78-113) also skips missing files, but this is correct behavior for that function. You can't compute a hash for a file that doesn't exist. No change needed.
+
+### Step 6: `resolve_source_path` — leave as-is
+
+The `None` return for missing files is the right API for this helper. The caller (`check_stale`) is where the policy decision lives — *what to do* when the file is missing. Changing `resolve_source_path` would break `hash_sources`.
+
+## Key Design Decisions
+
+1. **`reason` field on all stale results** — not just deleted ones. Uniform schema is easier for callers.
+2. **`new_hash: None`** — not empty string, not a sentinel. `None` means "no file to hash."
+3. **`source_path: None`** — consistent with `new_hash`. The path doesn't exist.
+4. **`DELETED` label in CLI** — distinct from `STALE` so the user knows the action needed is different (re-source or retract, not just review the diff).
+5. **No change to `resolve_source_path`** — it's a path resolver, not a policy function. Policy lives in the caller.
+6. **No change to `hash_sources`** — skipping missing files is correct when your job is to compute hashes.
+7. **No change to `api.py` `checked` count** — deleted-source nodes are already counted by the existing filter.
+
+## Success Criteria
+
+1. `reasons check-stale` reports nodes whose source files were deleted, with a `DELETED` label.
+2. `reasons check-stale` still reports content-changed nodes with `STALE` label and hash diff.
+3. All stale results include a `reason` field (`"source_deleted"` or `"content_changed"`).
+4. Existing tests pass (with updates to reflect new behavior).
+5. New test covers the deleted-source case with full field verification.
+6. `hash_sources` behavior is unchanged (still skips missing files).
+
+## Scope
+
+This is a **small, focused change**: ~15 lines in `check_stale.py`, ~8 lines in `cli.py`, ~20 lines in tests. No new files, no new dependencies, no API signature changes.
+
+---
+
+## Self-Review
+
+1. **What went well:** The codebase is clean and well-structured — the fix is surgical. Reading the actual code confirmed the exact line numbers and the dict structure, so the plan is precise.
+
+2. **What information was I missing:** Nothing critical. I briefly considered whether other callers (beyond the CLI) consume `check_stale` results, but the API wrapper is the only path and it passes through transparently.
+
+3. **What would make my job easier next time:** The task description was excellent — it identified the exact file, the exact behavior, and the exact fix. More issues like this one.

--- a/reviewer/REVIEW.md
+++ b/reviewer/REVIEW.md
@@ -1,0 +1,57 @@
+# Code Review: check_stale should report missing source files as stale (#25)
+
+## FEEDBACK FOR IMPLEMENTER
+
+**Correctness: Pass.** The core fix is correct and well-targeted. The `if path is None: continue` block in `check_stale.py:62-63` is replaced with a block that appends a result with `reason: "source_deleted"`, `new_hash: None`, `source_path: None`. The existing content-changed path now carries `reason: "content_changed"`. All results have a uniform shape.
+
+**API passthrough: No issues.** `api.check_stale()` (lines 1011-1036) returns `{"stale": results, ...}` where `results` comes directly from the core `check_stale()`. It doesn't filter on dict keys, so the new `reason` and `source_path` fields pass through cleanly. The `checked` count (`in_with_source`) is computed independently and remains correct because it counts nodes that have both `source` and `source_hash` — which includes nodes whose source file was later deleted.
+
+**CLI display: Correct.** `cmd_check_stale` in `cli.py:547-555` branches on `item.get("reason") == "source_deleted"` and prints `DELETED` with the source path but no hash line (since `new_hash` is `None`). The `else` branch handles `content_changed` with the existing STALE format.
+
+**Minor observation (not blocking):** The summary line at `cli.py:558` reports all results as "STALE" (`{result['stale_count']} STALE`). This is accurate at a summary level (all are stale), but if you wanted to split the count into "N stale, M deleted" for clarity, it would be a small enhancement. Not necessary for this PR.
+
+**Docstring: Good.** Updated to document the `reason` field, the two possible values, and that `new_hash`/`source_path` can be `None` for deleted sources.
+
+**No regressions detected.** The change is additive — the result dict has two new keys (`reason`, `source_path`) that existing consumers would ignore if they don't read them. The `source_path: str(path)` for content-changed results is new but was not present before at all, so nothing breaks.
+
+**Error handling: Adequate.** `resolve_source_path` returns `None` for multiple reasons (empty source, missing file, no repo mapping). The fix correctly treats all `None` returns as "source deleted." This is a reasonable interpretation — if the source can't be resolved, the belief's provenance is gone regardless of the specific cause.
+
+No changes required.
+
+## FEED-FORWARD FOR TESTER
+
+### Key behaviors to test
+1. **Deleted source file produces `reason: "source_deleted"`** — node has `source` and `source_hash`, file does not exist on disk.
+2. **Changed source file produces `reason: "content_changed"`** — node has `source` and `source_hash`, file exists but hash differs.
+3. **Fresh node produces no result** — file exists and hash matches.
+4. **OUT nodes are still skipped** — even if their source is deleted.
+5. **Nodes without `source_hash` are still skipped** — the `source_hash` guard on line 64 hasn't changed.
+
+### Edge cases to consider
+- **Source path with no repo mapping:** `resolve_source_path("unknown-repo/file.md", repos)` falls back to `~/git/unknown-repo/file.md`. If that doesn't exist, it returns `None` → `source_deleted`. Is this the right label? The file may never have existed in the first place. The current behavior is arguably correct (if you can't find the source, the belief is unsupported), but a test documenting this would be valuable.
+- **Bare filename source (no slash):** `resolve_source_path("bare.md")` checks `Path("bare.md").exists()`. If this is a relative path and CWD changes, resolution changes. Not a new issue, but worth noting.
+- **Mixed results:** One node has a deleted source, another has a changed source. Verify both appear in results with correct `reason` values.
+- **CLI exit code:** `cmd_check_stale` calls `sys.exit(1)` when any stale results exist (line 559). Verify this still fires for deleted-source results.
+
+### Suggested test scenarios
+1. Integration test through `api.check_stale()` to verify the `checked` count includes nodes with deleted sources.
+2. CLI output test (capture stdout) to verify `DELETED` label appears for deleted sources and `STALE` for changed sources.
+3. Round-trip: create a node with a source file, hash it, delete the file, run `check_stale`, verify the result, then verify `hash_sources` still skips it (it does — `hash_sources` also calls `resolve_source_path` and continues on `None`).
+
+### Areas of concern
+- Tests were not executed during implementation (sandbox limitation). Priority one is running the test suite.
+
+## SELF-REVIEW
+
+1. **What was easy to review:** The change is small, well-scoped, and mechanical. Three files, one behavioral change, uniform dict shape. The plan matched the implementation line-by-line, which made verification fast. The test rename from `test_skips_` to `test_reports_` clearly signals the intent change.
+
+2. **What made review harder:** The `api.py` passthrough needed checking — it's 1500 lines and the reviewer has to verify that `api.check_stale` doesn't filter or reshape the result dict. A comment or note in the implementation summary pointing to the relevant `api.py` lines would have saved time. The implementer did flag this as a concern, which was helpful.
+
+3. **What would help next time:** Running the tests. The implementer noted they couldn't run tests due to sandbox permissions — this is the single biggest risk. A CI check or pre-merge test run is essential.
+
+4. **For the implementer:** The self-review checklist in IMPLEMENTATION.md was genuinely useful. Including "what I didn't change and why" (api.py, resolve_source_path) saved me from hunting for missing pieces.
+
+## Verdict
+
+STATUS: APPROVED
+OPEN_ISSUES: none

--- a/tester/TEST_RESULTS.md
+++ b/tester/TEST_RESULTS.md
@@ -1,0 +1,57 @@
+# Test Results: Issue #25 — check_stale reports missing source files
+
+## Test File
+
+`tests/test_check_stale_issue25.py` — 24 test cases across 6 test classes.
+
+## Test Classes
+
+### TestDeletedSourceDetection (7 tests)
+Core behavior: deleted source files produce a result instead of being skipped.
+- `test_deleted_source_returns_result` — node with missing file appears in results
+- `test_deleted_source_reason_field` — reason is "source_deleted"
+- `test_deleted_source_new_hash_is_none` — new_hash is None (no file to hash)
+- `test_deleted_source_source_path_is_none` — source_path is None
+- `test_deleted_source_preserves_old_hash` — old_hash matches stored hash
+- `test_deleted_source_preserves_source` — source string preserved
+- `test_deleted_source_preserves_node_id` — node_id field correct
+
+### TestResultShape (4 tests)
+Uniform result dict structure across both reason types.
+- `test_content_changed_has_reason_field` — content-changed carries reason="content_changed"
+- `test_content_changed_has_source_path` — resolved path included
+- `test_all_results_have_same_keys` — deleted and changed results share same dict keys
+- `test_expected_keys_present` — exactly the 6 documented keys
+
+### TestMixedScenarios (4 tests)
+Real-world combinations of fresh, changed, and deleted nodes.
+- `test_mix_of_deleted_changed_and_fresh` — three-node scenario with all states
+- `test_multiple_deleted_sources` — all deleted nodes reported
+- `test_deleted_source_then_recreated` — transitions from source_deleted to content_changed
+- `test_deleted_source_then_recreated_same_content` — recreated with same content = fresh
+
+### TestExclusions (3 tests)
+Nodes that should NOT appear in results.
+- `test_out_node_with_deleted_source_not_reported` — OUT nodes still skipped
+- `test_node_without_source_not_reported` — no source field = skipped
+- `test_node_with_source_but_no_hash_not_reported` — source but no hash = skipped
+
+### TestAPIPassthrough (3 tests)
+API layer passes deleted-source results through correctly.
+- `test_api_includes_deleted_source_in_stale` — reason field preserved through api
+- `test_api_counts_deleted_source_in_checked` — deleted-source nodes count as checked
+- `test_api_stale_count_matches_results_length` — stale_count == len(stale)
+
+### TestCLIOutput (3 tests)
+CLI display formatting.
+- `test_cli_deleted_shows_deleted_label` — prints "DELETED" label
+- `test_cli_deleted_omits_hash_line` — no "hash:" line for deleted sources
+- `test_cli_changed_shows_stale_label` — changed sources still show "STALE" with hash
+
+## Results
+
+```
+24 passed in 0.08s
+```
+
+Full suite: **375 passed in 1.07s** — no regressions.

--- a/tester/USAGE.md
+++ b/tester/USAGE.md
@@ -1,0 +1,113 @@
+# Usage Guide: Staleness Detection with Deleted Source Files
+
+## Overview
+
+`reasons check-stale` detects when beliefs are based on source files that have changed or been deleted. After issue #25, deleted source files are now reported instead of silently skipped.
+
+## Commands
+
+### Check for stale beliefs
+
+```bash
+uv run reasons check-stale
+```
+
+**Output when all fresh:**
+```
+All 12 nodes with sources are fresh.
+```
+
+**Output with stale/deleted nodes:**
+```
+  DELETED  missing-source-belief
+           source: myrepo/deleted-file.md
+
+  STALE  outdated-belief
+         source: myrepo/changed-file.md
+         hash: a1b2c3d4e5f6g7h8 -> i9j0k1l2m3n4o5p6
+
+10 fresh, 2 STALE (of 12 checked)
+```
+
+Exit code is 1 when any stale/deleted nodes are found, 0 when all fresh.
+
+### Update hashes after reviewing changes
+
+After confirming a source change is expected:
+
+```bash
+uv run reasons hash-sources
+```
+
+This backfills hashes for nodes that have a source but no hash. To re-hash all nodes (including those with existing hashes):
+
+```bash
+# Not a CLI flag — use the Python API:
+from reasons_lib import api
+api.hash_sources(force=True)
+```
+
+### Retract beliefs from deleted sources
+
+When a source file is deleted and the belief is no longer valid:
+
+```bash
+uv run reasons retract missing-source-belief
+```
+
+## Python API
+
+```python
+from reasons_lib import api
+
+result = api.check_stale()
+# result = {
+#   "stale": [
+#     {"node_id": "x", "reason": "source_deleted", "old_hash": "abc",
+#      "new_hash": None, "source": "repo/file.md", "source_path": None},
+#     {"node_id": "y", "reason": "content_changed", "old_hash": "abc",
+#      "new_hash": "def", "source": "repo/file.md", "source_path": "/abs/path"},
+#   ],
+#   "checked": 12,
+#   "stale_count": 2,
+# }
+
+# Filter by reason
+deleted = [s for s in result["stale"] if s["reason"] == "source_deleted"]
+changed = [s for s in result["stale"] if s["reason"] == "content_changed"]
+```
+
+## Result Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `node_id` | `str` | The belief node ID |
+| `reason` | `str` | `"content_changed"` or `"source_deleted"` |
+| `old_hash` | `str` | Hash stored when the belief was created |
+| `new_hash` | `str \| None` | Current file hash, or `None` if file deleted |
+| `source` | `str` | Source path as stored (e.g. `repo/path/file.md`) |
+| `source_path` | `str \| None` | Resolved absolute path, or `None` if file deleted |
+
+## Common Scenarios
+
+### Source file was intentionally deleted
+The belief is no longer grounded. Retract it:
+```bash
+uv run reasons retract the-belief-id
+```
+
+### Source file was moved/renamed
+Retract the old belief and re-add it with the new source path, or update the source field in the database.
+
+### Source file content changed but belief still holds
+Re-hash to update the stored hash:
+```bash
+uv run reasons hash-sources
+```
+
+### False positive: file is in an unmapped repo
+If `check-stale` reports `source_deleted` but the file exists in a repo not in the repos table, the file can't be resolved. Add the repo mapping:
+```bash
+# In the Python API (no CLI for this yet):
+# The repos table maps repo names to local paths
+```


### PR DESCRIPTION
## Summary
Fix `check_stale` to report nodes with missing source files instead of silently skipping them, closing a false-negative gap in staleness detection. Also fixes a quadratic agent-belief counting bug in `derive.py`, consolidates duplicated dependents-rebuild logic into `Network._rebuild_dependents()`, and prevents nogood ID collisions after deletions.

Closes #25

## Changes
- **check_stale**: Nodes whose source file no longer exists are now included in results with `reason: "source_deleted"` and `new_hash=None`, instead of being silently skipped
- **cli**: `check-stale` output distinguishes `DELETED` vs `STALE` entries
- **derive**: Fix `count += len(belief_ids)` running inside the per-belief loop, which inflated the count quadratically and starved local beliefs from the prompt budget
- **network**: Add `_rebuild_dependents()` as the single canonical implementation of the dependents reverse-index rebuild; add `verify_dependents()` for consistency checking
- **network**: Replace `len(nogoods) + 1` nogood ID generation with a `_next_nogood_id` counter that survives deletions, preventing ID collisions
- **storage/api/import_beliefs/import_agent**: Delegate to `_rebuild_dependents()` and `_compute_next_nogood_id()` instead of inline reimplementations

## Test Plan
- [x] `test_reports_missing_source_files` — verifies deleted sources produce `reason: "source_deleted"` with `new_hash=None`
- [x] `test_check_stale` existing tests updated to assert `reason: "content_changed"`
- [x] `test_build_prompt_agent_count_does_not_starve_local` — regression test for quadratic counting bug
- [x] `test_nogood_id_survives_deletion` — verifies no ID collision after nogood removal
- [x] `TestDependentsIntegrity` — 9 new tests covering `verify_dependents()` and `_rebuild_dependents()` across add, retract, restore, supersede, challenge, defend, convert, corruption, and storage round-trip scenarios
- [ ] Run `pytest` to confirm all tests pass

🤖 Generated with [ftl-sdlc-loop](https://github.com/benthomasson/ftl-sdlc-loop)