### PR TITLE
Compact output format for 'reasons ask --no-synth'

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1273,6 +1273,8 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
             return _format_json(net, matched_ids, neighbor_ids)
         elif format == "minimal":
             return _format_minimal(net, matched_ids, neighbor_ids)
+        elif format == "compact":
+            return _format_compact(net, matched_ids, neighbor_ids)
         else:
             return _format_markdown(net, matched_ids, neighbor_ids)
 
@@ -1378,6 +1380,18 @@ def _format_minimal(net, matched_ids: list[str], neighbor_ids: set[str]) -> str:
         for nid in sorted(neighbor_ids):
             parts.append(net.nodes[nid].text)
     return "\n".join(parts)
+
+
+def _format_compact(net, matched_ids: list[str], neighbor_ids: set[str]) -> str:
+    """Format results as one line per belief: [STATUS] id — text."""
+    lines = []
+    for nid in matched_ids:
+        node = net.nodes[nid]
+        lines.append(f"[{node.truth_value}] {nid} — {node.text}")
+    for nid in sorted(neighbor_ids):
+        node = net.nodes[nid]
+        lines.append(f"[{node.truth_value}] {nid} — {node.text}")
+    return "\n".join(lines) if lines else "No results found."
 
 
 def _node_depth(nid, net, memo=None):

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -113,15 +113,16 @@ def _invoke_claude(prompt, timeout=300):
 MAX_ITERATIONS = 3
 
 
-def ask(question, db_path="reasons.db", timeout=300, no_synth=False):
+def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None):
     """Answer a question using FTS5 belief search and optional LLM synthesis.
 
     Returns the answer text.
     """
-    beliefs_context = api.search(question, db_path=db_path, format="markdown")
-
     if no_synth:
-        return beliefs_context
+        fmt = format or "compact"
+        return api.search(question, db_path=db_path, format=fmt)
+
+    beliefs_context = api.search(question, db_path=db_path, format="markdown")
 
     tool_history = []
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -627,6 +627,7 @@ def cmd_ask(args):
         db_path=args.db,
         timeout=args.timeout,
         no_synth=args.no_synth,
+        format=getattr(args, "format", None),
     )
     print(result)
 
@@ -1154,6 +1155,9 @@ def main():
     p.add_argument("question", help="Natural language question")
     p.add_argument("--no-synth", action="store_true",
                    help="Show belief matches only, no LLM synthesis")
+    p.add_argument("--format", choices=["compact", "markdown", "json", "minimal"],
+                   default=None,
+                   help="Output format for --no-synth (default: compact)")
     p.add_argument("--timeout", type=int, default=300,
                    help="LLM timeout in seconds (default: 300)")
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -98,13 +98,30 @@ class TestBuildAskPrompt:
 
 class TestAskNoSynth:
 
-    def test_no_synth_returns_search_results(self, db_path):
+    def test_no_synth_defaults_to_compact(self, db_path):
         run_cli("init", db_path=db_path)
         run_cli("add", "prop-bfs", "Propagation uses breadth-first search", db_path=db_path)
-        run_cli("add", "prop-cascade", "Propagation cascades through dependents", db_path=db_path)
 
         result = ask("propagation", db_path=db_path, no_synth=True)
-        assert "prop-bfs" in result or "prop-cascade" in result
+        assert "[IN] prop-bfs" in result
+        assert "—" in result
+
+    def test_no_synth_compact_multiple(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "prop-bfs", "Propagation uses BFS", db_path=db_path)
+        run_cli("add", "prop-cascade", "Propagation cascades", db_path=db_path)
+
+        result = ask("propagation", db_path=db_path, no_synth=True)
+        lines = [l for l in result.strip().split("\n") if l.strip()]
+        for line in lines:
+            assert line.startswith("[IN]") or line.startswith("[OUT]")
+
+    def test_no_synth_markdown_format(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "prop-bfs", "Propagation uses BFS", db_path=db_path)
+
+        result = ask("propagation", db_path=db_path, no_synth=True, format="markdown")
+        assert "##" in result or "**" in result or "prop-bfs" in result
 
     def test_no_synth_no_results(self, db_path):
         run_cli("init", db_path=db_path)
@@ -116,10 +133,18 @@ class TestAskNoSynth:
 
 class TestCmdAskNoSynth:
 
-    def test_cli_ask_no_synth(self, db_path):
+    def test_cli_ask_no_synth_compact(self, db_path):
         run_cli("init", db_path=db_path)
         run_cli("add", "test-belief", "The system uses BFS for propagation", db_path=db_path)
         out, err, code = run_cli("ask", "BFS propagation", "--no-synth", db_path=db_path)
+        assert code == 0
+        assert "[IN] test-belief" in out
+
+    def test_cli_ask_no_synth_markdown(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "test-belief", "The system uses BFS for propagation", db_path=db_path)
+        out, err, code = run_cli("ask", "BFS propagation", "--no-synth",
+                                 "--format", "markdown", db_path=db_path)
         assert code == 0
         assert "test-belief" in out
 


### PR DESCRIPTION
## Summary

- `--no-synth` now defaults to compact one-line-per-belief format: `[IN] belief-id — text`
- Full markdown available via `--format markdown`
- Adds `_format_compact()` to `api.py` as a new search output format
- Adds `--format` flag to `reasons ask` CLI (choices: compact, markdown, json, minimal)

Closes #45

## Test plan

- [x] 25 tests pass in `tests/test_ask.py`
- [x] Full suite: 611 tests pass, 90% coverage
- [x] Tests verify compact is default for `--no-synth`
- [x] Tests verify `--format markdown` override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)