### PR TITLE
Add challenge, defend, and compact to PgApi

### DIFF
--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -317,6 +317,72 @@ class PgApi:
         all_changed = [node_id] + went_out + went_in
         return {"changed": all_changed, "went_out": went_out, "went_in": [node_id] + went_in}
 
+    # ── Dialectical operations ─────────────────────────────────
+
+    def challenge(self, target_id, reason, challenge_id=None):
+        with self.conn.cursor() as cur:
+            result = self._challenge_internal(cur, target_id, reason, challenge_id)
+        self.conn.commit()
+        return result
+
+    def defend(self, target_id, challenge_id, reason, defense_id=None):
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            # Verify target and challenge exist
+            cur.execute(
+                "SELECT 1 FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (target_id, pid),
+            )
+            if not cur.fetchone():
+                raise KeyError(f"Node '{target_id}' not found")
+            cur.execute(
+                "SELECT 1 FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (challenge_id, pid),
+            )
+            if not cur.fetchone():
+                raise KeyError(f"Challenge '{challenge_id}' not found")
+
+            # Generate defense ID
+            if defense_id is None:
+                defense_id = f"defense-{challenge_id}"
+                suffix = 1
+                while True:
+                    cur.execute(
+                        "SELECT 1 FROM rms_nodes WHERE id = %s AND project_id = %s",
+                        (defense_id, pid),
+                    )
+                    if not cur.fetchone():
+                        break
+                    suffix += 1
+                    defense_id = f"defense-{challenge_id}-{suffix}"
+
+            # Challenge the challenge (defense = challenge against the challenge)
+            result = self._challenge_internal(cur, challenge_id, reason, defense_id)
+
+            # Update defense node metadata
+            cur.execute(
+                "SELECT metadata FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (defense_id, pid),
+            )
+            meta = cur.fetchone()[0]
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            meta["defense_target"] = challenge_id
+            meta["defends"] = target_id
+            cur.execute(
+                "UPDATE rms_nodes SET metadata = %s WHERE id = %s AND project_id = %s",
+                (json.dumps(meta), defense_id, pid),
+            )
+
+        self.conn.commit()
+        return {
+            "defense_id": defense_id,
+            "challenge_id": challenge_id,
+            "target_id": target_id,
+            "changed": result["changed"],
+        }
+
     # ── Read operations ─────────────────────────────────────────
 
     def get_status(self, visible_to=None):
@@ -542,6 +608,204 @@ class PgApi:
                     for r in cur.fetchall()
                 ]
         return {"entries": entries}
+
+    def compact(self, budget=500, truncate=True, visible_to=None):
+        from datetime import date as _date
+
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            # Fetch all nodes
+            cur.execute(
+                "SELECT id, text, truth_value, source, metadata "
+                "FROM rms_nodes WHERE project_id = %s ORDER BY id",
+                (pid,),
+            )
+            all_nodes = []
+            for row in cur.fetchall():
+                nid, text, tv, source, meta = row
+                if isinstance(meta, str):
+                    meta = json.loads(meta)
+                if visible_to is not None and not self._is_visible(meta, visible_to):
+                    continue
+                all_nodes.append({
+                    "id": nid, "text": text, "truth_value": tv,
+                    "source": source, "metadata": meta,
+                })
+
+            # Fetch nogoods
+            cur.execute(
+                "SELECT id, nodes, resolution FROM rms_nogoods "
+                "WHERE project_id = %s ORDER BY id",
+                (pid,),
+            )
+            nogoods = []
+            for row in cur.fetchall():
+                ng_id, nodes, resolution = row
+                if isinstance(nodes, str):
+                    nodes = json.loads(nodes)
+                nogoods.append({"id": ng_id, "nodes": nodes, "resolution": resolution or ""})
+
+            # Fetch dependent counts per node
+            cur.execute(
+                "SELECT je.value AS referenced_id, COUNT(DISTINCT j.node_id) AS dep_count "
+                "FROM rms_justifications j, "
+                "jsonb_array_elements_text(j.antecedents) je(value) "
+                "WHERE j.project_id = %s GROUP BY je.value",
+                (pid,),
+            )
+            dep_counts = {r[0]: r[1] for r in cur.fetchall()}
+            cur.execute(
+                "SELECT je.value AS referenced_id, COUNT(DISTINCT j.node_id) AS dep_count "
+                "FROM rms_justifications j, "
+                "jsonb_array_elements_text(j.outlist) je(value) "
+                "WHERE j.project_id = %s GROUP BY je.value",
+                (pid,),
+            )
+            for row in cur.fetchall():
+                dep_counts[row[0]] = dep_counts.get(row[0], 0) + row[1]
+
+            # Fetch first justification antecedents per node (for IN display)
+            cur.execute(
+                "SELECT DISTINCT ON (node_id) node_id, antecedents, label "
+                "FROM rms_justifications "
+                "WHERE project_id = %s ORDER BY node_id, id",
+                (pid,),
+            )
+            first_just = {}
+            for row in cur.fetchall():
+                nid, ants, label = row
+                if isinstance(ants, str):
+                    ants = json.loads(ants)
+                first_just[nid] = {"antecedents": ants, "label": label}
+
+        # Split nodes
+        in_nodes = [n for n in all_nodes if n["truth_value"] == "IN"]
+        out_nodes = [n for n in all_nodes if n["truth_value"] == "OUT"]
+
+        in_nodes.sort(key=lambda n: dep_counts.get(n["id"], 0), reverse=True)
+
+        today = _date.today().isoformat()
+        in_count = len(in_nodes)
+        out_count = len(out_nodes)
+        total = in_count + out_count
+        nogood_count = len(nogoods)
+
+        lines = [
+            f"# Belief State Summary ({today})",
+            f"# {total} nodes tracked | {nogood_count} nogoods | {in_count} IN | {out_count} OUT",
+            "",
+        ]
+
+        def _text(text):
+            if truncate and len(text) > 80:
+                return text[:77] + "..."
+            return text
+
+        def _estimate_tokens(text):
+            return max(1, len(text) // 4)
+
+        footer_tokens = _estimate_tokens(f"Token count: ~{budget} / {budget} budget")
+        _char_count = sum(len(l) for l in lines) + len(lines) - 1
+
+        def _add_line(line):
+            nonlocal _char_count
+            lines.append(line)
+            _char_count += 1 + len(line)
+
+        def _current_tokens():
+            return max(1, _char_count // 4)
+
+        def _over_budget(line):
+            return _current_tokens() + _estimate_tokens(line) + footer_tokens > budget
+
+        # Section 1: Nogoods
+        if nogoods and not _over_budget("## Nogoods"):
+            _add_line("## Nogoods")
+            added_nogoods = 0
+            for ng in nogoods:
+                res = f" — {ng['resolution']}" if ng["resolution"] else ""
+                line = f"- {ng['id']}: {', '.join(ng['nodes'])}{res}"
+                if _over_budget(line):
+                    remaining = len(nogoods) - added_nogoods
+                    _add_line(f"  ... ({remaining} more nogoods omitted)")
+                    break
+                _add_line(line)
+                added_nogoods += 1
+            _add_line("")
+
+        # Section 2: OUT nodes
+        if out_nodes and not _over_budget("## OUT (retracted)"):
+            _add_line("## OUT (retracted)")
+            added_out = 0
+            for node in out_nodes:
+                reason = ""
+                retract_reason = node["metadata"].get("retract_reason") or node["metadata"].get("stale_reason")
+                if retract_reason:
+                    reason = f" (stale: {retract_reason[:60]})"
+                elif node["metadata"].get("superseded_by"):
+                    reason = f" (superseded by: {node['metadata']['superseded_by']})"
+                line = f"- {node['id']}: {_text(node['text'])}{reason}"
+                if _over_budget(line):
+                    remaining = len(out_nodes) - added_out
+                    _add_line(f"  ... ({remaining} more OUT nodes omitted)")
+                    break
+                _add_line(line)
+                added_out += 1
+            _add_line("")
+
+        # Section 3: IN nodes
+        if in_nodes and not _over_budget("## IN (active)"):
+            covered_by_summary = set()
+            summary_nodes = []
+            regular_nodes = []
+            for node in in_nodes:
+                summarizes = node["metadata"].get("summarizes")
+                if summarizes:
+                    summary_nodes.append(node)
+                    for covered_id in summarizes:
+                        covered_by_summary.add(covered_id)
+                else:
+                    regular_nodes.append(node)
+
+            visible_nodes = summary_nodes + [
+                n for n in regular_nodes if n["id"] not in covered_by_summary
+            ]
+            visible_nodes.sort(key=lambda n: dep_counts.get(n["id"], 0), reverse=True)
+
+            hidden_count = len(in_nodes) - len(visible_nodes)
+
+            _add_line("## IN (active)")
+            added = 0
+
+            for node in visible_nodes:
+                is_summary = bool(node["metadata"].get("summarizes"))
+                prefix = "[summary] " if is_summary else ""
+                deps = ""
+                j = first_just.get(node["id"])
+                if j and j["antecedents"] and j["label"] != "summarizes":
+                    deps = f" <- {', '.join(j['antecedents'])}"
+                dep_count = dep_counts.get(node["id"], 0)
+                dep_info = f" ({dep_count} dependents)" if dep_count else ""
+                summarizes = node["metadata"].get("summarizes", [])
+                sum_info = f" (covers {len(summarizes)} nodes)" if summarizes else ""
+                line = f"- {prefix}{node['id']}: {_text(node['text'])}{deps}{dep_info}{sum_info}"
+
+                if _over_budget(line):
+                    remaining = len(visible_nodes) - added
+                    _add_line(f"  ... ({remaining} more IN nodes omitted)")
+                    break
+
+                _add_line(line)
+                added += 1
+
+            if hidden_count:
+                _add_line(f"  ({hidden_count} nodes hidden by summaries)")
+            _add_line("")
+
+        lines.append(f"Token count: ~{_current_tokens()} / {budget} budget")
+
+        return "\n".join(lines)
 
     # ── Nogoods + explain ───────────────────────────────────────
 
@@ -798,6 +1062,101 @@ class PgApi:
             if inlist_ok and outlist_ok:
                 return "IN"
         return "OUT"
+
+    def _challenge_internal(self, cur, target_id, reason, challenge_id):
+        pid = self.project_id
+
+        # Verify target exists
+        cur.execute(
+            "SELECT truth_value, metadata FROM rms_nodes WHERE id = %s AND project_id = %s",
+            (target_id, pid),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise KeyError(f"Node '{target_id}' not found")
+        old_value = row[0]
+        target_meta = row[1]
+        if isinstance(target_meta, str):
+            target_meta = json.loads(target_meta)
+
+        # Generate challenge ID
+        if challenge_id is None:
+            challenge_id = f"challenge-{target_id}"
+            suffix = 1
+            while True:
+                cur.execute(
+                    "SELECT 1 FROM rms_nodes WHERE id = %s AND project_id = %s",
+                    (challenge_id, pid),
+                )
+                if not cur.fetchone():
+                    break
+                suffix += 1
+                challenge_id = f"challenge-{target_id}-{suffix}"
+        else:
+            cur.execute(
+                "SELECT 1 FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (challenge_id, pid),
+            )
+            if cur.fetchone():
+                raise ValueError(f"Challenge node '{challenge_id}' already exists")
+
+        # Create challenge node as premise
+        now = datetime.now().isoformat(timespec="seconds")
+        challenge_meta = {"challenge_target": target_id}
+        cur.execute(
+            "INSERT INTO rms_nodes (id, project_id, text, truth_value, date, metadata) "
+            "VALUES (%s, %s, %s, 'IN', %s, %s)",
+            (challenge_id, pid, reason, now, json.dumps(challenge_meta)),
+        )
+        self._log(cur, "add", challenge_id, "IN")
+
+        # Add challenge to target's outlist
+        cur.execute(
+            "SELECT COUNT(*) FROM rms_justifications WHERE node_id = %s AND project_id = %s",
+            (target_id, pid),
+        )
+        has_justifications = cur.fetchone()[0] > 0
+
+        if has_justifications:
+            cur.execute(
+                "UPDATE rms_justifications SET outlist = outlist || %s::jsonb "
+                "WHERE node_id = %s AND project_id = %s",
+                (json.dumps([challenge_id]), target_id, pid),
+            )
+        else:
+            cur.execute(
+                "INSERT INTO rms_justifications (node_id, project_id, type, antecedents, outlist, label) "
+                "VALUES (%s, %s, 'SL', '[]', %s, '')",
+                (target_id, pid, json.dumps([challenge_id])),
+            )
+
+        # Update target metadata with challenges list
+        challenges = target_meta.get("challenges", [])
+        challenges.append(challenge_id)
+        target_meta["challenges"] = challenges
+        cur.execute(
+            "UPDATE rms_nodes SET metadata = %s WHERE id = %s AND project_id = %s",
+            (json.dumps(target_meta), target_id, pid),
+        )
+
+        # Recompute target truth and propagate
+        new_value = self._compute_truth(cur, target_id)
+        changed = []
+
+        if old_value != new_value:
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = %s WHERE id = %s AND project_id = %s",
+                (new_value, target_id, pid),
+            )
+            changed.append(target_id)
+            self._log(cur, "challenge", target_id, new_value)
+            went_out, went_in = self._propagate(cur, target_id)
+            changed.extend(went_out)
+            changed.extend(went_in)
+        else:
+            self._log(cur, "challenge", target_id, f"unchanged ({old_value})")
+
+        return {"challenge_id": challenge_id, "target_id": target_id, "changed": changed}
 
     def _find_dependents(self, cur, node_ids):
         """Find nodes that have any of node_ids in their antecedents or outlist."""

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -356,6 +356,13 @@ class PgApi:
                         break
                     suffix += 1
                     defense_id = f"defense-{challenge_id}-{suffix}"
+            else:
+                cur.execute(
+                    "SELECT 1 FROM rms_nodes WHERE id = %s AND project_id = %s",
+                    (defense_id, pid),
+                )
+                if cur.fetchone():
+                    raise ValueError(f"Defense node '{defense_id}' already exists")
 
             # Challenge the challenge (defense = challenge against the challenge)
             result = self._challenge_internal(cur, challenge_id, reason, defense_id)

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -640,17 +640,20 @@ class PgApi:
                     "source": source, "metadata": meta,
                 })
 
-            # Fetch nogoods
+            # Fetch nogoods (filter by visible_to — hide nogoods referencing inaccessible nodes)
             cur.execute(
                 "SELECT id, nodes, resolution FROM rms_nogoods "
                 "WHERE project_id = %s ORDER BY id",
                 (pid,),
             )
+            visible_ids = {n["id"] for n in all_nodes}
             nogoods = []
             for row in cur.fetchall():
                 ng_id, nodes, resolution = row
                 if isinstance(nodes, str):
                     nodes = json.loads(nodes)
+                if visible_to is not None and not all(n in visible_ids for n in nodes):
+                    continue
                 nogoods.append({"id": ng_id, "nodes": nodes, "resolution": resolution or ""})
 
             # Fetch dependent counts per node
@@ -1111,8 +1114,8 @@ class PgApi:
         now = datetime.now().isoformat(timespec="seconds")
         challenge_meta = {"challenge_target": target_id}
         cur.execute(
-            "INSERT INTO rms_nodes (id, project_id, text, truth_value, date, metadata) "
-            "VALUES (%s, %s, %s, 'IN', %s, %s)",
+            "INSERT INTO rms_nodes (id, project_id, text, truth_value, source, date, metadata) "
+            "VALUES (%s, %s, %s, 'IN', 'challenge', %s, %s)",
             (challenge_id, pid, reason, now, json.dumps(challenge_meta)),
         )
         self._log(cur, "add", challenge_id, "IN")

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -464,3 +464,152 @@ class TestMultiTenancy:
                     cur.execute(f"DELETE FROM {table} WHERE project_id = %s", (project2,))
             api2.conn.commit()
             api2.close()
+
+
+class TestChallenge:
+
+    def test_challenge_premise(self, pg_api):
+        pg_api.add_node("a", "Alpha premise")
+        result = pg_api.challenge("a", "Alpha is wrong")
+        assert result["challenge_id"] == "challenge-a"
+        assert result["target_id"] == "a"
+        assert "a" in result["changed"]
+        status = pg_api.show_node("a")
+        assert status["truth_value"] == "OUT"
+
+    def test_challenge_derived(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        result = pg_api.challenge("b", "Beta is wrong")
+        assert "b" in result["changed"]
+        status = pg_api.show_node("b")
+        assert status["truth_value"] == "OUT"
+
+    def test_challenge_already_out(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.retract_node("a")
+        result = pg_api.challenge("a", "Alpha is wrong")
+        assert result["challenge_id"] == "challenge-a"
+        # Target was already OUT, no change
+        assert "a" not in result["changed"]
+
+    def test_challenge_custom_id(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.challenge("a", "Alpha is wrong", challenge_id="my-challenge")
+        assert result["challenge_id"] == "my-challenge"
+        status = pg_api.show_node("my-challenge")
+        assert status["truth_value"] == "IN"
+
+    def test_challenge_auto_id_collision(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("challenge-a", "Existing node")
+        result = pg_api.challenge("a", "Alpha is wrong")
+        assert result["challenge_id"] == "challenge-a-2"
+
+    def test_challenge_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.challenge("nonexistent", "reason")
+
+    def test_challenge_metadata(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.challenge("a", "Alpha is wrong")
+        # Challenge node has challenge_target metadata
+        challenge = pg_api.show_node("challenge-a")
+        assert challenge["metadata"]["challenge_target"] == "a"
+        # Target has challenges list in metadata
+        target = pg_api.show_node("a")
+        assert "challenge-a" in target["metadata"]["challenges"]
+
+    def test_challenge_cascade(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma", sl="b")
+        result = pg_api.challenge("a", "Alpha is wrong")
+        assert "a" in result["changed"]
+        assert "b" in result["changed"]
+        assert "c" in result["changed"]
+
+
+class TestDefend:
+
+    def test_defend_restores_target(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.challenge("a", "Alpha is wrong")
+        assert pg_api.show_node("a")["truth_value"] == "OUT"
+        result = pg_api.defend("a", "challenge-a", "Alpha is right")
+        assert result["defense_id"] == "defense-challenge-a"
+        assert pg_api.show_node("challenge-a")["truth_value"] == "OUT"
+        assert pg_api.show_node("a")["truth_value"] == "IN"
+
+    def test_defend_cascade(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.challenge("a", "Alpha is wrong")
+        assert pg_api.show_node("b")["truth_value"] == "OUT"
+        pg_api.defend("a", "challenge-a", "Alpha is right")
+        assert pg_api.show_node("a")["truth_value"] == "IN"
+        assert pg_api.show_node("b")["truth_value"] == "IN"
+
+    def test_defend_metadata(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.challenge("a", "Alpha is wrong")
+        pg_api.defend("a", "challenge-a", "Alpha is right")
+        defense = pg_api.show_node("defense-challenge-a")
+        assert defense["metadata"]["defense_target"] == "challenge-a"
+        assert defense["metadata"]["defends"] == "a"
+
+    def test_defend_not_found(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        with pytest.raises(KeyError):
+            pg_api.defend("a", "nonexistent", "reason")
+        with pytest.raises(KeyError):
+            pg_api.defend("nonexistent", "a", "reason")
+
+    def test_defend_custom_id(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.challenge("a", "Alpha is wrong")
+        result = pg_api.defend("a", "challenge-a", "Alpha is right", defense_id="my-defense")
+        assert result["defense_id"] == "my-defense"
+        assert pg_api.show_node("my-defense")["truth_value"] == "IN"
+
+
+class TestCompact:
+
+    def test_compact_empty(self, pg_api):
+        result = pg_api.compact()
+        assert "0 nodes tracked" in result
+        assert "Belief State Summary" in result
+        assert "Token count:" in result
+
+    def test_compact_in_nodes(self, pg_api):
+        pg_api.add_node("a", "Alpha premise")
+        pg_api.add_node("b", "Beta premise")
+        pg_api.add_node("c", "Gamma derived", sl="a")
+        result = pg_api.compact()
+        assert "3 nodes tracked" in result
+        assert "## IN (active)" in result
+        assert "a" in result
+        assert "b" in result
+        assert "c" in result
+
+    def test_compact_out_nodes(self, pg_api):
+        pg_api.add_node("a", "Alpha premise")
+        pg_api.retract_node("a", reason="obsolete")
+        result = pg_api.compact()
+        assert "## OUT (retracted)" in result
+        assert "obsolete" in result
+
+    def test_compact_budget(self, pg_api):
+        for i in range(20):
+            pg_api.add_node(f"node-{i:02d}", f"This is belief number {i} with some text")
+        result_small = pg_api.compact(budget=50)
+        result_large = pg_api.compact(budget=5000)
+        assert len(result_small) < len(result_large)
+        assert "omitted" in result_small or "Token count:" in result_small
+
+    def test_compact_visible_to(self, pg_api):
+        pg_api.add_node("public", "Public belief")
+        pg_api.add_node("secret", "Secret belief", access_tags=["admin"])
+        result = pg_api.compact(visible_to=["user"])
+        assert "public" in result
+        assert "secret" not in result

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -572,6 +572,28 @@ class TestDefend:
         assert result["defense_id"] == "my-defense"
         assert pg_api.show_node("my-defense")["truth_value"] == "IN"
 
+    def test_defend_duplicate_id_raises(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("existing", "Existing node")
+        pg_api.challenge("a", "Alpha is wrong")
+        with pytest.raises(ValueError, match="Defense node"):
+            pg_api.defend("a", "challenge-a", "reason", defense_id="existing")
+
+    def test_defend_multiple_challenges(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.challenge("a", "First challenge")
+        pg_api.challenge("a", "Second challenge")
+        assert pg_api.show_node("a")["truth_value"] == "OUT"
+        # Defend against only the first challenge
+        pg_api.defend("a", "challenge-a", "First defense")
+        # Target should stay OUT because second challenge remains
+        assert pg_api.show_node("challenge-a")["truth_value"] == "OUT"
+        assert pg_api.show_node("challenge-a-2")["truth_value"] == "IN"
+        assert pg_api.show_node("a")["truth_value"] == "OUT"
+        # Defend against the second challenge too
+        pg_api.defend("a", "challenge-a-2", "Second defense")
+        assert pg_api.show_node("a")["truth_value"] == "IN"
+
 
 class TestCompact:
 
@@ -613,3 +635,39 @@ class TestCompact:
         result = pg_api.compact(visible_to=["user"])
         assert "public" in result
         assert "secret" not in result
+
+    def test_compact_nogoods(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.add_nogood(["a", "b"])
+        result = pg_api.compact(budget=5000)
+        assert "## Nogoods" in result
+        assert "nogood-001" in result
+
+    def test_compact_dependent_count_sorting(self, pg_api):
+        pg_api.add_node("root", "Root node")
+        pg_api.add_node("d1", "Dep 1", sl="root")
+        pg_api.add_node("d2", "Dep 2", sl="root")
+        pg_api.add_node("d3", "Dep 3", sl="root")
+        pg_api.add_node("leaf", "Leaf node")
+        result = pg_api.compact(budget=5000)
+        # root has 3 dependents, should appear before leaf (0 dependents)
+        root_pos = result.index("root")
+        leaf_pos = result.index("leaf")
+        assert root_pos < leaf_pos
+
+    def test_compact_summary_nodes(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        # Create a summary node that covers a and b
+        pg_api.add_node("summary", "Summary of a and b", sl="a,b")
+        # Manually set summarizes metadata
+        with pg_api.conn.cursor() as cur:
+            cur.execute(
+                "UPDATE rms_nodes SET metadata = %s WHERE id = %s AND project_id = %s",
+                (json.dumps({"summarizes": ["a", "b"]}), "summary", pg_api.project_id),
+            )
+        pg_api.conn.commit()
+        result = pg_api.compact(budget=5000)
+        assert "[summary]" in result
+        assert "hidden by summaries" in result

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -510,6 +510,12 @@ class TestChallenge:
         with pytest.raises(KeyError):
             pg_api.challenge("nonexistent", "reason")
 
+    def test_challenge_source(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.challenge("a", "Alpha is wrong")
+        challenge = pg_api.show_node("challenge-a")
+        assert challenge["source"] == "challenge"
+
     def test_challenge_metadata(self, pg_api):
         pg_api.add_node("a", "Alpha")
         pg_api.challenge("a", "Alpha is wrong")
@@ -643,6 +649,19 @@ class TestCompact:
         result = pg_api.compact(budget=5000)
         assert "## Nogoods" in result
         assert "nogood-001" in result
+
+    def test_compact_nogoods_filtered_by_visible_to(self, pg_api):
+        pg_api.add_node("public", "Public belief")
+        pg_api.add_node("secret", "Secret belief", access_tags=["admin"])
+        pg_api.add_nogood(["public", "secret"])
+        # Nogood references a secret node — should be hidden from non-admin
+        result = pg_api.compact(budget=5000, visible_to=["user"])
+        assert "Nogoods" not in result
+        assert "nogood-001" not in result
+        # Admin can see the nogood
+        result_admin = pg_api.compact(budget=5000, visible_to=["admin"])
+        assert "## Nogoods" in result_admin
+        assert "nogood-001" in result_admin
 
     def test_compact_dependent_count_sorting(self, pg_api):
         pg_api.add_node("root", "Root node")


### PR DESCRIPTION
## Summary
- Adds challenge(), defend(), and compact() methods to the PostgreSQL-native PgApi class, porting the three highest-priority missing methods from issue #46
- challenge() creates a premise node and adds it to the target outlist, knocking the target OUT with cascade propagation
- defend() uses symmetric challenge-the-challenge mechanism — creates a defense node that challenges the challenge, restoring the original target
- compact() generates token-budgeted belief state summaries (nogoods > OUT > IN priority) directly from SQL, matching the output format of compact.py
- Extracts _challenge_internal() as a shared helper so both challenge() and defend() execute in a single atomic transaction

## Test plan
- [x] 8 challenge tests: premise/derived/already-out targets, custom ID, auto-ID collision, not-found, metadata, cascade
- [x] 5 defend tests: restores target, cascade restoration, metadata, not-found, custom ID
- [x] 5 compact tests: empty network, IN nodes, OUT nodes with reasons, budget limiting, visible_to filtering
- [x] All 75 PG tests pass (57 existing + 18 new)
- [x] All 611 existing tests pass (no regressions)

Closes #51

Generated with [Claude Code](https://claude.com/claude-code)