### PR TITLE
Add 'reasons ask' natural language question interface

### DIFF
--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -1,0 +1,160 @@
+"""Ask natural language questions against a belief network.
+
+Uses FTS5 search to find relevant beliefs, then optionally synthesizes
+an answer via `claude -p` with a tool loop that allows the LLM to
+request additional belief searches.
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+
+from . import api
+
+
+ASK_PROMPT = """\
+You are answering a question using a belief network (a Truth Maintenance System).
+Each belief has an ID, text, truth value (IN = held true, OUT = retracted), and
+may have justifications tracing why it is believed.
+
+You have one tool available:
+
+{{"tool": "search_beliefs", "query": "search terms"}}
+
+Rules:
+- If the belief matches below are sufficient to answer the question, write your
+  answer directly. Do NOT call the tool.
+- If you need to search for more beliefs, respond with ONLY a single JSON line
+  (no other text). The system will run the search and give you the results.
+- Cite belief IDs in [brackets] when referencing specific beliefs.
+- If the beliefs are insufficient to answer, say so honestly.
+
+## Question
+
+{question}
+
+## Belief matches
+
+{beliefs_context}
+{tool_history}"""
+
+
+FINAL_TURN_INSTRUCTION = (
+    "\n\n**Final turn — write your answer now, no more tool calls.**"
+)
+
+
+def extract_tool_call(text):
+    """Extract a tool call from LLM response text.
+
+    Scans each line for valid JSON with a "tool" key.
+    Returns the parsed dict or None.
+    """
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+            if "tool" in obj:
+                return obj
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def build_ask_prompt(question, beliefs_context, tool_history=None):
+    """Build the full prompt for LLM synthesis."""
+    history_section = ""
+    if tool_history:
+        parts = []
+        for entry in tool_history:
+            parts.append(
+                f"### Tool call: search_beliefs(\"{entry['query']}\")\n\n"
+                f"{entry['result']}"
+            )
+        history_section = "\n\n## Additional search results\n\n" + "\n\n---\n\n".join(parts)
+
+    return ASK_PROMPT.format(
+        question=question,
+        beliefs_context=beliefs_context,
+        tool_history=history_section,
+    )
+
+
+def _invoke_claude(prompt, timeout=300):
+    """Call `claude -p` with the given prompt. Returns response text."""
+    if not shutil.which("claude"):
+        print("Error: 'claude' CLI not found in PATH", file=sys.stderr)
+        sys.exit(1)
+
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    async def _run():
+        proc = await asyncio.create_subprocess_exec(
+            "claude", "-p",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(prompt.encode()),
+            timeout=timeout,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"claude failed: {stderr.decode()}")
+        return stdout.decode()
+
+    return asyncio.run(_run())
+
+
+MAX_ITERATIONS = 3
+
+
+def ask(question, db_path="reasons.db", timeout=300, no_synth=False):
+    """Answer a question using FTS5 belief search and optional LLM synthesis.
+
+    Returns the answer text.
+    """
+    beliefs_context = api.search(question, db_path=db_path, format="markdown")
+
+    if no_synth:
+        return beliefs_context
+
+    tool_history = []
+
+    for iteration in range(MAX_ITERATIONS):
+        prompt = build_ask_prompt(question, beliefs_context, tool_history)
+
+        if iteration == MAX_ITERATIONS - 1:
+            prompt += FINAL_TURN_INSTRUCTION
+
+        print(f"Synthesizing (round {iteration + 1}/{MAX_ITERATIONS})...",
+              file=sys.stderr)
+
+        try:
+            response = _invoke_claude(prompt, timeout=timeout)
+        except TimeoutError:
+            print(f"LLM timed out after {timeout}s", file=sys.stderr)
+            return beliefs_context
+        except Exception as e:
+            print(f"LLM error: {e}", file=sys.stderr)
+            return beliefs_context
+
+        tool_call = extract_tool_call(response)
+
+        if tool_call is None or iteration == MAX_ITERATIONS - 1:
+            return response.strip()
+
+        if tool_call.get("tool") == "search_beliefs":
+            query = tool_call.get("query", "")
+            print(f"  Searching: {query}", file=sys.stderr)
+            result = api.search(query, db_path=db_path, format="markdown")
+            tool_history.append({"query": query, "result": result})
+        else:
+            return response.strip()
+
+    return beliefs_context

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -5,10 +5,10 @@ an answer via `claude -p` with a tool loop that allows the LLM to
 request additional belief searches.
 """
 
-import asyncio
 import json
 import os
 import shutil
+import subprocess
 import sys
 
 from . import api
@@ -85,30 +85,29 @@ def build_ask_prompt(question, beliefs_context, tool_history=None):
 
 
 def _invoke_claude(prompt, timeout=300):
-    """Call `claude -p` with the given prompt. Returns response text."""
-    if not shutil.which("claude"):
-        print("Error: 'claude' CLI not found in PATH", file=sys.stderr)
-        sys.exit(1)
+    """Call `claude -p` with the given prompt. Returns response text.
 
+    Raises FileNotFoundError if claude is not in PATH.
+    Raises RuntimeError if claude exits non-zero.
+    Raises subprocess.TimeoutExpired on timeout.
+    """
+    if not shutil.which("claude"):
+        raise FileNotFoundError("'claude' CLI not found in PATH")
+
+    # Strip CLAUDECODE to avoid recursive invocation inside Claude Code
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
 
-    async def _run():
-        proc = await asyncio.create_subprocess_exec(
-            "claude", "-p",
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
-        stdout, stderr = await asyncio.wait_for(
-            proc.communicate(prompt.encode()),
-            timeout=timeout,
-        )
-        if proc.returncode != 0:
-            raise RuntimeError(f"claude failed: {stderr.decode()}")
-        return stdout.decode()
-
-    return asyncio.run(_run())
+    result = subprocess.run(
+        ["claude", "-p"],
+        input=prompt,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"claude failed: {result.stderr}")
+    return result.stdout
 
 
 MAX_ITERATIONS = 3
@@ -137,7 +136,7 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False):
 
         try:
             response = _invoke_claude(prompt, timeout=timeout)
-        except TimeoutError:
+        except subprocess.TimeoutExpired:
             print(f"LLM timed out after {timeout}s", file=sys.stderr)
             return beliefs_context
         except Exception as e:

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -620,6 +620,17 @@ def cmd_lookup(args):
     print(result)
 
 
+def cmd_ask(args):
+    from .ask import ask
+    result = ask(
+        question=args.question,
+        db_path=args.db,
+        timeout=args.timeout,
+        no_synth=args.no_synth,
+    )
+    print(result)
+
+
 def cmd_deduplicate(args):
     if args.accept:
         accept_path = Path(args.accept)
@@ -1138,6 +1149,14 @@ def main():
     p.add_argument("query", help="Search terms (all must match, case-insensitive)")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
 
+    # ask
+    p = sub.add_parser("ask", help="Ask a question about beliefs (FTS5 search + LLM synthesis)")
+    p.add_argument("question", help="Natural language question")
+    p.add_argument("--no-synth", action="store_true",
+                   help="Show belief matches only, no LLM synthesis")
+    p.add_argument("--timeout", type=int, default=300,
+                   help="LLM timeout in seconds (default: 300)")
+
     # deduplicate
     p = sub.add_parser("deduplicate", help="Find and optionally retract duplicate IN beliefs")
     p.add_argument("--threshold", type=float, default=0.5,
@@ -1205,6 +1224,7 @@ def main():
         "trace-access-tags": cmd_trace_access_tags,
         "search": cmd_search,
         "lookup": cmd_lookup,
+        "ask": cmd_ask,
         "deduplicate": cmd_deduplicate,
         "list": cmd_list,
         "namespaces": cmd_namespaces,

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1,0 +1,129 @@
+"""Tests for the ask module (FTS5 search + LLM synthesis)."""
+
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib.ask import extract_tool_call, build_ask_prompt, ask
+from reasons_lib.cli import main
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+def run_cli(*args, db_path=None):
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+        except SystemExit as e:
+            return stdout.getvalue(), stderr.getvalue(), e.code
+    return stdout.getvalue(), stderr.getvalue(), 0
+
+
+class TestExtractToolCall:
+
+    def test_valid_tool_call(self):
+        text = 'Some preamble text\n{"tool": "search_beliefs", "query": "propagation"}\nMore text'
+        result = extract_tool_call(text)
+        assert result == {"tool": "search_beliefs", "query": "propagation"}
+
+    def test_no_tool_call(self):
+        text = "This is just a plain answer with no JSON."
+        result = extract_tool_call(text)
+        assert result is None
+
+    def test_json_without_tool_key(self):
+        text = '{"name": "test", "value": 42}'
+        result = extract_tool_call(text)
+        assert result is None
+
+    def test_malformed_json_skipped(self):
+        text = '{bad json}\n{"tool": "search_beliefs", "query": "test"}'
+        result = extract_tool_call(text)
+        assert result == {"tool": "search_beliefs", "query": "test"}
+
+    def test_first_tool_call_wins(self):
+        text = '{"tool": "search_beliefs", "query": "first"}\n{"tool": "search_beliefs", "query": "second"}'
+        result = extract_tool_call(text)
+        assert result["query"] == "first"
+
+    def test_non_json_lines_skipped(self):
+        text = "Hello\nWorld\n  not json\n"
+        result = extract_tool_call(text)
+        assert result is None
+
+    def test_empty_string(self):
+        result = extract_tool_call("")
+        assert result is None
+
+
+class TestBuildAskPrompt:
+
+    def test_contains_question_and_context(self):
+        prompt = build_ask_prompt("What is BFS?", "Some belief context")
+        assert "What is BFS?" in prompt
+        assert "Some belief context" in prompt
+
+    def test_no_tool_history(self):
+        prompt = build_ask_prompt("question", "context")
+        assert "Additional search results" not in prompt
+
+    def test_with_tool_history(self):
+        history = [
+            {"query": "propagation", "result": "Found: propagation-is-bfs"},
+            {"query": "retraction", "result": "Found: retraction-cascades"},
+        ]
+        prompt = build_ask_prompt("question", "context", tool_history=history)
+        assert "Additional search results" in prompt
+        assert "propagation" in prompt
+        assert "retraction" in prompt
+
+    def test_tool_definition_in_prompt(self):
+        prompt = build_ask_prompt("question", "context")
+        assert "search_beliefs" in prompt
+        assert '"tool"' in prompt
+
+
+class TestAskNoSynth:
+
+    def test_no_synth_returns_search_results(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "prop-bfs", "Propagation uses breadth-first search", db_path=db_path)
+        run_cli("add", "prop-cascade", "Propagation cascades through dependents", db_path=db_path)
+
+        result = ask("propagation", db_path=db_path, no_synth=True)
+        assert "prop-bfs" in result or "prop-cascade" in result
+
+    def test_no_synth_no_results(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "alpha", "Alpha belief", db_path=db_path)
+
+        result = ask("zzzznonexistent", db_path=db_path, no_synth=True)
+        assert "No results" in result
+
+
+class TestCmdAskNoSynth:
+
+    def test_cli_ask_no_synth(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "test-belief", "The system uses BFS for propagation", db_path=db_path)
+        out, err, code = run_cli("ask", "BFS propagation", "--no-synth", db_path=db_path)
+        assert code == 0
+        assert "test-belief" in out
+
+    def test_cli_ask_no_synth_no_results(self, db_path):
+        run_cli("init", db_path=db_path)
+        out, err, code = run_cli("ask", "nothing matches", "--no-synth", db_path=db_path)
+        assert code == 0
+        assert "No results" in out

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -1,12 +1,13 @@
 """Tests for the ask module (FTS5 search + LLM synthesis)."""
 
+import subprocess
 import sys
 from io import StringIO
 from unittest.mock import patch
 
 import pytest
 
-from reasons_lib.ask import extract_tool_call, build_ask_prompt, ask
+from reasons_lib.ask import extract_tool_call, build_ask_prompt, ask, _invoke_claude
 from reasons_lib.cli import main
 
 
@@ -127,3 +128,81 @@ class TestCmdAskNoSynth:
         out, err, code = run_cli("ask", "nothing matches", "--no-synth", db_path=db_path)
         assert code == 0
         assert "No results" in out
+
+
+class TestInvokeClaude:
+
+    def test_claude_not_in_path(self):
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(FileNotFoundError, match="claude"):
+                _invoke_claude("test prompt")
+
+
+class TestAskWithMockedLLM:
+
+    def test_direct_answer(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        with patch("reasons_lib.ask._invoke_claude", return_value="The answer is alpha."):
+            result = ask("what is alpha?", db_path=db_path)
+        assert result == "The answer is alpha."
+
+    def test_tool_call_then_answer(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+        run_cli("add", "b", "Beta belief about retraction", db_path=db_path)
+
+        responses = [
+            '{"tool": "search_beliefs", "query": "retraction"}',
+            "Retraction cascades through dependents [b].",
+        ]
+        call_count = [0]
+
+        def mock_invoke(prompt, timeout=300):
+            idx = call_count[0]
+            call_count[0] += 1
+            return responses[idx]
+
+        with patch("reasons_lib.ask._invoke_claude", side_effect=mock_invoke):
+            result = ask("how does retraction work?", db_path=db_path)
+        assert "retraction" in result.lower() or "Retraction" in result
+        assert call_count[0] == 2
+
+    def test_max_iterations_forces_answer(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha", db_path=db_path)
+
+        def always_tool_call(prompt, timeout=300):
+            return '{"tool": "search_beliefs", "query": "more"}'
+
+        with patch("reasons_lib.ask._invoke_claude", side_effect=always_tool_call):
+            result = ask("question", db_path=db_path)
+        assert "search_beliefs" in result
+
+    def test_timeout_returns_search_results(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        with patch("reasons_lib.ask._invoke_claude",
+                    side_effect=subprocess.TimeoutExpired("claude", 300)):
+            result = ask("alpha", db_path=db_path)
+        assert "a" in result
+
+    def test_error_returns_search_results(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        with patch("reasons_lib.ask._invoke_claude",
+                    side_effect=RuntimeError("claude crashed")):
+            result = ask("alpha", db_path=db_path)
+        assert "a" in result
+
+    def test_unknown_tool_returns_response(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha", db_path=db_path)
+
+        with patch("reasons_lib.ask._invoke_claude",
+                    return_value='{"tool": "unknown_tool", "query": "x"}'):
+            result = ask("question", db_path=db_path)
+        assert "unknown_tool" in result


### PR DESCRIPTION
## Summary

Implements #43: adds `reasons ask "question"` CLI command that answers natural language questions against a reasons.db using FTS5 belief search + LLM synthesis via `claude -p`.

- FTS5 search finds relevant beliefs (reuses existing `api.search()`)
- LLM synthesis via `claude -p` with a 3-iteration tool loop — the LLM can request additional belief searches when initial matches are insufficient
- `--no-synth` mode for raw belief matches without LLM
- Graceful degradation: returns raw search results on timeout or error

### Scoping

Per discussion on the issue:
- No data source adapters (beliefs only for v1)
- No Vertex AI or local model support (`claude -p` only)
- No streaming/SSE (simple CLI)

## Test plan

- [x] 22 tests in `tests/test_ask.py` covering:
  - `extract_tool_call` — 7 edge cases (valid, none, no-tool-key, malformed, first-wins, non-json, empty)
  - `build_ask_prompt` — 4 tests (question/context, no history, with history, tool definition)
  - `ask()` no-synth mode — 2 tests (with results, no results)
  - CLI integration — 2 tests (with results, no results)
  - `_invoke_claude` — 1 test (claude not in PATH)
  - Mock LLM synthesis — 6 tests (direct answer, tool-call-then-answer, max iterations, timeout, error, unknown tool)
- [x] Full suite: 608 tests pass, 90% overall coverage
- [x] `ask.py` at 91% coverage (only `subprocess.run` call uncovered)
- [x] Lint checks pass
- [x] Multi-model code review: Gemini PASS, Claude CONCERN (minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)