### PR TITLE
Use full SHA-256 hash for source staleness detection

### DIFF
--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -12,8 +12,8 @@ from .network import Network
 
 
 def hash_file(path: Path) -> str:
-    """SHA-256 hash of file content, first 16 hex chars."""
-    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+    """Full SHA-256 hash of file content (64 hex chars)."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def resolve_source_path(source: str, repos: dict[str, Path] | None = None) -> Path | None:

--- a/tests/test_check_stale.py
+++ b/tests/test_check_stale.py
@@ -15,7 +15,7 @@ class TestHashFile:
         f = tmp_path / "test.md"
         f.write_text("hello world")
         h = hash_file(f)
-        expected = hashlib.sha256(b"hello world").hexdigest()[:16]
+        expected = hashlib.sha256(b"hello world").hexdigest()
         assert h == expected
 
     def test_hash_changes_with_content(self, tmp_path):
@@ -51,7 +51,7 @@ class TestCheckStale:
     def test_fresh_node(self, tmp_path):
         f = tmp_path / "source.md"
         f.write_text("original content")
-        h = hashlib.sha256(b"original content").hexdigest()[:16]
+        h = hashlib.sha256(b"original content").hexdigest()
 
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/source.md", source_hash=h)
@@ -62,7 +62,7 @@ class TestCheckStale:
     def test_stale_node(self, tmp_path):
         f = tmp_path / "source.md"
         f.write_text("original content")
-        old_hash = hashlib.sha256(b"original content").hexdigest()[:16]
+        old_hash = hashlib.sha256(b"original content").hexdigest()
 
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/source.md", source_hash=old_hash)
@@ -80,7 +80,7 @@ class TestCheckStale:
     def test_skips_out_nodes(self, tmp_path):
         f = tmp_path / "source.md"
         f.write_text("original")
-        old_hash = hashlib.sha256(b"original").hexdigest()[:16]
+        old_hash = hashlib.sha256(b"original").hexdigest()
 
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/source.md", source_hash=old_hash)
@@ -117,8 +117,8 @@ class TestCheckStale:
         f2.write_text("old b")
 
         net = Network()
-        net.add_node("a", "Node A", source="r/a.md", source_hash=hashlib.sha256(b"old a").hexdigest()[:16])
-        net.add_node("b", "Node B", source="r/b.md", source_hash=hashlib.sha256(b"old b").hexdigest()[:16])
+        net.add_node("a", "Node A", source="r/a.md", source_hash=hashlib.sha256(b"old a").hexdigest())
+        net.add_node("b", "Node B", source="r/b.md", source_hash=hashlib.sha256(b"old b").hexdigest())
 
         f1.write_text("new a")
         f2.write_text("new b")

--- a/tests/test_check_stale_issue25.py
+++ b/tests/test_check_stale_issue25.py
@@ -14,7 +14,7 @@ from reasons_lib.check_stale import check_stale, hash_file
 
 
 def _hash(content: str) -> str:
-    return hashlib.sha256(content.encode()).hexdigest()[:16]
+    return hashlib.sha256(content.encode()).hexdigest()
 
 
 class TestSourceDeletedResult:


### PR DESCRIPTION
## Summary
- Remove `[:16]` truncation from `hash_file()` — now returns the full 64-char SHA-256 hex digest
- Eliminates the ~32-bit birthday-attack collision resistance blind spot in the staleness CI gate
- Updated all test helpers to match (7 occurrences across 2 test files)

**Note:** Existing `source_hash` values stored in `reasons.db` will be 16 chars. After merging, run `reasons hash-sources --force` to re-hash all sources with the full digest.

## Test plan
- [x] All 32 check_stale tests pass with full hashes
- [x] Full suite (426 tests) passes with no regressions

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)