### PR TITLE
check_stale silently skips nodes with missing source files

### DIFF
--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -47,8 +47,15 @@ def check_stale(
 ) -> list[dict]:
     """Check all IN nodes for source staleness.
 
-    Returns a list of dicts for each stale node:
-        {"node_id": str, "old_hash": str, "new_hash": str, "source": str}
+    Returns a list of dicts for each stale or missing-source node::
+
+        # Content changed on disk:
+        {"node_id": str, "old_hash": str, "new_hash": str,
+         "source": str, "source_path": str, "reason": "content_changed"}
+
+        # Source file no longer exists:
+        {"node_id": str, "old_hash": str, "new_hash": None,
+         "source": str, "source_path": None, "reason": "source_deleted"}
     """
     results = []
 
@@ -60,6 +67,14 @@ def check_stale(
 
         path = resolve_source_path(node.source, repos)
         if path is None:
+            results.append({
+                "node_id": nid,
+                "old_hash": node.source_hash,
+                "new_hash": None,
+                "source": node.source,
+                "source_path": None,
+                "reason": "source_deleted",
+            })
             continue
 
         current_hash = hash_file(path)
@@ -70,6 +85,7 @@ def check_stale(
                 "new_hash": current_hash,
                 "source": node.source,
                 "source_path": str(path),
+                "reason": "content_changed",
             })
 
     return results

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -545,9 +545,13 @@ def cmd_check_stale(args):
         return
 
     for item in result["stale"]:
-        print(f"  STALE  {item['node_id']}")
-        print(f"         source: {item['source']}")
-        print(f"         hash: {item['old_hash']} -> {item['new_hash']}")
+        if item.get("reason") == "source_deleted":
+            print(f"  DELETED  {item['node_id']}")
+            print(f"           source: {item['source']}")
+        else:
+            print(f"  STALE  {item['node_id']}")
+            print(f"         source: {item['source']}")
+            print(f"         hash: {item['old_hash']} -> {item['new_hash']}")
         print()
 
     fresh = result["checked"] - result["stale_count"]

--- a/tests/test_check_stale.py
+++ b/tests/test_check_stale.py
@@ -75,6 +75,7 @@ class TestCheckStale:
         assert results[0]["node_id"] == "a"
         assert results[0]["old_hash"] == old_hash
         assert results[0]["new_hash"] != old_hash
+        assert results[0]["reason"] == "content_changed"
 
     def test_skips_out_nodes(self, tmp_path):
         f = tmp_path / "source.md"
@@ -97,12 +98,17 @@ class TestCheckStale:
         results = check_stale(net, repos={"myrepo": tmp_path})
         assert results == []
 
-    def test_skips_missing_source_files(self, tmp_path):
+    def test_reports_missing_source_files(self, tmp_path):
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/missing.md", source_hash="abc123")
 
         results = check_stale(net, repos={"myrepo": tmp_path})
-        assert results == []
+        assert len(results) == 1
+        assert results[0]["node_id"] == "a"
+        assert results[0]["reason"] == "source_deleted"
+        assert results[0]["new_hash"] is None
+        assert results[0]["source_path"] is None
+        assert results[0]["old_hash"] == "abc123"
 
     def test_multiple_stale(self, tmp_path):
         f1 = tmp_path / "a.md"

--- a/tests/test_check_stale_issue25.py
+++ b/tests/test_check_stale_issue25.py
@@ -1,0 +1,204 @@
+"""Tests for issue #25: check_stale reports missing source files.
+
+Validates that check_stale() returns source_deleted results instead of
+silently skipping nodes whose source files no longer exist on disk.
+"""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from reasons_lib.network import Network
+from reasons_lib.check_stale import check_stale, hash_file
+
+
+def _hash(content: str) -> str:
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+class TestSourceDeletedResult:
+    """Core behavior: missing source files produce source_deleted results."""
+
+    def test_missing_source_returns_source_deleted(self, tmp_path):
+        net = Network()
+        net.add_node("a", "Belief A", source="r/gone.md", source_hash="abc123")
+
+        results = check_stale(net, repos={"r": tmp_path})
+
+        assert len(results) == 1
+        r = results[0]
+        assert r["node_id"] == "a"
+        assert r["reason"] == "source_deleted"
+        assert r["new_hash"] is None
+        assert r["source_path"] is None
+        assert r["old_hash"] == "abc123"
+        assert r["source"] == "r/gone.md"
+
+    def test_source_deleted_has_all_required_keys(self, tmp_path):
+        net = Network()
+        net.add_node("a", "Belief A", source="r/gone.md", source_hash="xyz")
+
+        results = check_stale(net, repos={"r": tmp_path})
+
+        required_keys = {"node_id", "old_hash", "new_hash", "source", "source_path", "reason"}
+        assert set(results[0].keys()) == required_keys
+
+    def test_content_changed_has_same_keys_as_source_deleted(self, tmp_path):
+        f = tmp_path / "src.md"
+        f.write_text("original")
+        h = _hash("original")
+
+        net = Network()
+        net.add_node("a", "Belief A", source="r/src.md", source_hash=h)
+        net.add_node("b", "Belief B", source="r/gone.md", source_hash="old")
+
+        f.write_text("changed")
+
+        results = check_stale(net, repos={"r": tmp_path})
+
+        assert len(results) == 2
+        changed = next(r for r in results if r["reason"] == "content_changed")
+        deleted = next(r for r in results if r["reason"] == "source_deleted")
+        assert set(changed.keys()) == set(deleted.keys())
+
+
+class TestMixedResults:
+    """Both deleted and changed sources in the same run."""
+
+    def test_mixed_deleted_and_changed(self, tmp_path):
+        changing = tmp_path / "changing.md"
+        changing.write_text("old content")
+        old_hash = _hash("old content")
+
+        stable = tmp_path / "stable.md"
+        stable.write_text("stable content")
+        stable_hash = _hash("stable content")
+
+        net = Network()
+        net.add_node("changed", "Changed belief", source="r/changing.md", source_hash=old_hash)
+        net.add_node("deleted", "Deleted belief", source="r/gone.md", source_hash="somehash")
+        net.add_node("fresh", "Fresh belief", source="r/stable.md", source_hash=stable_hash)
+
+        changing.write_text("new content")
+
+        results = check_stale(net, repos={"r": tmp_path})
+
+        reasons = {r["node_id"]: r["reason"] for r in results}
+        assert reasons["changed"] == "content_changed"
+        assert reasons["deleted"] == "source_deleted"
+        assert "fresh" not in reasons
+
+    def test_multiple_nodes_same_deleted_source(self, tmp_path):
+        net = Network()
+        net.add_node("a", "Belief A", source="r/shared.md", source_hash="h1")
+        net.add_node("b", "Belief B", source="r/shared.md", source_hash="h2")
+
+        results = check_stale(net, repos={"r": tmp_path})
+
+        assert len(results) == 2
+        assert all(r["reason"] == "source_deleted" for r in results)
+        ids = {r["node_id"] for r in results}
+        assert ids == {"a", "b"}
+
+
+class TestSkipBehavior:
+    """Nodes that should still be skipped by check_stale."""
+
+    def test_skips_out_nodes_with_missing_source(self, tmp_path):
+        net = Network()
+        net.add_node("a", "Belief A", source="r/gone.md", source_hash="abc")
+        net.retract("a")
+
+        results = check_stale(net, repos={"r": tmp_path})
+        assert results == []
+
+    def test_skips_nodes_without_source(self, tmp_path):
+        net = Network()
+        net.add_node("a", "Premise with no source")
+
+        results = check_stale(net, repos={"r": tmp_path})
+        assert results == []
+
+    def test_skips_nodes_without_hash(self, tmp_path):
+        net = Network()
+        net.add_node("a", "Has source but no hash", source="r/file.md")
+
+        results = check_stale(net, repos={"r": tmp_path})
+        assert results == []
+
+    def test_skips_nodes_with_empty_source_string(self, tmp_path):
+        net = Network()
+        net.add_node("a", "Empty source", source="", source_hash="abc")
+
+        results = check_stale(net, repos={"r": tmp_path})
+        assert results == []
+
+
+class TestEdgeCases:
+    """Edge cases from reviewer notes."""
+
+    def test_empty_file_is_not_deleted(self, tmp_path):
+        f = tmp_path / "empty.md"
+        f.write_text("")
+        empty_hash = _hash("")
+
+        net = Network()
+        net.add_node("a", "From empty file", source="r/empty.md", source_hash=empty_hash)
+
+        results = check_stale(net, repos={"r": tmp_path})
+        assert results == []
+
+    def test_empty_file_with_wrong_hash_is_content_changed(self, tmp_path):
+        f = tmp_path / "empty.md"
+        f.write_text("")
+
+        net = Network()
+        net.add_node("a", "From empty file", source="r/empty.md", source_hash="wronghash")
+
+        results = check_stale(net, repos={"r": tmp_path})
+        assert len(results) == 1
+        assert results[0]["reason"] == "content_changed"
+        assert results[0]["new_hash"] == _hash("")
+
+    def test_no_repos_mapping_with_missing_file(self):
+        net = Network()
+        net.add_node("a", "Belief", source="nonexistent-repo/file.md", source_hash="abc")
+
+        results = check_stale(net, repos=None)
+        assert len(results) == 1
+        assert results[0]["reason"] == "source_deleted"
+
+    def test_fresh_node_not_in_results(self, tmp_path):
+        f = tmp_path / "src.md"
+        f.write_text("content")
+        h = _hash("content")
+
+        net = Network()
+        net.add_node("a", "Belief A", source="r/src.md", source_hash=h)
+
+        results = check_stale(net, repos={"r": tmp_path})
+        assert results == []
+
+    def test_results_sorted_by_node_id(self, tmp_path):
+        net = Network()
+        net.add_node("z-node", "Z", source="r/z.md", source_hash="h")
+        net.add_node("a-node", "A", source="r/a.md", source_hash="h")
+        net.add_node("m-node", "M", source="r/m.md", source_hash="h")
+
+        results = check_stale(net, repos={"r": tmp_path})
+        ids = [r["node_id"] for r in results]
+        assert ids == sorted(ids)
+
+    def test_content_changed_populates_source_path(self, tmp_path):
+        f = tmp_path / "src.md"
+        f.write_text("old")
+        h = _hash("old")
+
+        net = Network()
+        net.add_node("a", "Belief", source="r/src.md", source_hash=h)
+        f.write_text("new")
+
+        results = check_stale(net, repos={"r": tmp_path})
+        assert results[0]["source_path"] == str(f)
+        assert results[0]["reason"] == "content_changed"


### PR DESCRIPTION
## Summary

Report deleted source files as stale instead of silently skipping them in `check_stale`, and fix several related bugs in the reasons network (nogood ID collisions after deletion, quadratic agent belief counting in derive prompts, and duplicated dependents-rebuild logic).

Closes #25

## Changes

- **check_stale**: Nodes whose source file no longer exists are now included in stale results with `reason: "source_deleted"` and `new_hash=None`, instead of being silently skipped. Existing content-change entries get `reason: "content_changed"`.
- **CLI output**: `check-stale` command displays `DELETED` label for missing-source entries, distinct from the `STALE` label for changed content.
- **Nogood ID generation**: Replaced `len(nogoods) + 1` with a tracked `_next_nogood_id` counter that survives deletions, preventing ID collisions after nogoods are removed.
- **Dependents rebuild**: Extracted duplicated dependents-rebuild logic from `storage.py`, `import_agent.py`, and `import_beliefs.py` into a single canonical `Network._rebuild_dependents()` method.
- **Dependents verification**: Added `Network.verify_dependents()` to detect index corruption (extra/missing dependents vs. justifications).
- **Derive budget fix**: Moved `count += len(belief_ids)` outside the per-belief loop in `_build_beliefs_section` to fix quadratic counting that could starve local beliefs from the prompt.

## Test Plan

- [x] `test_reports_missing_source_files` — verifies deleted sources produce `reason="source_deleted"` with `new_hash=None`
- [x] `test_detects_stale_content` — confirms existing content-change detection includes `reason="content_changed"`
- [x] `test_nogood_id_survives_deletion` — new ID after deleting middle nogood doesn't collide
- [x] `test_nogood_counter_empty_list` / `test_nogood_counter_ignores_prefixed_ids` — edge cases for counter reset
- [x] `test_build_prompt_agent_count_does_not_starve_local` — regression test for quadratic counting bug
- [x] `TestDependentsIntegrity` — 9 tests covering verify/rebuild after add, retract, restore, supersede, challenge, storage round-trip, and corruption detection/repair

🤖 Generated with [ftl-sdlc-loop](https://github.com/benthomasson/ftl-sdlc-loop)