### PR TITLE
Add PostgreSQL-native storage backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = []
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov"]
+pg = ["psycopg[binary]>=3.1"]
+test-pg = ["psycopg[binary]>=3.1", "pytest", "pytest-cov"]
 
 [project.scripts]
 reasons = "reasons_lib.cli:main"

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -111,7 +111,9 @@ class PgApi:
     def __enter__(self):
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(self, exc_type, *exc):
+        if exc_type is not None:
+            self.conn.rollback()
         self.close()
 
     # ── Schema ──────────────────────────────────────────────────
@@ -397,21 +399,18 @@ class PgApi:
         pid = self.project_id
 
         with self.conn.cursor() as cur:
-            # tsvector search + id ILIKE fallback
-            terms = query.strip().split()
-            ts_query = " & ".join(f"'{t}'" for t in terms if t)
-
-            if ts_query:
+            # plainto_tsquery handles arbitrary user input safely
+            if query.strip():
                 cur.execute(
                     "SELECT id, text, truth_value, source, metadata "
                     "FROM rms_nodes "
                     "WHERE project_id = %s "
-                    "AND (to_tsvector('english', text) @@ to_tsquery('english', %s) "
+                    "AND (to_tsvector('english', text) @@ plainto_tsquery('english', %s) "
                     "     OR id ILIKE %s) "
                     "ORDER BY ts_rank(to_tsvector('english', text), "
-                    "         to_tsquery('english', %s)) DESC "
+                    "         plainto_tsquery('english', %s)) DESC "
                     "LIMIT 20",
-                    (pid, ts_query, f"%{query}%", ts_query),
+                    (pid, query, f"%{query}%", query),
                 )
             else:
                 cur.execute(

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1,0 +1,1233 @@
+"""PostgreSQL-native storage backend for the dependency network.
+
+Each operation is a SQL transaction — no full-network load/save.
+Enables concurrent writers and multi-tenant deployment.
+
+Requires psycopg v3: pip install 'psycopg[binary]>=3.1'
+"""
+
+import json
+from collections import deque
+from datetime import datetime
+
+try:
+    import psycopg
+    from psycopg.rows import dict_row
+except ImportError:
+    psycopg = None  # type: ignore[assignment]
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS rms_nodes (
+    id TEXT NOT NULL,
+    project_id UUID NOT NULL,
+    text TEXT NOT NULL,
+    truth_value TEXT NOT NULL DEFAULT 'IN' CHECK (truth_value IN ('IN', 'OUT')),
+    source TEXT DEFAULT '',
+    source_hash TEXT DEFAULT '',
+    date TEXT DEFAULT '',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (id, project_id)
+);
+
+CREATE TABLE IF NOT EXISTS rms_justifications (
+    id SERIAL PRIMARY KEY,
+    node_id TEXT NOT NULL,
+    project_id UUID NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('SL', 'CP')),
+    antecedents JSONB NOT NULL DEFAULT '[]',
+    outlist JSONB NOT NULL DEFAULT '[]',
+    label TEXT DEFAULT '',
+    FOREIGN KEY (node_id, project_id) REFERENCES rms_nodes(id, project_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS rms_nogoods (
+    id TEXT NOT NULL,
+    project_id UUID NOT NULL,
+    nodes JSONB NOT NULL DEFAULT '[]',
+    discovered TEXT DEFAULT '',
+    resolution TEXT DEFAULT '',
+    PRIMARY KEY (id, project_id)
+);
+
+CREATE TABLE IF NOT EXISTS rms_propagation_log (
+    id SERIAL PRIMARY KEY,
+    project_id UUID NOT NULL,
+    timestamp TEXT NOT NULL,
+    action TEXT NOT NULL,
+    target TEXT NOT NULL,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS rms_network_meta (
+    key TEXT NOT NULL,
+    project_id UUID NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (key, project_id)
+);
+"""
+
+INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_rms_nodes_project ON rms_nodes(project_id);
+CREATE INDEX IF NOT EXISTS idx_rms_nodes_status ON rms_nodes(project_id, truth_value);
+CREATE INDEX IF NOT EXISTS idx_rms_justifications_node ON rms_justifications(node_id, project_id);
+CREATE INDEX IF NOT EXISTS idx_rms_nogoods_project ON rms_nogoods(project_id);
+CREATE INDEX IF NOT EXISTS idx_rms_log_project ON rms_propagation_log(project_id);
+CREATE INDEX IF NOT EXISTS idx_rms_nodes_fts ON rms_nodes USING gin(to_tsvector('english', text));
+CREATE INDEX IF NOT EXISTS idx_rms_justifications_antecedents ON rms_justifications USING gin(antecedents);
+CREATE INDEX IF NOT EXISTS idx_rms_justifications_outlist ON rms_justifications USING gin(outlist);
+"""
+
+
+def _require_psycopg():
+    if psycopg is None:
+        raise ImportError(
+            "psycopg is required for PostgreSQL support. "
+            "Install it with: pip install 'psycopg[binary]>=3.1'"
+        )
+
+
+class PgApi:
+    """PostgreSQL-native API for the dependency network.
+
+    Each method executes as a SQL transaction. No in-memory Network object.
+    """
+
+    def __init__(self, conninfo, project_id):
+        _require_psycopg()
+        if isinstance(conninfo, str):
+            self.conn = psycopg.connect(conninfo, autocommit=False)
+            self._owns_conn = True
+        else:
+            self.conn = conninfo
+            self._owns_conn = False
+        self.project_id = str(project_id)
+
+    def close(self):
+        if self._owns_conn:
+            self.conn.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    # ── Schema ──────────────────────────────────────────────────
+
+    def init_db(self):
+        with self.conn.cursor() as cur:
+            cur.execute(SCHEMA)
+            cur.execute(INDEXES)
+        self.conn.commit()
+        return {"project_id": self.project_id, "created": True}
+
+    # ── Core mutations ──────────────────────────────────────────
+
+    def add_node(self, node_id, text, sl="", cp="", unless="", label="",
+                 source="", access_tags=None):
+        pid = self.project_id
+        now = datetime.now().isoformat(timespec="seconds")
+        metadata = {}
+        if access_tags:
+            metadata["access_tags"] = sorted(access_tags)
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            if cur.fetchone():
+                raise ValueError(f"Node '{node_id}' already exists")
+
+            cur.execute(
+                "INSERT INTO rms_nodes (id, project_id, text, source, date, metadata) "
+                "VALUES (%s, %s, %s, %s, %s, %s)",
+                (node_id, pid, text, source, now, json.dumps(metadata)),
+            )
+
+            justifications = self._parse_justifications(sl, cp, unless, label)
+
+            for j in justifications:
+                cur.execute(
+                    "INSERT INTO rms_justifications (node_id, project_id, type, antecedents, outlist, label) "
+                    "VALUES (%s, %s, %s, %s, %s, %s)",
+                    (node_id, pid, j["type"],
+                     json.dumps(j["antecedents"]), json.dumps(j["outlist"]), j["label"]),
+                )
+
+            # Inherit access tags from antecedents
+            if justifications:
+                self._inherit_access_tags(cur, node_id, justifications)
+
+            # Compute initial truth value
+            if justifications:
+                truth = self._compute_truth(cur, node_id)
+            else:
+                truth = "IN"
+
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = %s WHERE id = %s AND project_id = %s",
+                (truth, node_id, pid),
+            )
+
+            self._log(cur, "add", node_id, truth)
+
+            # Count premises for return value
+            cur.execute(
+                "SELECT COUNT(*) FROM rms_nodes WHERE project_id = %s "
+                "AND NOT EXISTS (SELECT 1 FROM rms_justifications j "
+                "WHERE j.node_id = rms_nodes.id AND j.project_id = rms_nodes.project_id)",
+                (pid,),
+            )
+            premise_count = cur.fetchone()[0]
+
+        self.conn.commit()
+        return {
+            "node_id": node_id,
+            "truth_value": truth,
+            "type": "premise" if not justifications else "derived",
+            "premise_count": premise_count,
+        }
+
+    def add_justification(self, node_id, sl="", cp="", unless="", label=""):
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{node_id}' not found")
+            old_value = row[0]
+
+            justifications = self._parse_justifications(sl, cp, unless, label)
+            if not justifications:
+                raise ValueError("No justification specified (use --sl or --cp)")
+
+            for j in justifications:
+                cur.execute(
+                    "INSERT INTO rms_justifications (node_id, project_id, type, antecedents, outlist, label) "
+                    "VALUES (%s, %s, %s, %s, %s, %s)",
+                    (node_id, pid, j["type"],
+                     json.dumps(j["antecedents"]), json.dumps(j["outlist"]), j["label"]),
+                )
+
+            self._inherit_access_tags(cur, node_id, justifications)
+
+            new_value = self._compute_truth(cur, node_id)
+            changed = []
+
+            if old_value != new_value:
+                cur.execute(
+                    "UPDATE rms_nodes SET truth_value = %s WHERE id = %s AND project_id = %s",
+                    (new_value, node_id, pid),
+                )
+                changed.append(node_id)
+                went_out, went_in = self._propagate(cur, node_id)
+                changed.extend(went_out)
+                changed.extend(went_in)
+
+            self._log(cur, "add-justification", node_id, new_value)
+
+        self.conn.commit()
+        return {
+            "node_id": node_id,
+            "old_truth_value": old_value,
+            "new_truth_value": new_value,
+            "changed": changed,
+        }
+
+    def retract_node(self, node_id, reason=""):
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT truth_value, metadata FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{node_id}' not found")
+
+            old_value, metadata = row[0], row[1]
+            if isinstance(metadata, str):
+                metadata = json.loads(metadata)
+
+            metadata["_retracted"] = True
+            if reason:
+                metadata["retract_reason"] = reason
+
+            if old_value == "OUT":
+                cur.execute(
+                    "UPDATE rms_nodes SET metadata = %s WHERE id = %s AND project_id = %s",
+                    (json.dumps(metadata), node_id, pid),
+                )
+                self.conn.commit()
+                return {"changed": [], "went_out": [], "went_in": []}
+
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = 'OUT', metadata = %s "
+                "WHERE id = %s AND project_id = %s",
+                (json.dumps(metadata), node_id, pid),
+            )
+            self._log(cur, "retract", node_id, reason or "OUT")
+
+            went_out, went_in = self._propagate(cur, node_id)
+
+        self.conn.commit()
+        all_changed = [node_id] + went_out + went_in
+        return {"changed": all_changed, "went_out": [node_id] + went_out, "went_in": went_in}
+
+    def assert_node(self, node_id):
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT truth_value, metadata FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{node_id}' not found")
+
+            old_value, metadata = row[0], row[1]
+            if isinstance(metadata, str):
+                metadata = json.loads(metadata)
+
+            if old_value == "IN":
+                return {"changed": [], "went_out": [], "went_in": []}
+
+            metadata.pop("_retracted", None)
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = 'IN', metadata = %s "
+                "WHERE id = %s AND project_id = %s",
+                (json.dumps(metadata), node_id, pid),
+            )
+            self._log(cur, "assert", node_id, "IN")
+
+            went_out, went_in = self._propagate(cur, node_id)
+
+        self.conn.commit()
+        all_changed = [node_id] + went_out + went_in
+        return {"changed": all_changed, "went_out": went_out, "went_in": [node_id] + went_in}
+
+    # ── Read operations ─────────────────────────────────────────
+
+    def get_status(self, visible_to=None):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT n.id, n.text, n.truth_value, n.metadata, "
+                "(SELECT COUNT(*) FROM rms_justifications j "
+                " WHERE j.node_id = n.id AND j.project_id = n.project_id) AS jcount "
+                "FROM rms_nodes n WHERE n.project_id = %s ORDER BY n.id",
+                (pid,),
+            )
+            rows = cur.fetchall()
+
+        nodes = []
+        for row in rows:
+            nid, text, tv, meta, jcount = row
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                continue
+            nodes.append({
+                "id": nid,
+                "text": text,
+                "truth_value": tv,
+                "justification_count": jcount,
+            })
+
+        in_count = sum(1 for n in nodes if n["truth_value"] == "IN")
+        return {"nodes": nodes, "in_count": in_count, "total": len(nodes)}
+
+    def show_node(self, node_id, visible_to=None):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, text, truth_value, source, source_hash, metadata "
+                "FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{node_id}' not found")
+
+            nid, text, tv, source, source_hash, meta = row
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                raise PermissionError(f"Access denied for node '{node_id}'")
+
+            cur.execute(
+                "SELECT type, antecedents, outlist, label FROM rms_justifications "
+                "WHERE node_id = %s AND project_id = %s ORDER BY id",
+                (node_id, pid),
+            )
+            justifications = []
+            for jrow in cur.fetchall():
+                jtype, ants, outs, jlabel = jrow
+                if isinstance(ants, str):
+                    ants = json.loads(ants)
+                if isinstance(outs, str):
+                    outs = json.loads(outs)
+                j = {"type": jtype, "antecedents": ants, "outlist": outs, "label": jlabel}
+                justifications.append(j)
+
+            dependents = sorted(self._find_dependents(cur, [node_id]))
+
+        return {
+            "id": nid,
+            "text": text,
+            "truth_value": tv,
+            "source": source,
+            "source_hash": source_hash,
+            "justifications": justifications,
+            "dependents": dependents,
+            "metadata": meta,
+        }
+
+    def search(self, query, visible_to=None, format="markdown"):
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            # tsvector search + id ILIKE fallback
+            terms = query.strip().split()
+            ts_query = " & ".join(f"'{t}'" for t in terms if t)
+
+            if ts_query:
+                cur.execute(
+                    "SELECT id, text, truth_value, source, metadata "
+                    "FROM rms_nodes "
+                    "WHERE project_id = %s "
+                    "AND (to_tsvector('english', text) @@ to_tsquery('english', %s) "
+                    "     OR id ILIKE %s) "
+                    "ORDER BY ts_rank(to_tsvector('english', text), "
+                    "         to_tsquery('english', %s)) DESC "
+                    "LIMIT 20",
+                    (pid, ts_query, f"%{query}%", ts_query),
+                )
+            else:
+                cur.execute(
+                    "SELECT id, text, truth_value, source, metadata "
+                    "FROM rms_nodes WHERE project_id = %s AND id ILIKE %s LIMIT 20",
+                    (pid, f"%{query}%"),
+                )
+
+            matched_rows = cur.fetchall()
+
+        if not matched_rows:
+            return "No results found."
+
+        # Apply visibility filter
+        matched = []
+        for row in matched_rows:
+            nid, text, tv, source, meta = row
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                continue
+            matched.append({
+                "id": nid, "text": text, "truth_value": tv,
+                "source": source, "metadata": meta,
+            })
+
+        if not matched:
+            return "No results found."
+
+        matched_ids = [m["id"] for m in matched]
+
+        # Neighbor expansion
+        with self.conn.cursor() as cur:
+            neighbors = self._expand_neighbors(cur, matched_ids, visible_to)
+
+        return self._format_results(matched, neighbors, format)
+
+    def list_nodes(self, status=None, premises_only=False, has_dependents=False,
+                   namespace=None, visible_to=None):
+        pid = self.project_id
+        conditions = ["n.project_id = %s"]
+        params = [pid]
+
+        if status:
+            conditions.append("n.truth_value = %s")
+            params.append(status)
+
+        if premises_only:
+            conditions.append(
+                "NOT EXISTS (SELECT 1 FROM rms_justifications j "
+                "WHERE j.node_id = n.id AND j.project_id = n.project_id)"
+            )
+
+        if namespace:
+            conditions.append("n.id LIKE %s")
+            params.append(f"{namespace}:%")
+
+        where = " AND ".join(conditions)
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT n.id, n.text, n.truth_value, n.metadata, "
+                f"(SELECT COUNT(*) FROM rms_justifications j "
+                f" WHERE j.node_id = n.id AND j.project_id = n.project_id) AS jcount "
+                f"FROM rms_nodes n WHERE {where} ORDER BY n.id",
+                params,
+            )
+            rows = cur.fetchall()
+
+            # For has_dependents filter, we need the reverse lookup
+            if has_dependents:
+                all_ids = [r[0] for r in rows]
+                dep_set = self._find_dependents(cur, all_ids) if all_ids else set()
+                # dep_set contains nodes that ARE dependents, not nodes that HAVE dependents
+                # We need nodes that appear in others' justifications
+                ids_with_deps = set()
+                if all_ids:
+                    cur.execute(
+                        "SELECT DISTINCT je.value FROM rms_justifications j, "
+                        "jsonb_array_elements_text(j.antecedents) je(value) "
+                        "WHERE j.project_id = %s "
+                        "UNION "
+                        "SELECT DISTINCT je.value FROM rms_justifications j, "
+                        "jsonb_array_elements_text(j.outlist) je(value) "
+                        "WHERE j.project_id = %s",
+                        (pid, pid),
+                    )
+                    ids_with_deps = {r[0] for r in cur.fetchall()}
+
+        nodes = []
+        for row in rows:
+            nid, text, tv, meta, jcount = row
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                continue
+            if has_dependents and nid not in ids_with_deps:
+                continue
+            nodes.append({
+                "id": nid,
+                "text": text,
+                "truth_value": tv,
+                "justification_count": jcount,
+            })
+
+        return {"nodes": nodes, "count": len(nodes)}
+
+    def get_log(self, last=None):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            if last:
+                cur.execute(
+                    "SELECT timestamp, action, target, value FROM rms_propagation_log "
+                    "WHERE project_id = %s ORDER BY id DESC LIMIT %s",
+                    (pid, last),
+                )
+                entries = [
+                    {"timestamp": r[0], "action": r[1], "target": r[2], "value": r[3]}
+                    for r in reversed(cur.fetchall())
+                ]
+            else:
+                cur.execute(
+                    "SELECT timestamp, action, target, value FROM rms_propagation_log "
+                    "WHERE project_id = %s ORDER BY id",
+                    (pid,),
+                )
+                entries = [
+                    {"timestamp": r[0], "action": r[1], "target": r[2], "value": r[3]}
+                    for r in cur.fetchall()
+                ]
+        return {"entries": entries}
+
+    # ── Nogoods + explain ───────────────────────────────────────
+
+    def add_nogood(self, node_ids):
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            # Verify all nodes exist
+            cur.execute(
+                "SELECT id, truth_value FROM rms_nodes WHERE project_id = %s AND id = ANY(%s)",
+                (pid, node_ids),
+            )
+            found = {r[0]: r[1] for r in cur.fetchall()}
+            for nid in node_ids:
+                if nid not in found:
+                    raise KeyError(f"Node '{nid}' not found")
+
+            # Get next nogood ID
+            cur.execute(
+                "SELECT value FROM rms_network_meta "
+                "WHERE key = 'next_nogood_id' AND project_id = %s",
+                (pid,),
+            )
+            row = cur.fetchone()
+            next_id = int(row[0]) if row else 1
+            nogood_id = f"nogood-{next_id:03d}"
+
+            cur.execute(
+                "INSERT INTO rms_network_meta (key, project_id, value) "
+                "VALUES ('next_nogood_id', %s, %s) "
+                "ON CONFLICT (key, project_id) DO UPDATE SET value = EXCLUDED.value",
+                (pid, str(next_id + 1)),
+            )
+
+            cur.execute(
+                "INSERT INTO rms_nogoods (id, project_id, nodes, discovered) "
+                "VALUES (%s, %s, %s, %s)",
+                (nogood_id, pid, json.dumps(node_ids),
+                 datetime.now().isoformat(timespec="seconds")),
+            )
+            self._log(cur, "nogood", nogood_id, str(node_ids))
+
+            # Check if contradiction is active
+            all_in = all(found.get(nid) == "IN" for nid in node_ids)
+            if not all_in:
+                self.conn.commit()
+                return {"nogood_id": nogood_id, "changed": [], "backtracked_to": None}
+
+            # Dependency-directed backtracking
+            culprits = self._find_culprits_internal(cur, node_ids)
+
+            if culprits:
+                victim_id = culprits[0]["premise"]
+                self._log(cur, "backtrack", victim_id, f"culprit for {nogood_id}")
+            else:
+                # Fallback: retract node with fewest dependents
+                dep_counts = []
+                for nid in node_ids:
+                    deps = self._find_dependents(cur, [nid])
+                    dep_counts.append((nid, len(deps)))
+                dep_counts.sort(key=lambda x: x[1])
+                victim_id = dep_counts[0][0]
+
+            # Retract the victim
+            cur.execute(
+                "SELECT metadata FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (victim_id, pid),
+            )
+            meta = cur.fetchone()[0]
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            meta["_retracted"] = True
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = 'OUT', metadata = %s "
+                "WHERE id = %s AND project_id = %s",
+                (json.dumps(meta), victim_id, pid),
+            )
+            self._log(cur, "retract", victim_id, f"backtrack for {nogood_id}")
+
+            went_out, went_in = self._propagate(cur, victim_id)
+
+        self.conn.commit()
+        changed = [victim_id] + went_out + went_in
+        return {"nogood_id": nogood_id, "changed": changed, "backtracked_to": victim_id}
+
+    def find_culprits(self, node_ids):
+        with self.conn.cursor() as cur:
+            culprits = self._find_culprits_internal(cur, node_ids)
+        return {"culprits": culprits}
+
+    def explain_node(self, node_id, visible_to=None):
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            steps = self._explain_recursive(cur, node_id, visible_to, set())
+        return {"steps": steps}
+
+    def trace_assumptions(self, node_id, visible_to=None):
+        pid = self.project_id
+        premises = []
+        visited = set()
+
+        with self.conn.cursor() as cur:
+            self._trace_assumptions_recursive(cur, node_id, premises, visited)
+
+        return {"node_id": node_id, "premises": premises}
+
+    # ── Internal: propagation ───────────────────────────────────
+
+    def _propagate(self, cur, changed_id):
+        """BFS propagation of truth value changes through dependents.
+
+        Returns (went_out, went_in) lists.
+        """
+        went_out = []
+        went_in = []
+        queue = deque([changed_id])
+        visited = {changed_id}
+        pid = self.project_id
+
+        while queue:
+            batch = []
+            while queue:
+                batch.append(queue.popleft())
+
+            # Find all dependents of this batch
+            dep_ids = self._find_dependents(cur, batch) - visited
+
+            if not dep_ids:
+                continue
+
+            # Fetch current state of all dependents
+            cur.execute(
+                "SELECT id, truth_value, metadata FROM rms_nodes "
+                "WHERE project_id = %s AND id = ANY(%s)",
+                (pid, list(dep_ids)),
+            )
+            dep_states = {}
+            for row in cur.fetchall():
+                nid, tv, meta = row
+                if isinstance(meta, str):
+                    meta = json.loads(meta)
+                dep_states[nid] = (tv, meta)
+
+            # Fetch all justifications for these dependents
+            cur.execute(
+                "SELECT node_id, type, antecedents, outlist FROM rms_justifications "
+                "WHERE project_id = %s AND node_id = ANY(%s)",
+                (pid, list(dep_ids)),
+            )
+            justs_by_node = {}
+            all_referenced = set()
+            for row in cur.fetchall():
+                nid, jtype, ants, outs = row
+                if isinstance(ants, str):
+                    ants = json.loads(ants)
+                if isinstance(outs, str):
+                    outs = json.loads(outs)
+                justs_by_node.setdefault(nid, []).append((jtype, ants, outs))
+                all_referenced.update(ants)
+                all_referenced.update(outs)
+
+            # Batch-fetch truth values for all referenced nodes
+            truth_cache = {}
+            if all_referenced:
+                cur.execute(
+                    "SELECT id, truth_value FROM rms_nodes "
+                    "WHERE project_id = %s AND id = ANY(%s)",
+                    (pid, list(all_referenced)),
+                )
+                for row in cur.fetchall():
+                    truth_cache[row[0]] = row[1]
+
+            # Evaluate each dependent
+            for dep_id in dep_ids:
+                if dep_id not in dep_states:
+                    continue
+                old_tv, meta = dep_states[dep_id]
+
+                if meta.get("_retracted"):
+                    continue
+
+                justs = justs_by_node.get(dep_id, [])
+                if not justs:
+                    continue  # premise — keep current
+
+                new_tv = "OUT"
+                for jtype, ants, outs in justs:
+                    inlist_ok = all(
+                        truth_cache.get(a, "OUT") == "IN" for a in ants
+                    )
+                    outlist_ok = all(
+                        truth_cache.get(o, "OUT") == "OUT" for o in outs
+                    )
+                    if inlist_ok and outlist_ok:
+                        new_tv = "IN"
+                        break
+
+                if old_tv != new_tv:
+                    cur.execute(
+                        "UPDATE rms_nodes SET truth_value = %s "
+                        "WHERE id = %s AND project_id = %s",
+                        (new_tv, dep_id, pid),
+                    )
+                    self._log(cur, "propagate", dep_id, new_tv)
+                    truth_cache[dep_id] = new_tv
+                    visited.add(dep_id)
+                    queue.append(dep_id)
+                    if new_tv == "OUT":
+                        went_out.append(dep_id)
+                    else:
+                        went_in.append(dep_id)
+
+        return went_out, went_in
+
+    def _compute_truth(self, cur, node_id):
+        """Compute truth value from justifications."""
+        pid = self.project_id
+        cur.execute(
+            "SELECT type, antecedents, outlist FROM rms_justifications "
+            "WHERE node_id = %s AND project_id = %s",
+            (node_id, pid),
+        )
+        justs = cur.fetchall()
+        if not justs:
+            return "IN"  # premise
+
+        # Collect all referenced nodes
+        all_refs = set()
+        parsed = []
+        for jtype, ants, outs in justs:
+            if isinstance(ants, str):
+                ants = json.loads(ants)
+            if isinstance(outs, str):
+                outs = json.loads(outs)
+            parsed.append((jtype, ants, outs))
+            all_refs.update(ants)
+            all_refs.update(outs)
+
+        # Batch-fetch truth values
+        truth_cache = {}
+        if all_refs:
+            cur.execute(
+                "SELECT id, truth_value FROM rms_nodes "
+                "WHERE project_id = %s AND id = ANY(%s)",
+                (pid, list(all_refs)),
+            )
+            for row in cur.fetchall():
+                truth_cache[row[0]] = row[1]
+
+        for jtype, ants, outs in parsed:
+            inlist_ok = all(truth_cache.get(a, "OUT") == "IN" for a in ants)
+            outlist_ok = all(truth_cache.get(o, "OUT") == "OUT" for o in outs)
+            if inlist_ok and outlist_ok:
+                return "IN"
+        return "OUT"
+
+    def _find_dependents(self, cur, node_ids):
+        """Find nodes that have any of node_ids in their antecedents or outlist."""
+        if not node_ids:
+            return set()
+        pid = self.project_id
+        # Use JSONB containment: antecedents @> '["node_id"]'
+        dep_ids = set()
+        for nid in node_ids:
+            needle = json.dumps([nid])
+            cur.execute(
+                "SELECT DISTINCT node_id FROM rms_justifications "
+                "WHERE project_id = %s "
+                "AND (antecedents @> %s::jsonb OR outlist @> %s::jsonb)",
+                (pid, needle, needle),
+            )
+            for row in cur.fetchall():
+                dep_ids.add(row[0])
+        return dep_ids
+
+    def _log(self, cur, action, target, value):
+        cur.execute(
+            "INSERT INTO rms_propagation_log (project_id, timestamp, action, target, value) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            (self.project_id, datetime.now().isoformat(timespec="seconds"),
+             action, target, value),
+        )
+
+    # ── Internal: nogoods + explain ─────────────────────────────
+
+    def _find_culprits_internal(self, cur, nogood_node_ids):
+        pid = self.project_id
+
+        # Get truth values
+        cur.execute(
+            "SELECT id, truth_value FROM rms_nodes WHERE project_id = %s AND id = ANY(%s)",
+            (pid, nogood_node_ids),
+        )
+        node_tvs = {r[0]: r[1] for r in cur.fetchall()}
+
+        assumptions_by_node = {}
+        all_premises = set()
+
+        for nid in nogood_node_ids:
+            if node_tvs.get(nid) != "IN":
+                continue
+            premises = []
+            visited = set()
+            self._trace_assumptions_recursive(cur, nid, premises, visited)
+            assumptions_by_node[nid] = premises
+            all_premises.update(premises)
+
+        candidates = []
+        for premise_id in all_premises:
+            would_resolve = [
+                nid for nid, assumptions in assumptions_by_node.items()
+                if premise_id in assumptions
+            ]
+            if would_resolve:
+                entrenchment = self._entrenchment(cur, premise_id)
+                deps = self._find_dependents(cur, [premise_id])
+                candidates.append({
+                    "premise": premise_id,
+                    "would_resolve": would_resolve,
+                    "dependent_count": len(deps),
+                    "entrenchment": entrenchment,
+                })
+
+        candidates.sort(key=lambda c: c["entrenchment"])
+        return candidates
+
+    def _entrenchment(self, cur, node_id):
+        pid = self.project_id
+        cur.execute(
+            "SELECT source, source_hash, metadata FROM rms_nodes "
+            "WHERE id = %s AND project_id = %s",
+            (node_id, pid),
+        )
+        row = cur.fetchone()
+        if not row:
+            return 0
+        source, source_hash, meta = row
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+
+        score = 0
+
+        # Premises are more entrenched
+        cur.execute(
+            "SELECT COUNT(*) FROM rms_justifications "
+            "WHERE node_id = %s AND project_id = %s",
+            (node_id, pid),
+        )
+        if cur.fetchone()[0] == 0:
+            score += 100
+
+        if source:
+            score += 50
+        if source_hash:
+            score += 25
+
+        deps = self._find_dependents(cur, [node_id])
+        score += len(deps) * 10
+
+        btype = meta.get("beliefs_type", "").upper()
+        type_scores = {
+            "AXIOM": 90, "WARNING": 90,
+            "OBSERVATION": 80,
+            "DERIVED": 40,
+            "PREDICTED": 30,
+            "NOTE": 10,
+        }
+        score += type_scores.get(btype, 20)
+
+        return score
+
+    def _trace_assumptions_recursive(self, cur, node_id, premises, visited):
+        if node_id in visited:
+            return
+        visited.add(node_id)
+        pid = self.project_id
+
+        cur.execute(
+            "SELECT type, antecedents FROM rms_justifications "
+            "WHERE node_id = %s AND project_id = %s",
+            (node_id, pid),
+        )
+        justs = cur.fetchall()
+
+        if not justs:
+            if node_id not in premises:
+                premises.append(node_id)
+            return
+
+        for jtype, ants in justs:
+            if isinstance(ants, str):
+                ants = json.loads(ants)
+            for ant_id in ants:
+                self._trace_assumptions_recursive(cur, ant_id, premises, visited)
+
+    def _explain_recursive(self, cur, node_id, visible_to, visited):
+        if node_id in visited:
+            return []
+        visited.add(node_id)
+        pid = self.project_id
+
+        cur.execute(
+            "SELECT truth_value, metadata FROM rms_nodes "
+            "WHERE id = %s AND project_id = %s",
+            (node_id, pid),
+        )
+        row = cur.fetchone()
+        if not row:
+            return []
+        tv, meta = row
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+
+        if visible_to is not None and not self._is_visible(meta, visible_to):
+            return []
+
+        cur.execute(
+            "SELECT type, antecedents, outlist, label FROM rms_justifications "
+            "WHERE node_id = %s AND project_id = %s ORDER BY id",
+            (node_id, pid),
+        )
+        justs = cur.fetchall()
+
+        steps = []
+
+        if not justs:
+            steps.append({
+                "node": node_id,
+                "truth_value": tv,
+                "reason": "premise" if tv == "IN" else "retracted premise",
+            })
+            return steps
+
+        if tv == "IN":
+            # Find the valid justification
+            for jtype, ants, outs, jlabel in justs:
+                if isinstance(ants, str):
+                    ants = json.loads(ants)
+                if isinstance(outs, str):
+                    outs = json.loads(outs)
+
+                # Check validity
+                if self._justification_valid_cached(cur, ants, outs):
+                    step = {
+                        "node": node_id,
+                        "truth_value": "IN",
+                        "reason": f"{jtype} justification valid",
+                        "antecedents": list(ants),
+                        "label": jlabel,
+                    }
+                    if outs:
+                        step["outlist"] = list(outs)
+                    steps.append(step)
+                    for ant_id in ants:
+                        steps.extend(self._explain_recursive(cur, ant_id, visible_to, visited))
+                    break
+        else:
+            # All justifications invalid
+            for jtype, ants, outs, jlabel in justs:
+                if isinstance(ants, str):
+                    ants = json.loads(ants)
+                if isinstance(outs, str):
+                    outs = json.loads(outs)
+
+                # Find failed antecedents and violated outlist
+                all_refs = set(ants) | set(outs)
+                truth_cache = {}
+                if all_refs:
+                    cur.execute(
+                        "SELECT id, truth_value FROM rms_nodes "
+                        "WHERE project_id = %s AND id = ANY(%s)",
+                        (pid, list(all_refs)),
+                    )
+                    truth_cache = {r[0]: r[1] for r in cur.fetchall()}
+
+                failed = [a for a in ants if truth_cache.get(a, "OUT") == "OUT"]
+                violated = [o for o in outs if truth_cache.get(o, "OUT") == "IN"]
+
+                step = {
+                    "node": node_id,
+                    "truth_value": "OUT",
+                    "reason": f"{jtype} justification invalid",
+                    "failed_antecedents": failed,
+                    "label": jlabel,
+                }
+                if violated:
+                    step["violated_outlist"] = violated
+                steps.append(step)
+
+        return steps
+
+    def _justification_valid_cached(self, cur, antecedents, outlist):
+        pid = self.project_id
+        all_refs = set(antecedents) | set(outlist)
+        if not all_refs:
+            return True
+        cur.execute(
+            "SELECT id, truth_value FROM rms_nodes "
+            "WHERE project_id = %s AND id = ANY(%s)",
+            (pid, list(all_refs)),
+        )
+        truth_cache = {r[0]: r[1] for r in cur.fetchall()}
+
+        inlist_ok = all(truth_cache.get(a, "OUT") == "IN" for a in antecedents)
+        outlist_ok = all(truth_cache.get(o, "OUT") == "OUT" for o in outlist)
+        return inlist_ok and outlist_ok
+
+    # ── Internal: formatting ────────────────────────────────────
+
+    def _expand_neighbors(self, cur, matched_ids, visible_to):
+        """Expand matched nodes to include 1-hop neighbors."""
+        pid = self.project_id
+        neighbor_ids = set()
+
+        # Get justifications for matched nodes (dependencies)
+        if matched_ids:
+            cur.execute(
+                "SELECT antecedents FROM rms_justifications "
+                "WHERE project_id = %s AND node_id = ANY(%s)",
+                (pid, matched_ids),
+            )
+            for row in cur.fetchall():
+                ants = row[0]
+                if isinstance(ants, str):
+                    ants = json.loads(ants)
+                neighbor_ids.update(ants)
+
+        # Get dependents (nodes that reference matched nodes)
+        dep_ids = self._find_dependents(cur, matched_ids)
+        neighbor_ids.update(dep_ids)
+
+        # Remove already-matched
+        neighbor_ids -= set(matched_ids)
+
+        if not neighbor_ids:
+            return []
+
+        # Fetch neighbor data
+        cur.execute(
+            "SELECT id, text, truth_value, source, metadata FROM rms_nodes "
+            "WHERE project_id = %s AND id = ANY(%s) ORDER BY id",
+            (pid, list(neighbor_ids)),
+        )
+        neighbors = []
+        for row in cur.fetchall():
+            nid, text, tv, source, meta = row
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                continue
+            neighbors.append({
+                "id": nid, "text": text, "truth_value": tv,
+                "source": source, "metadata": meta,
+            })
+        return neighbors
+
+    def _format_results(self, matched, neighbors, format):
+        if format == "json":
+            return self._format_json(matched, neighbors)
+        elif format == "minimal":
+            return self._format_minimal(matched, neighbors)
+        elif format == "compact":
+            return self._format_compact(matched, neighbors)
+        else:
+            return self._format_markdown(matched, neighbors)
+
+    def _format_markdown(self, matched, neighbors):
+        parts = []
+        for m in matched:
+            parts.append(f"### {m['id']}")
+            parts.append(f"**Status:** {m['truth_value']}")
+            parts.append(m["text"])
+            if m.get("source"):
+                parts.append(f"**Source:** {m['source']}")
+            parts.append("")
+
+        if neighbors:
+            parts.append("---")
+            parts.append("**Related nodes:**\n")
+            for n in neighbors:
+                parts.append(f"- **{n['id']}** ({n['truth_value']}): {n['text']}")
+            parts.append("")
+
+        return "\n".join(parts)
+
+    def _format_json(self, matched, neighbors):
+        results = []
+        for m in matched:
+            results.append({
+                "id": m["id"], "text": m["text"],
+                "truth_value": m["truth_value"],
+                "source": m.get("source", ""), "match": True,
+            })
+        for n in neighbors:
+            results.append({
+                "id": n["id"], "text": n["text"],
+                "truth_value": n["truth_value"],
+                "source": n.get("source", ""), "match": False,
+                "relation": "neighbor",
+            })
+        return json.dumps(results, indent=2)
+
+    def _format_minimal(self, matched, neighbors):
+        parts = [m["text"] for m in matched]
+        if neighbors:
+            parts.append("")
+            parts.extend(n["text"] for n in neighbors)
+        return "\n".join(parts)
+
+    def _format_compact(self, matched, neighbors):
+        lines = []
+        for m in matched:
+            lines.append(f"[{m['truth_value']}] {m['id']} — {m['text']}")
+        for n in neighbors:
+            lines.append(f"[{n['truth_value']}] {n['id']} — {n['text']}")
+        return "\n".join(lines) if lines else "No results found."
+
+    # ── Internal: helpers ───────────────────────────────────────
+
+    def _parse_justifications(self, sl, cp, unless, label):
+        justs = []
+        outlist = [o.strip() for o in unless.split(",") if o.strip()] if unless else []
+
+        if sl:
+            antecedents = [a.strip() for a in sl.split(",") if a.strip()]
+            justs.append({
+                "type": "SL",
+                "antecedents": antecedents,
+                "outlist": outlist,
+                "label": label,
+            })
+        if cp:
+            antecedents = [a.strip() for a in cp.split(",") if a.strip()]
+            justs.append({
+                "type": "CP",
+                "antecedents": antecedents,
+                "outlist": outlist,
+                "label": label,
+            })
+        return justs
+
+    def _is_visible(self, metadata, visible_to):
+        tags = metadata.get("access_tags", [])
+        if not tags:
+            return True
+        return all(t in visible_to for t in tags)
+
+    def _inherit_access_tags(self, cur, node_id, justifications):
+        pid = self.project_id
+        all_ant_ids = set()
+        for j in justifications:
+            all_ant_ids.update(j["antecedents"])
+
+        if not all_ant_ids:
+            return
+
+        cur.execute(
+            "SELECT metadata FROM rms_nodes WHERE project_id = %s AND id = ANY(%s)",
+            (pid, list(all_ant_ids)),
+        )
+        inherited = set()
+        for row in cur.fetchall():
+            meta = row[0]
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            inherited.update(meta.get("access_tags", []))
+
+        if not inherited:
+            return
+
+        cur.execute(
+            "SELECT metadata FROM rms_nodes WHERE id = %s AND project_id = %s",
+            (node_id, pid),
+        )
+        row = cur.fetchone()
+        meta = row[0] if row else {}
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+
+        existing = set(meta.get("access_tags", []))
+        merged = existing | inherited
+        meta["access_tags"] = sorted(merged)
+
+        cur.execute(
+            "UPDATE rms_nodes SET metadata = %s WHERE id = %s AND project_id = %s",
+            (json.dumps(meta), node_id, pid),
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Shared fixtures for tests."""
+
+import os
+import uuid
+
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "pg: requires PostgreSQL (set DATABASE_URL)")
+
+
+pg_available = bool(os.environ.get("DATABASE_URL"))
+skip_no_pg = pytest.mark.skipif(not pg_available, reason="DATABASE_URL not set")
+
+
+@pytest.fixture
+def pg_api():
+    """Provide a PgApi instance with a unique project_id, cleaned up after test."""
+    if not pg_available:
+        pytest.skip("DATABASE_URL not set")
+
+    from reasons_lib.pg import PgApi
+
+    conninfo = os.environ["DATABASE_URL"]
+    project_id = str(uuid.uuid4())
+    api = PgApi(conninfo, project_id)
+    api.init_db()
+
+    yield api
+
+    # Clean up test data (rollback any failed transaction first)
+    api.conn.rollback()
+    with api.conn.cursor() as cur:
+        for table in ("rms_propagation_log", "rms_justifications",
+                      "rms_nogoods", "rms_network_meta", "rms_nodes"):
+            cur.execute(f"DELETE FROM {table} WHERE project_id = %s", (project_id,))
+    api.conn.commit()
+    api.close()

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -1,0 +1,466 @@
+"""Tests for the PostgreSQL-native storage backend."""
+
+import json
+
+import pytest
+
+from tests.conftest import skip_no_pg
+
+pytestmark = [pytest.mark.pg, skip_no_pg]
+
+
+class TestAddNode:
+
+    def test_add_premise(self, pg_api):
+        result = pg_api.add_node("a", "Alpha premise")
+        assert result["node_id"] == "a"
+        assert result["truth_value"] == "IN"
+        assert result["type"] == "premise"
+
+    def test_add_derived_in(self, pg_api):
+        pg_api.add_node("a", "Alpha premise")
+        result = pg_api.add_node("b", "Beta derived", sl="a")
+        assert result["truth_value"] == "IN"
+        assert result["type"] == "derived"
+
+    def test_add_derived_out(self, pg_api):
+        pg_api.add_node("a", "Alpha premise")
+        pg_api.retract_node("a")
+        result = pg_api.add_node("b", "Beta derived", sl="a")
+        assert result["truth_value"] == "OUT"
+
+    def test_add_with_outlist(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("blocker", "Blocker node")
+        result = pg_api.add_node("c", "C unless blocker", sl="a", unless="blocker")
+        assert result["truth_value"] == "OUT"
+
+    def test_add_with_outlist_out(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("blocker", "Blocker node")
+        pg_api.retract_node("blocker")
+        result = pg_api.add_node("c", "C unless blocker", sl="a", unless="blocker")
+        assert result["truth_value"] == "IN"
+
+    def test_add_duplicate_raises(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        with pytest.raises(Exception):
+            pg_api.add_node("a", "Alpha again")
+
+    def test_add_with_access_tags(self, pg_api):
+        pg_api.add_node("a", "Alpha", access_tags=["billing", "aws"])
+        result = pg_api.show_node("a")
+        assert result["metadata"]["access_tags"] == ["aws", "billing"]
+
+    def test_access_tag_inheritance(self, pg_api):
+        pg_api.add_node("a", "Alpha", access_tags=["billing"])
+        pg_api.add_node("b", "Beta", access_tags=["aws"])
+        pg_api.add_node("c", "Gamma derived", sl="a,b")
+        result = pg_api.show_node("c")
+        assert set(result["metadata"]["access_tags"]) == {"aws", "billing"}
+
+
+class TestRetractNode:
+
+    def test_retract_premise(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.retract_node("a")
+        assert "a" in result["changed"]
+        assert "a" in result["went_out"]
+        status = pg_api.show_node("a")
+        assert status["truth_value"] == "OUT"
+
+    def test_retract_already_out(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.retract_node("a")
+        result = pg_api.retract_node("a")
+        assert result["changed"] == []
+
+    def test_retract_cascade(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma", sl="b")
+        result = pg_api.retract_node("a")
+        assert "a" in result["went_out"]
+        assert "b" in result["went_out"]
+        assert "c" in result["went_out"]
+
+    def test_retract_with_reason(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.retract_node("a", reason="obsolete")
+        result = pg_api.show_node("a")
+        assert result["metadata"].get("retract_reason") == "obsolete"
+
+    def test_retract_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.retract_node("nonexistent")
+
+
+class TestAssertNode:
+
+    def test_assert_restores(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.retract_node("a")
+        result = pg_api.assert_node("a")
+        assert "a" in result["changed"]
+        assert "a" in result["went_in"]
+        status = pg_api.show_node("a")
+        assert status["truth_value"] == "IN"
+
+    def test_assert_already_in(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.assert_node("a")
+        assert result["changed"] == []
+
+    def test_assert_restores_cascade(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma", sl="b")
+        pg_api.retract_node("a")
+        result = pg_api.assert_node("a")
+        assert "a" in result["went_in"]
+        assert "b" in result["went_in"]
+        assert "c" in result["went_in"]
+
+
+class TestPropagation:
+
+    def test_diamond_dependency(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma", sl="a")
+        pg_api.add_node("d", "Delta", sl="b,c")
+        result = pg_api.retract_node("a")
+        assert set(result["went_out"]) == {"a", "b", "c", "d"}
+
+    def test_diamond_restoration(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma", sl="a")
+        pg_api.add_node("d", "Delta", sl="b,c")
+        pg_api.retract_node("a")
+        result = pg_api.assert_node("a")
+        assert "b" in result["went_in"]
+        assert "c" in result["went_in"]
+        assert "d" in result["went_in"]
+
+    def test_outlist_blocks(self, pg_api):
+        pg_api.add_node("x", "X premise")
+        pg_api.add_node("y", "Y blocker")
+        pg_api.add_node("z", "Z unless Y", sl="x", unless="y")
+        status = pg_api.show_node("z")
+        assert status["truth_value"] == "OUT"
+
+    def test_outlist_unblocks(self, pg_api):
+        pg_api.add_node("x", "X premise")
+        pg_api.add_node("y", "Y blocker")
+        pg_api.add_node("z", "Z unless Y", sl="x", unless="y")
+        pg_api.retract_node("y")
+        status = pg_api.show_node("z")
+        assert status["truth_value"] == "IN"
+
+    def test_outlist_reblocks(self, pg_api):
+        pg_api.add_node("x", "X premise")
+        pg_api.add_node("y", "Y blocker")
+        pg_api.add_node("z", "Z unless Y", sl="x", unless="y")
+        pg_api.retract_node("y")
+        pg_api.assert_node("y")
+        status = pg_api.show_node("z")
+        assert status["truth_value"] == "OUT"
+
+    def test_multiple_justifications(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.add_node("c", "Gamma", sl="a")
+        pg_api.add_justification("c", sl="b")
+        pg_api.retract_node("a")
+        status = pg_api.show_node("c")
+        assert status["truth_value"] == "IN"
+
+    def test_retracted_pin_skipped(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.retract_node("b")
+        pg_api.retract_node("a")
+        pg_api.assert_node("a")
+        status = pg_api.show_node("b")
+        assert status["truth_value"] == "OUT"
+
+
+class TestGetStatus:
+
+    def test_empty(self, pg_api):
+        result = pg_api.get_status()
+        assert result["nodes"] == []
+        assert result["total"] == 0
+
+    def test_with_nodes(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.retract_node("b")
+        result = pg_api.get_status()
+        assert result["total"] == 2
+        assert result["in_count"] == 1
+
+    def test_visible_to_filter(self, pg_api):
+        pg_api.add_node("a", "Alpha", access_tags=["secret"])
+        pg_api.add_node("b", "Beta")
+        result = pg_api.get_status(visible_to=["public"])
+        assert len(result["nodes"]) == 1
+        assert result["nodes"][0]["id"] == "b"
+
+
+class TestShowNode:
+
+    def test_show_premise(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.show_node("a")
+        assert result["id"] == "a"
+        assert result["truth_value"] == "IN"
+        assert result["justifications"] == []
+
+    def test_show_derived(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a", label="test")
+        result = pg_api.show_node("b")
+        assert len(result["justifications"]) == 1
+        assert result["justifications"][0]["antecedents"] == ["a"]
+        assert result["justifications"][0]["label"] == "test"
+
+    def test_show_dependents(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        result = pg_api.show_node("a")
+        assert "b" in result["dependents"]
+
+    def test_show_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.show_node("nonexistent")
+
+    def test_show_access_denied(self, pg_api):
+        pg_api.add_node("a", "Alpha", access_tags=["secret"])
+        with pytest.raises(PermissionError):
+            pg_api.show_node("a", visible_to=["public"])
+
+
+class TestSearch:
+
+    def test_search_by_text(self, pg_api):
+        pg_api.add_node("a", "Propagation uses breadth-first search")
+        pg_api.add_node("b", "Retraction cascades through dependents")
+        result = pg_api.search("propagation")
+        assert "propagation" in result.lower() or "a" in result
+
+    def test_search_by_id(self, pg_api):
+        pg_api.add_node("prop-bfs", "Propagation uses BFS")
+        result = pg_api.search("prop-bfs")
+        assert "prop-bfs" in result
+
+    def test_search_no_results(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.search("zzzznonexistent")
+        assert "No results" in result
+
+    def test_search_compact_format(self, pg_api):
+        pg_api.add_node("a", "Alpha belief")
+        result = pg_api.search("alpha", format="compact")
+        assert "[IN] a" in result
+
+    def test_search_json_format(self, pg_api):
+        pg_api.add_node("a", "Alpha belief")
+        result = pg_api.search("alpha", format="json")
+        data = json.loads(result)
+        assert any(d["id"] == "a" for d in data)
+
+    def test_search_with_neighbors(self, pg_api):
+        pg_api.add_node("a", "Alpha premise")
+        pg_api.add_node("b", "Beta depends on alpha", sl="a")
+        result = pg_api.search("beta", format="compact")
+        assert "b" in result
+        assert "a" in result
+
+
+class TestListNodes:
+
+    def test_list_all(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        result = pg_api.list_nodes()
+        assert result["count"] == 2
+
+    def test_list_by_status(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.retract_node("b")
+        result = pg_api.list_nodes(status="IN")
+        assert result["count"] == 1
+        assert result["nodes"][0]["id"] == "a"
+
+    def test_list_premises_only(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        result = pg_api.list_nodes(premises_only=True)
+        assert result["count"] == 1
+        assert result["nodes"][0]["id"] == "a"
+
+    def test_list_has_dependents(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma")
+        result = pg_api.list_nodes(has_dependents=True)
+        assert result["count"] == 1
+        assert result["nodes"][0]["id"] == "a"
+
+    def test_list_by_namespace(self, pg_api):
+        pg_api.add_node("ns1:a", "Alpha")
+        pg_api.add_node("ns2:b", "Beta")
+        result = pg_api.list_nodes(namespace="ns1")
+        assert result["count"] == 1
+        assert result["nodes"][0]["id"] == "ns1:a"
+
+
+class TestGetLog:
+
+    def test_log_after_add(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.get_log()
+        assert len(result["entries"]) >= 1
+        assert result["entries"][-1]["action"] == "add"
+
+    def test_log_last(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.retract_node("a")
+        result = pg_api.get_log(last=1)
+        assert len(result["entries"]) == 1
+
+
+class TestAddJustification:
+
+    def test_add_justification_changes_truth(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.retract_node("b")
+        result = pg_api.add_justification("b", sl="a")
+        assert result["old_truth_value"] == "OUT"
+        assert result["new_truth_value"] == "IN"
+
+    def test_add_justification_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.add_justification("nonexistent", sl="a")
+
+
+class TestNogood:
+
+    def test_add_nogood_active(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        result = pg_api.add_nogood(["a", "b"])
+        assert result["backtracked_to"] is not None
+        # One of a or b should be retracted
+        a = pg_api.show_node("a")
+        b = pg_api.show_node("b")
+        assert a["truth_value"] == "OUT" or b["truth_value"] == "OUT"
+
+    def test_add_nogood_inactive(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.retract_node("b")
+        result = pg_api.add_nogood(["a", "b"])
+        assert result["backtracked_to"] is None
+        assert result["changed"] == []
+
+    def test_add_nogood_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.add_nogood(["nonexistent"])
+
+
+class TestFindCulprits:
+
+    def test_find_culprits(self, pg_api):
+        pg_api.add_node("premise-a", "Alpha", source="code.py")
+        pg_api.add_node("premise-b", "Beta")
+        pg_api.add_node("derived", "Gamma", sl="premise-a,premise-b")
+        result = pg_api.find_culprits(["premise-a", "premise-b"])
+        assert len(result["culprits"]) >= 1
+        # premise-b should be less entrenched (no source)
+        assert result["culprits"][0]["premise"] == "premise-b"
+
+
+class TestExplainNode:
+
+    def test_explain_premise(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.explain_node("a")
+        assert result["steps"][0]["reason"] == "premise"
+
+    def test_explain_derived_in(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a", label="test")
+        result = pg_api.explain_node("b")
+        assert result["steps"][0]["truth_value"] == "IN"
+        assert "SL" in result["steps"][0]["reason"]
+        assert result["steps"][0]["antecedents"] == ["a"]
+
+    def test_explain_derived_out(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.retract_node("a")
+        result = pg_api.explain_node("b")
+        assert result["steps"][0]["truth_value"] == "OUT"
+        assert "a" in result["steps"][0]["failed_antecedents"]
+
+
+class TestTraceAssumptions:
+
+    def test_trace_premise(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.trace_assumptions("a")
+        assert result["premises"] == ["a"]
+
+    def test_trace_chain(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma", sl="b")
+        result = pg_api.trace_assumptions("c")
+        assert "a" in result["premises"]
+
+    def test_trace_diamond(self, pg_api):
+        pg_api.add_node("p1", "Premise 1")
+        pg_api.add_node("p2", "Premise 2")
+        pg_api.add_node("d1", "Derived 1", sl="p1")
+        pg_api.add_node("d2", "Derived 2", sl="p2")
+        pg_api.add_node("top", "Top", sl="d1,d2")
+        result = pg_api.trace_assumptions("top")
+        assert set(result["premises"]) == {"p1", "p2"}
+
+
+class TestMultiTenancy:
+
+    def test_projects_isolated(self, pg_api):
+        import os
+        import uuid
+        from reasons_lib.pg import PgApi
+
+        pg_api.add_node("shared-id", "Project 1 data")
+
+        project2 = str(uuid.uuid4())
+        api2 = PgApi(os.environ["DATABASE_URL"], project2)
+        api2.init_db()
+
+        try:
+            result = api2.get_status()
+            assert result["total"] == 0
+
+            api2.add_node("shared-id", "Project 2 data")
+            p1 = pg_api.show_node("shared-id")
+            p2 = api2.show_node("shared-id")
+            assert p1["text"] == "Project 1 data"
+            assert p2["text"] == "Project 2 data"
+        finally:
+            with api2.conn.cursor() as cur:
+                for table in ("rms_propagation_log", "rms_justifications",
+                              "rms_nogoods", "rms_network_meta", "rms_nodes"):
+                    cur.execute(f"DELETE FROM {table} WHERE project_id = %s", (project2,))
+            api2.conn.commit()
+            api2.close()


### PR DESCRIPTION
## Summary

- Adds `reasons_lib.pg.PgApi` — PostgreSQL-native API where each operation is a SQL transaction (no full-network load/save)
- Enables concurrent writers and multi-tenant deployment via `project_id` composite PKs
- Schema compatible with expert-service existing `rms_*` tables
- Application-level BFS propagation with batched SQL queries per level
- 57 new tests covering add/retract/assert/cascade/outlist/search/nogoods/explain
- psycopg v3 as optional dependency (`pip install 'ftl-reasons[pg]'`)

## What is included

Core mutations: `add_node`, `retract_node`, `assert_node`, `add_justification`
Reads: `get_status`, `show_node`, `search` (tsvector + GIN), `list_nodes`, `get_log`
Nogoods: `add_nogood` (with DDB), `find_culprits`, `explain_node`, `trace_assumptions`
Multi-tenancy: each operation scoped by `project_id`, projects fully isolated

## What is deferred

Namespace support, `what_if_retract/assert`, `challenge/defend/supersede`, `export/import`, `deduplicate`, async wrapper

## Test plan

- [x] 57 PG tests pass with `DATABASE_URL` set (PostgreSQL 15)
- [x] 57 PG tests skip cleanly without `DATABASE_URL`
- [x] 611 existing SQLite tests unaffected
- [x] Propagation correctness: retraction cascade, restoration, diamond, outlist, multiple justifications, retracted pin

Closes #46
