### PR TITLE
Add access_tags for data source provenance filtering

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -559,12 +559,19 @@ def trace_assumptions(node_id: str, visible_to: list[str] | None = None, db_path
         return {"node_id": node_id, "premises": premises}
 
 
-def trace_access_tags(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+def trace_access_tags(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Trace backward through dependency chains and return union of all access_tags.
 
     Returns: {"node_id": str, "access_tags": list[str]}
+    Raises PermissionError if node's access_tags are not a subset of visible_to.
     """
     with _with_network(db_path) as net:
+        if node_id not in net.nodes:
+            raise KeyError(f"Node '{node_id}' not found")
+        if visible_to is not None and not _is_visible(net.nodes[node_id], visible_to):
+            raise PermissionError(
+                f"Node '{node_id}' requires access tags not in {visible_to}"
+            )
         tags = net.trace_access_tags(node_id)
         return {"node_id": node_id, "access_tags": tags}
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -716,6 +716,7 @@ def export_network(visible_to: list[str] | None = None, db_path: str = DEFAULT_D
             "nogoods": [
                 {"id": ng.id, "nodes": ng.nodes, "discovered": ng.discovered, "resolution": ng.resolution}
                 for ng in net.nogoods
+                if visible_to is None or all(n in net.nodes and _is_visible(net.nodes[n], visible_to) for n in ng.nodes)
             ],
             "repos": dict(net.repos),
         }
@@ -1076,7 +1077,7 @@ def export_markdown(visible_to: list[str] | None = None, db_path: str = DEFAULT_
             for nid, node in net.nodes.items():
                 if _is_visible(node, visible_to):
                     filtered.nodes[nid] = node
-            filtered.nogoods = net.nogoods
+            filtered.nogoods = [ng for ng in net.nogoods if all(n in filtered.nodes for n in ng.nodes)]
             filtered.repos = net.repos
             return _export(filtered, repos=filtered.repos)
         return _export(net, repos=net.repos)
@@ -1145,7 +1146,7 @@ def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | No
             for nid, node in net.nodes.items():
                 if _is_visible(node, visible_to):
                     filtered.nodes[nid] = node
-            filtered.nogoods = net.nogoods
+            filtered.nogoods = [ng for ng in net.nogoods if all(n in filtered.nodes for n in ng.nodes)]
             return _compact(filtered, budget=budget, truncate=truncate)
         return _compact(net, budget=budget, truncate=truncate)
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -473,7 +473,7 @@ def assert_node(node_id: str, db_path: str = DEFAULT_DB) -> dict:
         return {"changed": changed, "went_out": went_out, "went_in": went_in}
 
 
-def get_status(db_path: str = DEFAULT_DB) -> dict:
+def get_status(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Get all nodes with truth values.
 
     Returns: {"nodes": list[dict], "in_count": int, "total": int}
@@ -481,6 +481,8 @@ def get_status(db_path: str = DEFAULT_DB) -> dict:
     with _with_network(db_path) as net:
         nodes = []
         for nid, node in sorted(net.nodes.items()):
+            if visible_to is not None and not _is_visible(node, visible_to):
+                continue
             nodes.append({
                 "id": nid,
                 "text": node.text,
@@ -520,23 +522,40 @@ def show_node(node_id: str, visible_to: list[str] | None = None, db_path: str = 
         }
 
 
-def explain_node(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+def explain_node(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Explain why a node is IN or OUT.
 
     Returns: {"steps": list[dict]}
+    Raises PermissionError if node's access_tags are not a subset of visible_to.
     """
     with _with_network(db_path) as net:
+        if node_id not in net.nodes:
+            raise KeyError(f"Node '{node_id}' not found")
+        if visible_to is not None and not _is_visible(net.nodes[node_id], visible_to):
+            raise PermissionError(
+                f"Node '{node_id}' requires access tags not in {visible_to}"
+            )
         steps = net.explain(node_id)
         return {"steps": steps}
 
 
-def trace_assumptions(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+def trace_assumptions(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Trace backward to find all premises a node rests on.
 
     Returns: {"node_id": str, "premises": list[str]}
+    Raises PermissionError if node's access_tags are not a subset of visible_to.
+    Filters returned premises by visible_to.
     """
     with _with_network(db_path) as net:
+        if node_id not in net.nodes:
+            raise KeyError(f"Node '{node_id}' not found")
+        if visible_to is not None and not _is_visible(net.nodes[node_id], visible_to):
+            raise PermissionError(
+                f"Node '{node_id}' requires access tags not in {visible_to}"
+            )
         premises = net.trace_assumptions(node_id)
+        if visible_to is not None:
+            premises = [p for p in premises if p in net.nodes and _is_visible(net.nodes[p], visible_to)]
         return {"node_id": node_id, "premises": premises}
 
 
@@ -664,7 +683,7 @@ def get_log(last: int | None = None, db_path: str = DEFAULT_DB) -> dict:
         return {"entries": entries}
 
 
-def export_network(db_path: str = DEFAULT_DB) -> dict:
+def export_network(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Export the entire network as a dict.
 
     Returns: {"nodes": dict, "nogoods": list}
@@ -685,6 +704,7 @@ def export_network(db_path: str = DEFAULT_DB) -> dict:
                     "metadata": {k: v for k, v in n.metadata.items() if not k.startswith("_")},
                 }
                 for nid, n in sorted(net.nodes.items())
+                if visible_to is None or _is_visible(n, visible_to)
             },
             "nogoods": [
                 {"id": ng.id, "nodes": ng.nodes, "discovered": ng.discovered, "resolution": ng.resolution}
@@ -1035,7 +1055,7 @@ def list_repos(db_path: str = DEFAULT_DB) -> dict:
         return {"repos": dict(net.repos)}
 
 
-def export_markdown(db_path: str = DEFAULT_DB) -> str:
+def export_markdown(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> str:
     """Export the network as beliefs.md-compatible markdown.
 
     Returns: the markdown string
@@ -1043,6 +1063,15 @@ def export_markdown(db_path: str = DEFAULT_DB) -> str:
     from .export_markdown import export_markdown as _export
 
     with _with_network(db_path) as net:
+        if visible_to is not None:
+            from .network import Network
+            filtered = Network()
+            for nid, node in net.nodes.items():
+                if _is_visible(node, visible_to):
+                    filtered.nodes[nid] = node
+            filtered.nogoods = net.nogoods
+            filtered.repos = net.repos
+            return _export(filtered, repos=filtered.repos)
         return _export(net, repos=net.repos)
 
 
@@ -1095,7 +1124,7 @@ def hash_sources(
         return {"hashed": results, "count": len(results)}
 
 
-def compact(budget: int = 500, truncate: bool = True, db_path: str = DEFAULT_DB) -> str:
+def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> str:
     """Generate a token-budgeted belief state summary.
 
     Returns: the compact summary string
@@ -1103,6 +1132,14 @@ def compact(budget: int = 500, truncate: bool = True, db_path: str = DEFAULT_DB)
     from .compact import compact as _compact
 
     with _with_network(db_path) as net:
+        if visible_to is not None:
+            from .network import Network
+            filtered = Network()
+            for nid, node in net.nodes.items():
+                if _is_visible(node, visible_to):
+                    filtered.nodes[nid] = node
+            filtered.nogoods = net.nogoods
+            return _compact(filtered, budget=budget, truncate=truncate)
         return _compact(net, budget=budget, truncate=truncate)
 
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -18,6 +18,19 @@ from .storage import Storage
 DEFAULT_DB = "reasons.db"
 
 
+def _is_visible(node, visible_to: list[str]) -> bool:
+    """Check if a node is visible given the caller's access tags.
+
+    A node is visible if its access_tags are all contained in visible_to.
+    Nodes with no access_tags are always visible.
+    """
+    tags = node.metadata.get("access_tags", [])
+    if not tags:
+        return True
+    visible_set = set(visible_to)
+    return all(t in visible_set for t in tags)
+
+
 def _resolve_namespace(node_id: str, namespace: str | None) -> str:
     """Prefix node_id with namespace if provided and not already namespaced.
 
@@ -124,6 +137,7 @@ def add_node(
     source: str = "",
     namespace: str | None = None,
     any_mode: bool = False,
+    access_tags: list[str] | None = None,
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """Add a node to the network.
@@ -138,6 +152,7 @@ def add_node(
         source: Provenance (repo:path)
         namespace: Optional namespace prefix (auto-creates ns:active premise)
         any_mode: If True, expand SL into one justification per antecedent (OR)
+        access_tags: Data source provenance tags for access control
         db_path: Path to RMS database
 
     Returns: {"node_id": str, "truth_value": str, "type": str, "premise_count": int}
@@ -192,11 +207,16 @@ def add_node(
                 j.antecedents = [_resolve_namespace(a, namespace) for a in j.antecedents]
                 j.outlist = [_resolve_namespace(o, namespace) for o in j.outlist]
 
+        metadata = {}
+        if access_tags:
+            metadata["access_tags"] = sorted(set(access_tags))
+
         node = net.add_node(
             id=node_id,
             text=text,
             justifications=justifications or None,
             source=source,
+            metadata=metadata or None,
         )
         jtype = justifications[0].type if justifications else "premise"
         max_premises = max((len(j.antecedents) for j in justifications), default=0)
@@ -471,15 +491,20 @@ def get_status(db_path: str = DEFAULT_DB) -> dict:
         return {"nodes": nodes, "in_count": in_count, "total": len(nodes)}
 
 
-def show_node(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+def show_node(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Get full details for a node.
 
     Returns: dict with id, text, truth_value, source, justifications, dependents
+    Raises PermissionError if node's access_tags are not a subset of visible_to.
     """
     with _with_network(db_path) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
         node = net.nodes[node_id]
+        if visible_to is not None and not _is_visible(node, visible_to):
+            raise PermissionError(
+                f"Node '{node_id}' requires access tags not in {visible_to}"
+            )
         return {
             "id": node.id,
             "text": node.text,
@@ -513,6 +538,16 @@ def trace_assumptions(node_id: str, db_path: str = DEFAULT_DB) -> dict:
     with _with_network(db_path) as net:
         premises = net.trace_assumptions(node_id)
         return {"node_id": node_id, "premises": premises}
+
+
+def trace_access_tags(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+    """Trace backward through dependency chains and return union of all access_tags.
+
+    Returns: {"node_id": str, "access_tags": list[str]}
+    """
+    with _with_network(db_path) as net:
+        tags = net.trace_access_tags(node_id)
+        return {"node_id": node_id, "access_tags": tags}
 
 
 def find_culprits(node_ids: list[str], db_path: str = DEFAULT_DB) -> dict:
@@ -1071,13 +1106,14 @@ def compact(budget: int = 500, truncate: bool = True, db_path: str = DEFAULT_DB)
         return _compact(net, budget=budget, truncate=truncate)
 
 
-def lookup(query: str, db_path: str = DEFAULT_DB) -> str:
+def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> str:
     """Simple all-terms search over the full belief block — ID, text, source,
     dependencies, and metadata. Matches the same search corpus and output
     format as lookup_beliefs on a flat beliefs.md file.
 
     Args:
         query: search terms (all must appear, case-insensitive)
+        visible_to: only return nodes whose access_tags are a subset
         db_path: path to RMS database
 
     Returns: formatted string with matching beliefs (full blocks)
@@ -1086,6 +1122,8 @@ def lookup(query: str, db_path: str = DEFAULT_DB) -> str:
         query_terms = query.lower().split()
         matches = []
         for nid, node in sorted(net.nodes.items()):
+            if visible_to is not None and not _is_visible(node, visible_to):
+                continue
             # Build the full searchable block — same fields as beliefs.md
             block_parts = [nid, node.text]
             if node.source:
@@ -1125,7 +1163,7 @@ def lookup(query: str, db_path: str = DEFAULT_DB) -> str:
         return "\n".join(parts)
 
 
-def search(query: str, db_path: str = DEFAULT_DB, format: str = "markdown") -> str:
+def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB, format: str = "markdown") -> str:
     """Search nodes using full-text search with neighbor expansion.
 
     Uses SQLite FTS5 for ranked all-terms matching. Returns matched nodes
@@ -1136,6 +1174,7 @@ def search(query: str, db_path: str = DEFAULT_DB, format: str = "markdown") -> s
 
     Args:
         query: search terms (FTS5 matches all terms in any order)
+        visible_to: only return nodes whose access_tags are a subset
         db_path: path to RMS database
         format: output format — "markdown" (default), "json", or "minimal"
 
@@ -1150,6 +1189,15 @@ def search(query: str, db_path: str = DEFAULT_DB, format: str = "markdown") -> s
 
         if not matched_ids:
             return "No results found."
+
+        # Apply access filtering
+        if visible_to is not None:
+            matched_ids = [
+                nid for nid in matched_ids
+                if nid in net.nodes and _is_visible(net.nodes[nid], visible_to)
+            ]
+            if not matched_ids:
+                return "No results found."
 
         # Expand to include neighbors (1-hop in dependency graph)
         neighbor_ids = set()
@@ -1307,6 +1355,7 @@ def list_nodes(
     namespace: str | None = None,
     min_depth: int | None = None,
     max_depth: int | None = None,
+    visible_to: list[str] | None = None,
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """List nodes with optional filters.
@@ -1326,6 +1375,8 @@ def list_nodes(
             if has_dependents and not node.dependents:
                 continue
             if challenged and not node.metadata.get("challenges"):
+                continue
+            if visible_to is not None and not _is_visible(node, visible_to):
                 continue
             if memo is not None:
                 d = _node_depth(nid, net, memo)

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1217,6 +1217,13 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
         # Remove already-matched nodes from neighbors
         neighbor_ids -= set(matched_ids)
 
+        # Apply access filtering to neighbors too
+        if visible_to is not None:
+            neighbor_ids = {
+                nid for nid in neighbor_ids
+                if nid in net.nodes and _is_visible(net.nodes[nid], visible_to)
+            }
+
         if format == "json":
             return _format_json(net, matched_ids, neighbor_ids)
         elif format == "minimal":

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -30,6 +30,9 @@ def _warn_multi_premise(premise_count, any_mode):
 
 
 def cmd_add(args):
+    access_tags = None
+    if getattr(args, "access_tags", None):
+        access_tags = [t.strip() for t in args.access_tags.split(",") if t.strip()]
     try:
         result = api.add_node(
             node_id=args.node_id,
@@ -41,6 +44,7 @@ def cmd_add(args):
             source=args.source or "",
             namespace=getattr(args, "namespace", None),
             any_mode=getattr(args, "any", False),
+            access_tags=access_tags,
             db_path=args.db,
         )
         print(f"Added {result['node_id']} [{result['truth_value']}] ({result['type']})")
@@ -206,10 +210,16 @@ def cmd_status(args):
 
 
 def cmd_show(args):
+    visible_to = None
+    if getattr(args, "visible_to", None):
+        visible_to = [t.strip() for t in args.visible_to.split(",") if t.strip()]
     try:
-        node = api.show_node(args.node_id, db_path=args.db)
+        node = api.show_node(args.node_id, visible_to=visible_to, db_path=args.db)
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except PermissionError as e:
+        print(f"Access denied: {e}", file=sys.stderr)
         sys.exit(1)
 
     print(f"ID:     {node['id']}")
@@ -345,6 +355,20 @@ def cmd_nogood(args):
         print(f"Backtracked to premise: {result['backtracked_to']}")
     if result["changed"]:
         print(f"Retracted: {', '.join(result['changed'])}")
+
+
+def cmd_trace_access_tags(args):
+    try:
+        result = api.trace_access_tags(args.node_id, db_path=args.db)
+    except KeyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not result["access_tags"]:
+        print(f"{args.node_id} has no access tags in its dependency chain (unrestricted).")
+        return
+
+    print(f"{args.node_id} depends on data tagged: {', '.join(result['access_tags'])}")
 
 
 def cmd_trace(args):
@@ -568,14 +592,20 @@ def cmd_compact(args):
     print(summary)
 
 
+def _parse_visible_to(args):
+    if getattr(args, "visible_to", None):
+        return [t.strip() for t in args.visible_to.split(",") if t.strip()]
+    return None
+
+
 def cmd_search(args):
     fmt = getattr(args, "format", "markdown")
-    result = api.search(args.query, db_path=args.db, format=fmt)
+    result = api.search(args.query, visible_to=_parse_visible_to(args), db_path=args.db, format=fmt)
     print(result)
 
 
 def cmd_lookup(args):
-    result = api.lookup(args.query, db_path=args.db)
+    result = api.lookup(args.query, visible_to=_parse_visible_to(args), db_path=args.db)
     print(result)
 
 
@@ -851,6 +881,7 @@ def cmd_list(args):
         namespace=getattr(args, "namespace", None),
         min_depth=args.min_depth,
         max_depth=args.max_depth,
+        visible_to=_parse_visible_to(args),
         db_path=args.db,
     )
 
@@ -901,6 +932,7 @@ def main():
     p.add_argument("--label", help="Justification label")
     p.add_argument("--source", help="Provenance (repo:path)")
     p.add_argument("-n", "--namespace", help="Namespace prefix (auto-creates ns:active premise)")
+    p.add_argument("--access-tags", metavar="TAG,TAG", help="Data source provenance tags (comma-separated)")
 
     # add-justification
     p = sub.add_parser("add-justification", help="Add a justification to an existing node")
@@ -932,6 +964,7 @@ def main():
     # show
     p = sub.add_parser("show", help="Show node details")
     p.add_argument("node_id", help="Node to show")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show if access_tags are a subset of these tags")
 
     # explain
     p = sub.add_parser("explain", help="Explain why a node is IN or OUT")
@@ -971,6 +1004,9 @@ def main():
     p.add_argument("node_ids", nargs="+", help="Node IDs that cannot all be IN")
 
     # trace
+    p = sub.add_parser("trace-access-tags", help="Trace all access tags in a node's dependency chain")
+    p.add_argument("node_id", help="Node to trace")
+
     p = sub.add_parser("trace", help="Trace backward to find premises a node rests on")
     p.add_argument("node_id", help="Node to trace")
 
@@ -1076,10 +1112,12 @@ def main():
     p.add_argument("query", help="Search terms (FTS5 all-terms matching)")
     p.add_argument("--format", choices=["markdown", "json", "minimal"], default="markdown",
                    help="Output format (default: markdown)")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
 
     # lookup
     p = sub.add_parser("lookup", help="Simple keyword search over beliefs (no neighbor expansion)")
     p.add_argument("query", help="Search terms (all must match, case-insensitive)")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
 
     # deduplicate
     p = sub.add_parser("deduplicate", help="Find and optionally retract duplicate IN beliefs")
@@ -1106,6 +1144,7 @@ def main():
                    help="Only show beliefs at this depth or deeper (0=premises)")
     p.add_argument("--max-depth", type=int, default=None,
                    help="Only show beliefs at this depth or shallower")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
 
     args = parser.parse_args()
     if not args.command:
@@ -1144,6 +1183,7 @@ def main():
         "challenge": cmd_challenge,
         "defend": cmd_defend,
         "trace": cmd_trace,
+        "trace-access-tags": cmd_trace_access_tags,
         "search": cmd_search,
         "lookup": cmd_lookup,
         "deduplicate": cmd_deduplicate,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -210,9 +210,7 @@ def cmd_status(args):
 
 
 def cmd_show(args):
-    visible_to = None
-    if getattr(args, "visible_to", None):
-        visible_to = [t.strip() for t in args.visible_to.split(",") if t.strip()]
+    visible_to = _parse_visible_to(args)
     try:
         node = api.show_node(args.node_id, visible_to=visible_to, db_path=args.db)
     except KeyError as e:
@@ -593,8 +591,9 @@ def cmd_compact(args):
 
 
 def _parse_visible_to(args):
-    if getattr(args, "visible_to", None):
-        return [t.strip() for t in args.visible_to.split(",") if t.strip()]
+    val = getattr(args, "visible_to", None)
+    if val is not None:
+        return [t.strip() for t in val.split(",") if t.strip()]
     return None
 
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -360,9 +360,12 @@ def cmd_nogood(args):
 
 def cmd_trace_access_tags(args):
     try:
-        result = api.trace_access_tags(args.node_id, db_path=args.db)
+        result = api.trace_access_tags(args.node_id, visible_to=_parse_visible_to(args), db_path=args.db)
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except PermissionError as e:
+        print(f"Access denied: {e}", file=sys.stderr)
         sys.exit(1)
 
     if not result["access_tags"]:
@@ -1014,6 +1017,7 @@ def main():
     # trace
     p = sub.add_parser("trace-access-tags", help="Trace all access tags in a node's dependency chain")
     p.add_argument("node_id", help="Node to trace")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only allow if access_tags are a subset of these tags")
 
     p = sub.add_parser("trace", help="Trace backward to find premises a node rests on")
     p.add_argument("node_id", help="Node to trace")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -194,7 +194,7 @@ def cmd_what_if(args):
 
 
 def cmd_status(args):
-    result = api.get_status(db_path=args.db)
+    result = api.get_status(visible_to=_parse_visible_to(args), db_path=args.db)
 
     if not result["nodes"]:
         print("No nodes in the network.")
@@ -246,9 +246,12 @@ def cmd_show(args):
 
 def cmd_explain(args):
     try:
-        result = api.explain_node(args.node_id, db_path=args.db)
+        result = api.explain_node(args.node_id, visible_to=_parse_visible_to(args), db_path=args.db)
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except PermissionError as e:
+        print(f"Access denied: {e}", file=sys.stderr)
         sys.exit(1)
 
     for step in result["steps"]:
@@ -371,9 +374,12 @@ def cmd_trace_access_tags(args):
 
 def cmd_trace(args):
     try:
-        result = api.trace_assumptions(args.node_id, db_path=args.db)
+        result = api.trace_assumptions(args.node_id, visible_to=_parse_visible_to(args), db_path=args.db)
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except PermissionError as e:
+        print(f"Access denied: {e}", file=sys.stderr)
         sys.exit(1)
 
     if not result["premises"]:
@@ -523,12 +529,12 @@ def cmd_import_json(args):
 
 
 def cmd_export(args):
-    data = api.export_network(db_path=args.db)
+    data = api.export_network(visible_to=_parse_visible_to(args), db_path=args.db)
     print(json.dumps(data, indent=2))
 
 
 def cmd_export_markdown(args):
-    md = api.export_markdown(db_path=args.db)
+    md = api.export_markdown(visible_to=_parse_visible_to(args), db_path=args.db)
     if args.output:
         Path(args.output).write_text(md)
         print(f"Written to {args.output}")
@@ -585,6 +591,7 @@ def cmd_compact(args):
     summary = api.compact(
         budget=args.budget,
         truncate=not args.no_truncate,
+        visible_to=_parse_visible_to(args),
         db_path=args.db,
     )
     print(summary)
@@ -958,7 +965,8 @@ def main():
     p.add_argument("node_id", help="Node to simulate")
 
     # status
-    sub.add_parser("status", help="Show all nodes with truth values")
+    p = sub.add_parser("status", help="Show all nodes with truth values")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
 
     # show
     p = sub.add_parser("show", help="Show node details")
@@ -968,6 +976,7 @@ def main():
     # explain
     p = sub.add_parser("explain", help="Explain why a node is IN or OUT")
     p.add_argument("node_id", help="Node to explain")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show if access_tags are a subset of these tags")
 
     # convert-to-premise
     p = sub.add_parser("convert-to-premise", help="Strip justifications, make a node a premise")
@@ -1008,6 +1017,7 @@ def main():
 
     p = sub.add_parser("trace", help="Trace backward to find premises a node rests on")
     p.add_argument("node_id", help="Node to trace")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show premises whose access_tags are a subset of these tags")
 
     # propagate
     sub.add_parser("propagate", help="Recompute all truth values")
@@ -1088,11 +1098,13 @@ def main():
     p.add_argument("json_file", help="Path to JSON file")
 
     # export
-    sub.add_parser("export", help="Export network as JSON")
+    p = sub.add_parser("export", help="Export network as JSON")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only export nodes whose access_tags are a subset of these tags")
 
     # export-markdown
     p = sub.add_parser("export-markdown", help="Export network as beliefs.md-compatible markdown")
     p.add_argument("-o", "--output", help="Write to file instead of stdout")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only export nodes whose access_tags are a subset of these tags")
 
     # hash-sources
     p = sub.add_parser("hash-sources", help="Backfill source hashes for nodes without them")
@@ -1105,6 +1117,7 @@ def main():
     p = sub.add_parser("compact", help="Token-budgeted belief state summary")
     p.add_argument("--budget", type=int, default=500, help="Token budget (default: 500)")
     p.add_argument("--no-truncate", action="store_true", help="Show full node text")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only include nodes whose access_tags are a subset of these tags")
 
     # search
     p = sub.add_parser("search", help="Search nodes using full-text search with neighbor expansion")

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -182,6 +182,24 @@ class Network:
         if inherited:
             node.metadata["access_tags"] = sorted(inherited)
 
+    def _propagate_access_tags(self, changed_id: str) -> None:
+        """Push access_tags forward to dependents that derive from this node."""
+        queue = deque([changed_id])
+        visited = {changed_id}
+        while queue:
+            current_id = queue.popleft()
+            current = self.nodes[current_id]
+            for dep_id in current.dependents:
+                if dep_id in visited or dep_id not in self.nodes:
+                    continue
+                dep = self.nodes[dep_id]
+                old_tags = dep.metadata.get("access_tags", [])
+                self._inherit_access_tags(dep)
+                new_tags = dep.metadata.get("access_tags", [])
+                if old_tags != new_tags:
+                    visited.add(dep_id)
+                    queue.append(dep_id)
+
     def trace_access_tags(self, node_id: str) -> list[str]:
         """Return the union of all access_tags in the dependency subgraph.
 
@@ -441,6 +459,7 @@ class Network:
 
         node.justifications.append(justification)
         self._inherit_access_tags(node)
+        self._propagate_access_tags(node_id)
 
         new_value = self._compute_truth(node)
         changed = []

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -107,6 +107,7 @@ class Network:
                     self.nodes[out_id].dependents.add(id)
 
         self.nodes[id] = node
+        self._inherit_access_tags(node)
 
         # Compute initial truth value
         if node.justifications:
@@ -166,6 +167,45 @@ class Network:
         # Propagate to dependents
         changed.extend(self._propagate(node_id))
         return changed
+
+    def _inherit_access_tags(self, node: "Node") -> None:
+        """Merge access_tags from all justification antecedents into this node."""
+        if not node.justifications:
+            return
+        inherited = set(node.metadata.get("access_tags", []))
+        for j in node.justifications:
+            for ant_id in j.antecedents:
+                if ant_id in self.nodes:
+                    inherited.update(
+                        self.nodes[ant_id].metadata.get("access_tags", [])
+                    )
+        if inherited:
+            node.metadata["access_tags"] = sorted(inherited)
+
+    def trace_access_tags(self, node_id: str) -> list[str]:
+        """Return the union of all access_tags in the dependency subgraph.
+
+        Traces backward through all justification chains, collecting
+        access_tags from every node visited (not just premises).
+        """
+        if node_id not in self.nodes:
+            raise KeyError(f"Node '{node_id}' not found")
+
+        all_tags: set[str] = set()
+        visited: set[str] = set()
+
+        def _walk(nid: str) -> None:
+            if nid in visited or nid not in self.nodes:
+                return
+            visited.add(nid)
+            node = self.nodes[nid]
+            all_tags.update(node.metadata.get("access_tags", []))
+            for j in node.justifications:
+                for ant_id in j.antecedents:
+                    _walk(ant_id)
+
+        _walk(node_id)
+        return sorted(all_tags)
 
     def trace_assumptions(self, node_id: str) -> list[str]:
         """Trace backward through justification chains to find all premises.
@@ -400,6 +440,7 @@ class Network:
                 self.nodes[out_id].dependents.add(node_id)
 
         node.justifications.append(justification)
+        self._inherit_access_tags(node)
 
         new_value = self._compute_truth(node)
         changed = []

--- a/tests/test_access_tags.py
+++ b/tests/test_access_tags.py
@@ -311,3 +311,10 @@ class TestTraceAccessTags:
         result = api.trace_access_tags("b", db_path=db)
         assert result["node_id"] == "b"
         assert result["access_tags"] == ["finance"]
+
+    def test_api_trace_access_tags_raises_on_forbidden(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("a", "Finance premise", access_tags=["finance"], db_path=db)
+
+        with pytest.raises(PermissionError):
+            api.trace_access_tags("a", visible_to=["hr"], db_path=db)

--- a/tests/test_access_tags.py
+++ b/tests/test_access_tags.py
@@ -267,6 +267,17 @@ class TestVisibleTo:
         assert "pub" in data["nodes"]
         assert "fin" not in data["nodes"]
 
+    def test_export_network_filters_nogoods(self, db_path):
+        api.add_node("pub", "Public", db_path=db_path)
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+        api.add_nogood(["pub", "fin"], db_path=db_path)
+
+        data = api.export_network(visible_to=["public"], db_path=db_path)
+        assert len(data["nogoods"]) == 0
+
+        data_all = api.export_network(visible_to=["finance", "public"], db_path=db_path)
+        assert len(data_all["nogoods"]) == 1
+
     def test_export_markdown_respects_visible_to(self, db_path):
         api.add_node("pub", "Public", db_path=db_path)
         api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)

--- a/tests/test_access_tags.py
+++ b/tests/test_access_tags.py
@@ -91,6 +91,26 @@ class TestInheritance:
 
         assert net.nodes["c"].metadata.get("access_tags") == ["finance", "hr"]
 
+    def test_add_justification_propagates_tags_to_dependents(self):
+        net = Network()
+        net.add_node("a", "A")
+        j1 = Justification(type="SL", antecedents=["a"], outlist=[], label="")
+        net.add_node("b", "B", justifications=[j1])
+        j2 = Justification(type="SL", antecedents=["b"], outlist=[], label="")
+        net.add_node("c", "C", justifications=[j2])
+
+        assert "access_tags" not in net.nodes["b"].metadata
+        assert "access_tags" not in net.nodes["c"].metadata
+
+        # Now give "a" access tags via a new justification from a tagged node
+        net.add_node("secret", "Secret", metadata={"access_tags": ["finance"]})
+        j3 = Justification(type="SL", antecedents=["secret"], outlist=[], label="")
+        net.add_justification("a", j3)
+
+        assert net.nodes["a"].metadata.get("access_tags") == ["finance"]
+        assert net.nodes["b"].metadata.get("access_tags") == ["finance"]
+        assert net.nodes["c"].metadata.get("access_tags") == ["finance"]
+
     def test_tags_persist_through_storage(self, db_path):
         api.add_node("a", "Premise A", access_tags=["finance"], db_path=db_path)
         api.add_node("b", "Derived B", sl="a", db_path=db_path)
@@ -177,6 +197,13 @@ class TestVisibleTo:
         assert "public-item" in result
         assert "secret-item" not in result
 
+    def test_search_neighbors_filtered(self, db_path):
+        api.add_node("secret", "Secret finance data", access_tags=["finance"], db_path=db_path)
+        api.add_node("public", "Public derived fact", sl="secret", db_path=db_path)
+
+        result = api.search("public", visible_to=["public"], db_path=db_path)
+        assert "secret" not in result
+
 
 class TestTraceAccessTags:
 
@@ -216,14 +243,11 @@ class TestTraceAccessTags:
         with pytest.raises(KeyError):
             net.trace_access_tags("nonexistent")
 
-    def test_api_trace_access_tags(self, db_path):
-        api.add_node("a", "Finance premise", access_tags=["finance"], db_path=db_path)
-        api.add_node("b", "Derived", sl="a", db_path=db_path)
+    def test_api_trace_access_tags(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("a", "Finance premise", access_tags=["finance"], db_path=db)
+        api.add_node("b", "Derived", sl="a", db_path=db)
 
-        result = api.trace_access_tags("b", db_path=db_path)
+        result = api.trace_access_tags("b", db_path=db)
         assert result["node_id"] == "b"
         assert result["access_tags"] == ["finance"]
-
-    @pytest.fixture
-    def db_path(self, tmp_path):
-        return str(tmp_path / "test.db")

--- a/tests/test_access_tags.py
+++ b/tests/test_access_tags.py
@@ -204,6 +204,66 @@ class TestVisibleTo:
         result = api.search("public", visible_to=["public"], db_path=db_path)
         assert "secret" not in result
 
+    def test_status_respects_visible_to(self, db_path):
+        api.add_node("pub", "Public", db_path=db_path)
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+
+        result = api.get_status(visible_to=["public"], db_path=db_path)
+        ids = {n["id"] for n in result["nodes"]}
+        assert "pub" in ids
+        assert "fin" not in ids
+        assert result["total"] == 1
+
+    def test_explain_raises_on_forbidden(self, db_path):
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+
+        with pytest.raises(PermissionError):
+            api.explain_node("fin", visible_to=["hr"], db_path=db_path)
+
+    def test_trace_raises_on_forbidden(self, db_path):
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+        api.add_node("derived", "Derived", sl="fin", db_path=db_path)
+
+        with pytest.raises(PermissionError):
+            api.trace_assumptions("derived", visible_to=["public"], db_path=db_path)
+
+    def test_trace_filters_premises(self, db_path):
+        api.add_node("pub", "Public premise", db_path=db_path)
+        api.add_node("fin", "Finance premise", access_tags=["finance"], db_path=db_path)
+        api.add_node("derived", "Derived", sl="pub,fin", db_path=db_path)
+
+        result = api.trace_assumptions("derived", visible_to=["finance", "public"], db_path=db_path)
+        assert "pub" in result["premises"]
+        assert "fin" in result["premises"]
+
+        # derived inherits ["finance"] from fin, so visible_to=["public"] can't see it
+        with pytest.raises(PermissionError):
+            api.trace_assumptions("derived", visible_to=["public"], db_path=db_path)
+
+    def test_export_network_respects_visible_to(self, db_path):
+        api.add_node("pub", "Public", db_path=db_path)
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+
+        data = api.export_network(visible_to=["public"], db_path=db_path)
+        assert "pub" in data["nodes"]
+        assert "fin" not in data["nodes"]
+
+    def test_export_markdown_respects_visible_to(self, db_path):
+        api.add_node("pub", "Public", db_path=db_path)
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+
+        md = api.export_markdown(visible_to=["public"], db_path=db_path)
+        assert "pub" in md
+        assert "fin" not in md
+
+    def test_compact_respects_visible_to(self, db_path):
+        api.add_node("pub", "Public belief", db_path=db_path)
+        api.add_node("fin", "Finance belief", access_tags=["finance"], db_path=db_path)
+
+        result = api.compact(visible_to=["public"], db_path=db_path)
+        assert "pub" in result
+        assert "fin" not in result
+
 
 class TestTraceAccessTags:
 

--- a/tests/test_access_tags.py
+++ b/tests/test_access_tags.py
@@ -220,6 +220,25 @@ class TestVisibleTo:
         with pytest.raises(PermissionError):
             api.explain_node("fin", visible_to=["hr"], db_path=db_path)
 
+    def test_explain_inherits_restriction_from_antecedent(self, db_path):
+        """Tag inheritance prevents explain from leaking restricted antecedents.
+
+        A derived node inherits its parent's tags, so a caller without
+        access to the parent also can't explain the derived node.
+        """
+        api.add_node("secret", "Secret finance data", access_tags=["finance"], db_path=db_path)
+        api.add_node("derived", "Derived from secret", sl="secret", db_path=db_path)
+
+        # derived inherits ["finance"] — caller without finance can't explain it
+        with pytest.raises(PermissionError):
+            api.explain_node("derived", visible_to=["public"], db_path=db_path)
+
+        # caller with finance can explain and sees the antecedent (allowed)
+        result = api.explain_node("derived", visible_to=["finance"], db_path=db_path)
+        step_ids = [s["node"] for s in result["steps"]]
+        assert "derived" in step_ids
+        assert "secret" in step_ids
+
     def test_trace_raises_on_forbidden(self, db_path):
         api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
         api.add_node("derived", "Derived", sl="fin", db_path=db_path)

--- a/tests/test_access_tags.py
+++ b/tests/test_access_tags.py
@@ -1,0 +1,229 @@
+"""Tests for access control via data source provenance tags (issue #38)."""
+
+import pytest
+
+from reasons_lib import Justification
+from reasons_lib.network import Network
+from reasons_lib import api
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+class TestInheritance:
+
+    def test_derived_inherits_single_parent_tags(self):
+        net = Network()
+        net.add_node("a", "Premise A", metadata={"access_tags": ["finance"]})
+        j = Justification(type="SL", antecedents=["a"], outlist=[], label="")
+        net.add_node("b", "Derived B", justifications=[j])
+
+        assert net.nodes["b"].metadata.get("access_tags") == ["finance"]
+
+    def test_derived_inherits_union_of_parents(self):
+        net = Network()
+        net.add_node("a", "A", metadata={"access_tags": ["finance"]})
+        net.add_node("b", "B", metadata={"access_tags": ["hr"]})
+        j = Justification(type="SL", antecedents=["a", "b"], outlist=[], label="")
+        net.add_node("c", "Derived C", justifications=[j])
+
+        assert net.nodes["c"].metadata.get("access_tags") == ["finance", "hr"]
+
+    def test_derived_merges_explicit_and_inherited_tags(self):
+        net = Network()
+        net.add_node("a", "A", metadata={"access_tags": ["finance"]})
+        j = Justification(type="SL", antecedents=["a"], outlist=[], label="")
+        net.add_node("b", "B", justifications=[j], metadata={"access_tags": ["ops"]})
+
+        assert net.nodes["b"].metadata.get("access_tags") == ["finance", "ops"]
+
+    def test_premise_does_not_inherit(self):
+        net = Network()
+        net.add_node("a", "Premise")
+
+        assert "access_tags" not in net.nodes["a"].metadata
+
+    def test_chain_inheritance(self):
+        net = Network()
+        net.add_node("a", "A", metadata={"access_tags": ["finance"]})
+        j1 = Justification(type="SL", antecedents=["a"], outlist=[], label="")
+        net.add_node("b", "B", justifications=[j1])
+        j2 = Justification(type="SL", antecedents=["b"], outlist=[], label="")
+        net.add_node("c", "C", justifications=[j2])
+
+        assert net.nodes["b"].metadata.get("access_tags") == ["finance"]
+        assert net.nodes["c"].metadata.get("access_tags") == ["finance"]
+
+    def test_diamond_inheritance(self):
+        net = Network()
+        net.add_node("a", "A", metadata={"access_tags": ["finance"]})
+        net.add_node("b", "B", metadata={"access_tags": ["hr"]})
+        j1 = Justification(type="SL", antecedents=["a"], outlist=[], label="")
+        net.add_node("m1", "M1", justifications=[j1])
+        j2 = Justification(type="SL", antecedents=["b"], outlist=[], label="")
+        net.add_node("m2", "M2", justifications=[j2])
+        j3 = Justification(type="SL", antecedents=["m1", "m2"], outlist=[], label="")
+        net.add_node("c", "C", justifications=[j3])
+
+        assert net.nodes["c"].metadata.get("access_tags") == ["finance", "hr"]
+
+    def test_no_tags_no_inheritance(self):
+        net = Network()
+        net.add_node("a", "A")
+        j = Justification(type="SL", antecedents=["a"], outlist=[], label="")
+        net.add_node("b", "B", justifications=[j])
+
+        assert "access_tags" not in net.nodes["b"].metadata
+
+    def test_add_justification_updates_tags(self):
+        net = Network()
+        net.add_node("a", "A", metadata={"access_tags": ["finance"]})
+        net.add_node("b", "B", metadata={"access_tags": ["hr"]})
+        j1 = Justification(type="SL", antecedents=["a"], outlist=[], label="")
+        net.add_node("c", "C", justifications=[j1])
+
+        assert net.nodes["c"].metadata.get("access_tags") == ["finance"]
+
+        j2 = Justification(type="SL", antecedents=["b"], outlist=[], label="")
+        net.add_justification("c", j2)
+
+        assert net.nodes["c"].metadata.get("access_tags") == ["finance", "hr"]
+
+    def test_tags_persist_through_storage(self, db_path):
+        api.add_node("a", "Premise A", access_tags=["finance"], db_path=db_path)
+        api.add_node("b", "Derived B", sl="a", db_path=db_path)
+
+        node_a = api.show_node("a", db_path=db_path)
+        node_b = api.show_node("b", db_path=db_path)
+
+        assert node_a["metadata"]["access_tags"] == ["finance"]
+        assert node_b["metadata"]["access_tags"] == ["finance"]
+
+
+class TestVisibleTo:
+
+    def test_list_nodes_filters_by_access(self, db_path):
+        api.add_node("pub", "Public", db_path=db_path)
+        api.add_node("fin", "Finance data", access_tags=["finance"], db_path=db_path)
+        api.add_node("hr", "HR data", access_tags=["hr"], db_path=db_path)
+
+        result = api.list_nodes(visible_to=["finance"], db_path=db_path)
+        ids = {n["id"] for n in result["nodes"]}
+        assert "pub" in ids
+        assert "fin" in ids
+        assert "hr" not in ids
+
+    def test_list_nodes_visible_to_none_shows_all(self, db_path):
+        api.add_node("pub", "Public", db_path=db_path)
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+
+        result = api.list_nodes(db_path=db_path)
+        assert result["count"] == 2
+
+    def test_list_nodes_untagged_always_visible(self, db_path):
+        api.add_node("a", "No tags", db_path=db_path)
+
+        result = api.list_nodes(visible_to=["anything"], db_path=db_path)
+        assert result["count"] == 1
+
+    def test_list_nodes_subset_match(self, db_path):
+        api.add_node("a", "Finance", access_tags=["finance"], db_path=db_path)
+
+        result = api.list_nodes(visible_to=["finance", "hr"], db_path=db_path)
+        assert result["count"] == 1
+
+    def test_list_nodes_multi_tag_requires_all(self, db_path):
+        api.add_node("a", "Multi-source", access_tags=["finance", "hr"], db_path=db_path)
+
+        only_finance = api.list_nodes(visible_to=["finance"], db_path=db_path)
+        assert only_finance["count"] == 0
+
+        both = api.list_nodes(visible_to=["finance", "hr"], db_path=db_path)
+        assert both["count"] == 1
+
+    def test_show_node_raises_on_forbidden(self, db_path):
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+
+        with pytest.raises(PermissionError):
+            api.show_node("fin", visible_to=["hr"], db_path=db_path)
+
+    def test_show_node_allowed(self, db_path):
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+
+        node = api.show_node("fin", visible_to=["finance"], db_path=db_path)
+        assert node["id"] == "fin"
+
+    def test_show_node_no_filter(self, db_path):
+        api.add_node("fin", "Finance", access_tags=["finance"], db_path=db_path)
+
+        node = api.show_node("fin", db_path=db_path)
+        assert node["id"] == "fin"
+
+    def test_lookup_respects_visible_to(self, db_path):
+        api.add_node("fin-data", "Finance data point", access_tags=["finance"], db_path=db_path)
+        api.add_node("pub-data", "Public data point", db_path=db_path)
+
+        result = api.lookup("data", visible_to=["public"], db_path=db_path)
+        assert "pub-data" in result
+        assert "fin-data" not in result
+
+    def test_search_respects_visible_to(self, db_path):
+        api.add_node("secret-item", "Secret finance item", access_tags=["finance"], db_path=db_path)
+        api.add_node("public-item", "Public item", db_path=db_path)
+
+        result = api.search("item", visible_to=["public"], db_path=db_path)
+        assert "public-item" in result
+        assert "secret-item" not in result
+
+
+class TestTraceAccessTags:
+
+    def test_premise_returns_own_tags(self):
+        net = Network()
+        net.add_node("a", "A", metadata={"access_tags": ["finance"]})
+
+        assert net.trace_access_tags("a") == ["finance"]
+
+    def test_no_tags_returns_empty(self):
+        net = Network()
+        net.add_node("a", "A")
+
+        assert net.trace_access_tags("a") == []
+
+    def test_chain_collects_all_tags(self):
+        net = Network()
+        net.add_node("a", "A", metadata={"access_tags": ["finance"]})
+        j1 = Justification(type="SL", antecedents=["a"], outlist=[], label="")
+        net.add_node("b", "B", justifications=[j1], metadata={"access_tags": ["hr"]})
+        j2 = Justification(type="SL", antecedents=["b"], outlist=[], label="")
+        net.add_node("c", "C", justifications=[j2])
+
+        assert net.trace_access_tags("c") == ["finance", "hr"]
+
+    def test_diamond_collects_union(self):
+        net = Network()
+        net.add_node("a", "A", metadata={"access_tags": ["finance"]})
+        net.add_node("b", "B", metadata={"access_tags": ["hr"]})
+        j = Justification(type="SL", antecedents=["a", "b"], outlist=[], label="")
+        net.add_node("c", "C", justifications=[j])
+
+        assert net.trace_access_tags("c") == ["finance", "hr"]
+
+    def test_missing_node_raises(self):
+        net = Network()
+        with pytest.raises(KeyError):
+            net.trace_access_tags("nonexistent")
+
+    def test_api_trace_access_tags(self, db_path):
+        api.add_node("a", "Finance premise", access_tags=["finance"], db_path=db_path)
+        api.add_node("b", "Derived", sl="a", db_path=db_path)
+
+        result = api.trace_access_tags("b", db_path=db_path)
+        assert result["node_id"] == "b"
+        assert result["access_tags"] == ["finance"]
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        return str(tmp_path / "test.db")


### PR DESCRIPTION
## Summary

- Beliefs can carry `access_tags` in metadata for RBAC filtering (no schema change — uses existing `metadata_json` column)
- Derived beliefs automatically inherit the union of all parent access tags via `_inherit_access_tags()`
- Query APIs (`list_nodes`, `search`, `lookup`, `show_node`) accept `visible_to` parameter to filter by tag subset
- New `trace_access_tags()` utility traces the full dependency chain and returns all tags
- CLI: `--access-tags` on `add`, `--visible-to` on `list`/`search`/`lookup`/`show`, new `trace-access-tags` subcommand

Closes #38

## Test plan

- [x] 25 new tests covering inheritance, filtering, and tracing
- [x] 457 total tests pass (432 existing + 25 new, zero regressions)
- [x] End-to-end CLI test with tagged premises, derived beliefs, and filtering

Generated with [Claude Code](https://claude.com/claude-code)