### PR TITLE
Use persisted monotonic counter for nogood IDs

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -922,6 +922,7 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB) -> dict:
             remaining = next_remaining
 
         # Import nogoods
+        import re
         from . import Nogood
         nogoods_imported = 0
         for ng_data in data.get("nogoods", []):
@@ -932,6 +933,9 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB) -> dict:
                 resolution=ng_data.get("resolution", ""),
             )
             net.nogoods.append(nogood)
+            m = re.fullmatch(r"nogood-(\d+)", nogood.id)
+            if m:
+                net._next_nogood_id = max(net._next_nogood_id, int(m.group(1)) + 1)
             nogoods_imported += 1
 
         # Import repos

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -7,6 +7,7 @@ or argparse. Each function opens the database, operates, saves, and closes.
 All functions return dicts suitable for JSON serialization.
 """
 
+import re
 from pathlib import Path
 
 from . import Justification
@@ -922,7 +923,7 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB) -> dict:
             remaining = next_remaining
 
         # Import nogoods
-        import re
+
         from . import Nogood
         nogoods_imported = 0
         for ng_data in data.get("nogoods", []):

--- a/reasons_lib/import_beliefs.py
+++ b/reasons_lib/import_beliefs.py
@@ -239,6 +239,11 @@ def import_into_network(
                     resolution=ng["resolution"],
                 )
                 network.nogoods.append(nogood)
+                m = re.fullmatch(r"nogood-(\d+)", nogood.id)
+                if m:
+                    network._next_nogood_id = max(
+                        network._next_nogood_id, int(m.group(1)) + 1
+                    )
                 nogoods_imported += 1
 
     return {

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -20,6 +20,7 @@ class Network:
     def __init__(self):
         self.nodes: dict[str, Node] = {}
         self.nogoods: list[Nogood] = []
+        self._next_nogood_id: int = 1
         self.repos: dict[str, str] = {}  # name → path mapping
         self.log: list[dict] = []  # propagation audit trail
 
@@ -299,7 +300,8 @@ class Network:
             if nid not in self.nodes:
                 raise KeyError(f"Node '{nid}' not found")
 
-        nogood_id = f"nogood-{len(self.nogoods) + 1:03d}"
+        nogood_id = f"nogood-{self._next_nogood_id:03d}"
+        self._next_nogood_id += 1
         nogood = Nogood(
             id=nogood_id,
             nodes=list(node_ids),

--- a/reasons_lib/storage.py
+++ b/reasons_lib/storage.py
@@ -52,6 +52,11 @@ CREATE TABLE IF NOT EXISTS propagation_log (
     value TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS network_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(id, text);
 """
 
@@ -80,6 +85,7 @@ class Storage:
             self.conn.execute("DELETE FROM nogoods")
             self.conn.execute("DELETE FROM repos")
             self.conn.execute("DELETE FROM propagation_log")
+            self.conn.execute("DELETE FROM network_meta")
 
             for node in network.nodes.values():
                 self.conn.execute(
@@ -112,6 +118,11 @@ class Storage:
                     "VALUES (?, ?, ?, ?)",
                     (nogood.id, json.dumps(nogood.nodes), nogood.discovered, nogood.resolution),
                 )
+
+            self.conn.execute(
+                "INSERT INTO network_meta (key, value) VALUES (?, ?)",
+                ("next_nogood_id", str(network._next_nogood_id)),
+            )
 
             for name, path in network.repos.items():
                 self.conn.execute(
@@ -179,6 +190,16 @@ class Storage:
                 discovered=discovered,
                 resolution=resolution,
             ))
+
+        # Load network metadata
+        try:
+            row = self.conn.execute(
+                "SELECT value FROM network_meta WHERE key = 'next_nogood_id'"
+            ).fetchone()
+            if row:
+                network._next_nogood_id = int(row[0])
+        except Exception:
+            pass  # network_meta table may not exist in old databases
 
         # Load repos
         try:

--- a/reasons_lib/storage.py
+++ b/reasons_lib/storage.py
@@ -198,6 +198,15 @@ class Storage:
             ).fetchone()
             if row:
                 network._next_nogood_id = int(row[0])
+            elif network.nogoods:
+                # Old database without persisted counter — derive from existing nogoods
+                import re
+                max_id = 0
+                for ng in network.nogoods:
+                    m = re.fullmatch(r"nogood-(\d+)", ng.id)
+                    if m:
+                        max_id = max(max_id, int(m.group(1)))
+                network._next_nogood_id = max_id + 1
         except Exception:
             pass  # network_meta table may not exist in old databases
 

--- a/reasons_lib/storage.py
+++ b/reasons_lib/storage.py
@@ -191,24 +191,26 @@ class Storage:
                 resolution=resolution,
             ))
 
-        # Load network metadata
+        # Load network metadata — persisted counter takes priority,
+        # otherwise derive from existing nogoods to avoid ID collisions
+        loaded_counter = False
         try:
             row = self.conn.execute(
                 "SELECT value FROM network_meta WHERE key = 'next_nogood_id'"
             ).fetchone()
             if row:
                 network._next_nogood_id = int(row[0])
-            elif network.nogoods:
-                # Old database without persisted counter — derive from existing nogoods
-                import re
-                max_id = 0
-                for ng in network.nogoods:
-                    m = re.fullmatch(r"nogood-(\d+)", ng.id)
-                    if m:
-                        max_id = max(max_id, int(m.group(1)))
-                network._next_nogood_id = max_id + 1
+                loaded_counter = True
         except Exception:
             pass  # network_meta table may not exist in old databases
+        if not loaded_counter and network.nogoods:
+            import re
+            max_id = 0
+            for ng in network.nogoods:
+                m = re.fullmatch(r"nogood-(\d+)", ng.id)
+                if m:
+                    max_id = max(max_id, int(m.group(1)))
+            network._next_nogood_id = max_id + 1
 
         # Load repos
         try:

--- a/tests/test_nogood_id.py
+++ b/tests/test_nogood_id.py
@@ -114,6 +114,30 @@ class TestPersistence:
         assert loaded._next_nogood_id == 1
         storage2.close()
 
+    def test_old_db_with_nogoods_derives_counter(self, tmp_path):
+        """Old DB with existing nogoods must derive counter, not start at 1."""
+        db_path = str(tmp_path / "reasons.db")
+        storage = Storage(db_path)
+        net = Network()
+        net.add_node("a", "A")
+        net.add_node("b", "B")
+        net.add_node("c", "C")
+        net.add_node("d", "D")
+        net.add_nogood(["a", "b"])
+        net.add_nogood(["c", "d"])
+        storage.save(net)
+        # Remove the meta row to simulate an old database
+        storage.conn.execute("DELETE FROM network_meta")
+        storage.conn.commit()
+        storage.close()
+
+        storage2 = Storage(db_path)
+        loaded = storage2.load()
+        assert loaded._next_nogood_id == 3
+        loaded.add_nogood(["a", "c"])
+        assert loaded.nogoods[-1].id == "nogood-003"
+        storage2.close()
+
 
 class TestImportJson:
 

--- a/tests/test_nogood_id.py
+++ b/tests/test_nogood_id.py
@@ -126,8 +126,8 @@ class TestPersistence:
         net.add_nogood(["a", "b"])
         net.add_nogood(["c", "d"])
         storage.save(net)
-        # Remove the meta row to simulate an old database
-        storage.conn.execute("DELETE FROM network_meta")
+        # Drop the table entirely to simulate an old database
+        storage.conn.execute("DROP TABLE IF EXISTS network_meta")
         storage.conn.commit()
         storage.close()
 
@@ -136,6 +136,8 @@ class TestPersistence:
         assert loaded._next_nogood_id == 3
         loaded.add_nogood(["a", "c"])
         assert loaded.nogoods[-1].id == "nogood-003"
+        # Verify save works after upgrade
+        storage2.save(loaded)
         storage2.close()
 
 

--- a/tests/test_nogood_id.py
+++ b/tests/test_nogood_id.py
@@ -1,0 +1,164 @@
+"""Tests for monotonic nogood ID generation (issue #26).
+
+The bug: nogood IDs were derived from len(self.nogoods) + 1, so deleting
+a nogood and adding a new one would reuse the deleted ID. The fix uses a
+persisted monotonic counter (_next_nogood_id) that never decreases.
+"""
+
+import json
+
+import pytest
+
+from reasons_lib import api, Nogood
+from reasons_lib.network import Network
+from reasons_lib.storage import Storage
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "reasons.db")
+    api.init_db(db_path=db_path)
+    return db_path
+
+
+class TestMonotonicCounter:
+
+    def test_ids_increment(self):
+        net = Network()
+        net.add_node("a", "A")
+        net.add_node("b", "B")
+        net.add_node("c", "C")
+        net.add_node("d", "D")
+        net.add_nogood(["a", "b"])
+        net.add_nogood(["c", "d"])
+        assert net.nogoods[0].id == "nogood-001"
+        assert net.nogoods[1].id == "nogood-002"
+        assert net._next_nogood_id == 3
+
+    def test_delete_last_does_not_reuse_id(self):
+        net = Network()
+        net.add_node("a", "A")
+        net.add_node("b", "B")
+        net.add_node("c", "C")
+        net.add_node("d", "D")
+        net.add_nogood(["a", "b"])
+        net.add_nogood(["c", "d"])
+        del net.nogoods[-1]
+        net.add_nogood(["a", "c"])
+        assert net.nogoods[-1].id == "nogood-003"
+
+    def test_delete_all_does_not_reset(self):
+        net = Network()
+        net.add_node("a", "A")
+        net.add_node("b", "B")
+        net.add_nogood(["a", "b"])
+        net.nogoods.clear()
+        assert net._next_nogood_id == 2
+        net.add_nogood(["a", "b"])
+        assert net.nogoods[0].id == "nogood-002"
+
+
+class TestPersistence:
+
+    def test_counter_survives_save_load(self, tmp_path):
+        db_path = str(tmp_path / "reasons.db")
+        storage = Storage(db_path)
+        net = Network()
+        net.add_node("a", "A")
+        net.add_node("b", "B")
+        net.add_nogood(["a", "b"])
+        assert net._next_nogood_id == 2
+        storage.save(net)
+        storage.close()
+
+        storage2 = Storage(db_path)
+        loaded = storage2.load()
+        assert loaded._next_nogood_id == 2
+        storage2.close()
+
+    def test_counter_persists_after_deletion(self, tmp_path):
+        db_path = str(tmp_path / "reasons.db")
+        storage = Storage(db_path)
+        net = Network()
+        net.add_node("a", "A")
+        net.add_node("b", "B")
+        net.add_node("c", "C")
+        net.add_node("d", "D")
+        net.add_nogood(["a", "b"])
+        net.add_nogood(["c", "d"])
+        del net.nogoods[-1]
+        storage.save(net)
+        storage.close()
+
+        storage2 = Storage(db_path)
+        loaded = storage2.load()
+        assert loaded._next_nogood_id == 3
+        loaded.add_nogood(["a", "c"])
+        assert loaded.nogoods[-1].id == "nogood-003"
+        storage2.close()
+
+    def test_old_db_without_meta_table(self, tmp_path):
+        """Databases created before this fix should still load."""
+        db_path = str(tmp_path / "reasons.db")
+        storage = Storage(db_path)
+        net = Network()
+        net.add_node("a", "A")
+        storage.save(net)
+        # Drop the meta table to simulate an old database
+        storage.conn.execute("DROP TABLE IF EXISTS network_meta")
+        storage.conn.commit()
+        storage.close()
+
+        storage2 = Storage(db_path)
+        loaded = storage2.load()
+        assert loaded._next_nogood_id == 1
+        storage2.close()
+
+
+class TestImportJson:
+
+    def test_import_json_updates_counter(self, db, tmp_path):
+        api.add_node("a", "A", db_path=db)
+        api.add_node("b", "B", db_path=db)
+
+        json_data = {
+            "nodes": {},
+            "nogoods": [
+                {"id": "nogood-005", "nodes": ["a", "b"], "discovered": "", "resolution": ""},
+            ],
+            "repos": {},
+        }
+        json_file = str(tmp_path / "import.json")
+        with open(json_file, "w") as f:
+            json.dump(json_data, f)
+
+        api.import_json(json_file, db_path=db)
+        result = api.add_nogood(["a", "b"], db_path=db)
+        assert result["nogood_id"] == "nogood-006"
+
+
+class TestImportBeliefs:
+
+    def test_import_nogoods_updates_counter(self, db, tmp_path):
+        api.add_node("a", "A", db_path=db)
+        api.add_node("b", "B", db_path=db)
+
+        beliefs_text = ""
+        nogoods_text = """# Nogoods
+
+### nogood-010: a, b
+- Affects: a, b
+- Discovered: 2026-01-01
+"""
+        from reasons_lib.import_beliefs import import_into_network
+        from reasons_lib.storage import Storage
+
+        storage = Storage(db)
+        net = storage.load()
+        import_into_network(net, beliefs_text, nogoods_text)
+        assert net._next_nogood_id == 11
+        storage.save(net)
+        storage.close()
+
+        result = api.add_nogood(["a", "b"], db_path=db)
+        assert result["nogood_id"] == "nogood-011"


### PR DESCRIPTION
## Summary

- Replaces `len(self.nogoods) + 1` with a `_next_nogood_id` counter that only increments, ensuring deleted nogood IDs are never reused
- Persists the counter in a new `network_meta` SQLite table
- Updates the counter correctly when importing nogoods from JSON or beliefs.md
- Gracefully handles old databases that lack the `network_meta` table

Closes #26

## Test plan

- [x] 8 new tests covering monotonic IDs, persistence round-trips, old DB compat, and both import paths
- [x] Full test suite passes (425 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)