### PR TITLE
Add list-gated command for finding blocked beliefs

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1461,6 +1461,45 @@ def list_nodes(
         return {"nodes": nodes, "count": len(nodes)}
 
 
+def list_gated(
+    visible_to: list[str] | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Find OUT nodes blocked by IN outlist nodes (active gates).
+
+    Returns: {"blockers": {blocker_id: {"text": str, "gated": [{"id": str, "text": str}]}},
+              "gated_count": int, "blocker_count": int}
+    """
+    with _with_network(db_path) as net:
+        blockers: dict[str, dict] = {}
+        for nid, node in sorted(net.nodes.items()):
+            if node.truth_value != "OUT":
+                continue
+            if node.metadata.get("superseded_by"):
+                continue
+            if visible_to is not None and not _is_visible(node, visible_to):
+                continue
+            for j in node.justifications:
+                for outlist_id in j.outlist:
+                    if outlist_id not in net.nodes:
+                        continue
+                    out_node = net.nodes[outlist_id]
+                    if out_node.truth_value != "IN":
+                        continue
+                    if outlist_id not in blockers:
+                        blockers[outlist_id] = {
+                            "text": out_node.text,
+                            "gated": [],
+                        }
+                    if not any(g["id"] == nid for g in blockers[outlist_id]["gated"]):
+                        blockers[outlist_id]["gated"].append({
+                            "id": nid,
+                            "text": node.text,
+                        })
+        gated_count = sum(len(b["gated"]) for b in blockers.values())
+        return {"blockers": blockers, "gated_count": gated_count, "blocker_count": len(blockers)}
+
+
 def _rewrite_dependents(net, old_id: str, new_id: str):
     """Rewrite justifications that reference old_id to point at new_id.
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -921,6 +921,25 @@ def cmd_list(args):
     print(f"\n{result['count']} node{'s' if result['count'] != 1 else ''}")
 
 
+def cmd_list_gated(args):
+    result = api.list_gated(
+        visible_to=_parse_visible_to(args),
+        db_path=args.db,
+    )
+
+    if not result["blockers"]:
+        print("No active gates found. All gated beliefs are satisfied.")
+        return
+
+    for blocker_id, info in sorted(result["blockers"].items()):
+        print(f"  [{blocker_id}] {info['text']}")
+        for gated in info["gated"]:
+            print(f"    ⊢ {gated['id']}: {gated['text']}")
+        print()
+
+    print(f"{result['blocker_count']} blocker(s) gating {result['gated_count']} belief(s)")
+
+
 def cmd_namespaces(args):
     result = api.list_namespaces(db_path=args.db)
     if not result["namespaces"]:
@@ -1173,6 +1192,9 @@ def main():
                    help="Apply a reviewed dedup plan file")
 
     # namespaces
+    p = sub.add_parser("list-gated", help="List OUT nodes blocked by IN outlist nodes")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
+
     sub.add_parser("namespaces", help="List all agent namespaces in the database")
 
     # list
@@ -1231,6 +1253,7 @@ def main():
         "ask": cmd_ask,
         "deduplicate": cmd_deduplicate,
         "list": cmd_list,
+        "list-gated": cmd_list_gated,
         "namespaces": cmd_namespaces,
     }
     commands[args.command](args)

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -598,6 +598,71 @@ class PgApi:
 
         return {"nodes": nodes, "count": len(nodes)}
 
+    def list_gated(self, visible_to=None):
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            # Find OUT nodes that have justifications with IN outlist nodes
+            cur.execute(
+                "SELECT n.id, n.text, n.metadata, j.outlist "
+                "FROM rms_nodes n "
+                "JOIN rms_justifications j ON j.node_id = n.id AND j.project_id = n.project_id "
+                "WHERE n.project_id = %s AND n.truth_value = 'OUT' "
+                "AND j.outlist != '[]'::jsonb",
+                (pid,),
+            )
+            candidates = cur.fetchall()
+
+            if not candidates:
+                return {"blockers": {}, "gated_count": 0, "blocker_count": 0}
+
+            # Collect all outlist node IDs
+            all_outlist_ids = set()
+            for row in candidates:
+                outlist = row[3]
+                if isinstance(outlist, str):
+                    outlist = json.loads(outlist)
+                all_outlist_ids.update(outlist)
+
+            # Fetch truth values and text for outlist nodes
+            if all_outlist_ids:
+                cur.execute(
+                    "SELECT id, text, truth_value, metadata FROM rms_nodes "
+                    "WHERE project_id = %s AND id = ANY(%s)",
+                    (pid, list(all_outlist_ids)),
+                )
+                outlist_info = {}
+                for r in cur.fetchall():
+                    meta = r[3]
+                    if isinstance(meta, str):
+                        meta = json.loads(meta)
+                    outlist_info[r[0]] = {"text": r[1], "truth_value": r[2], "metadata": meta}
+            else:
+                outlist_info = {}
+
+        blockers: dict[str, dict] = {}
+        for row in candidates:
+            nid, text, meta, outlist = row
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            if isinstance(outlist, str):
+                outlist = json.loads(outlist)
+            if meta.get("superseded_by"):
+                continue
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                continue
+            for outlist_id in outlist:
+                info = outlist_info.get(outlist_id)
+                if not info or info["truth_value"] != "IN":
+                    continue
+                if outlist_id not in blockers:
+                    blockers[outlist_id] = {"text": info["text"], "gated": []}
+                if not any(g["id"] == nid for g in blockers[outlist_id]["gated"]):
+                    blockers[outlist_id]["gated"].append({"id": nid, "text": text})
+
+        gated_count = sum(len(b["gated"]) for b in blockers.values())
+        return {"blockers": blockers, "gated_count": gated_count, "blocker_count": len(blockers)}
+
     def get_log(self, last=None):
         pid = self.project_id
         with self.conn.cursor() as cur:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -235,3 +235,58 @@ class TestListNodesDepth:
         result = api.list_nodes(min_depth=1, max_depth=1, db_path=db_path)
         ids = [n["id"] for n in result["nodes"]]
         assert ids == ["mid"]
+
+
+class TestListGated:
+
+    def test_no_gates(self, db_path):
+        api.add_node("a", "Alpha", db_path=db_path)
+        result = api.list_gated(db_path=db_path)
+        assert result["blockers"] == {}
+        assert result["gated_count"] == 0
+
+    def test_active_gate(self, db_path):
+        api.add_node("premise", "Supporting premise", db_path=db_path)
+        api.add_node("blocker", "Defect premise", db_path=db_path)
+        api.add_node("gated", "Conclusion unless blocker", sl="premise", unless="blocker", db_path=db_path)
+        result = api.list_gated(db_path=db_path)
+        assert result["blocker_count"] == 1
+        assert result["gated_count"] == 1
+        assert "blocker" in result["blockers"]
+        assert result["blockers"]["blocker"]["gated"][0]["id"] == "gated"
+
+    def test_satisfied_gate(self, db_path):
+        api.add_node("premise", "Supporting premise", db_path=db_path)
+        api.add_node("blocker", "Defect premise", db_path=db_path)
+        api.add_node("gated", "Conclusion unless blocker", sl="premise", unless="blocker", db_path=db_path)
+        api.retract_node("blocker", db_path=db_path)
+        result = api.list_gated(db_path=db_path)
+        assert result["blockers"] == {}
+
+    def test_multiple_gated_per_blocker(self, db_path):
+        api.add_node("premise", "Supporting premise", db_path=db_path)
+        api.add_node("blocker", "Defect", db_path=db_path)
+        api.add_node("g1", "Gated 1", sl="premise", unless="blocker", db_path=db_path)
+        api.add_node("g2", "Gated 2", sl="premise", unless="blocker", db_path=db_path)
+        result = api.list_gated(db_path=db_path)
+        assert result["blocker_count"] == 1
+        assert result["gated_count"] == 2
+        gated_ids = [g["id"] for g in result["blockers"]["blocker"]["gated"]]
+        assert "g1" in gated_ids
+        assert "g2" in gated_ids
+
+    def test_superseded_excluded(self, db_path):
+        api.add_node("premise", "Supporting premise", db_path=db_path)
+        api.add_node("blocker", "Defect", db_path=db_path)
+        api.add_node("old", "Old conclusion", sl="premise", unless="blocker", db_path=db_path)
+        api.add_node("new", "New conclusion", sl="premise", db_path=db_path)
+        api.supersede("old", "new", db_path=db_path)
+        result = api.list_gated(db_path=db_path)
+        assert result["gated_count"] == 0
+
+    def test_blocker_text_included(self, db_path):
+        api.add_node("premise", "Supporting premise", db_path=db_path)
+        api.add_node("bug-123", "File X has a null check missing", db_path=db_path)
+        api.add_node("gated", "X is safe", sl="premise", unless="bug-123", db_path=db_path)
+        result = api.list_gated(db_path=db_path)
+        assert result["blockers"]["bug-123"]["text"] == "File X has a null check missing"

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -334,6 +334,49 @@ class TestListNodes:
         assert result["nodes"][0]["id"] == "ns1:a"
 
 
+class TestListGated:
+
+    def test_no_gates(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.list_gated()
+        assert result["blockers"] == {}
+        assert result["gated_count"] == 0
+
+    def test_active_gate(self, pg_api):
+        pg_api.add_node("premise", "Supporting premise")
+        pg_api.add_node("blocker", "Defect premise")
+        pg_api.add_node("gated", "Conclusion unless blocker", sl="premise", unless="blocker")
+        result = pg_api.list_gated()
+        assert result["blocker_count"] == 1
+        assert result["gated_count"] == 1
+        assert "blocker" in result["blockers"]
+        assert result["blockers"]["blocker"]["gated"][0]["id"] == "gated"
+
+    def test_satisfied_gate(self, pg_api):
+        pg_api.add_node("premise", "Supporting premise")
+        pg_api.add_node("blocker", "Defect premise")
+        pg_api.add_node("gated", "Conclusion unless blocker", sl="premise", unless="blocker")
+        pg_api.retract_node("blocker")
+        result = pg_api.list_gated()
+        assert result["blockers"] == {}
+
+    def test_multiple_gated_per_blocker(self, pg_api):
+        pg_api.add_node("premise", "Supporting premise")
+        pg_api.add_node("blocker", "Defect")
+        pg_api.add_node("g1", "Gated 1", sl="premise", unless="blocker")
+        pg_api.add_node("g2", "Gated 2", sl="premise", unless="blocker")
+        result = pg_api.list_gated()
+        assert result["blocker_count"] == 1
+        assert result["gated_count"] == 2
+
+    def test_blocker_text_included(self, pg_api):
+        pg_api.add_node("premise", "Supporting premise")
+        pg_api.add_node("bug-123", "Null check missing")
+        pg_api.add_node("gated", "X is safe", sl="premise", unless="bug-123")
+        result = pg_api.list_gated()
+        assert result["blockers"]["bug-123"]["text"] == "Null check missing"
+
+
 class TestGetLog:
 
     def test_log_after_add(self, pg_api):


### PR DESCRIPTION
## Summary
- Adds `list-gated` subcommand and `api.list_gated()` function to find OUT nodes blocked by IN outlist nodes
- Extracts the gated-belief query pattern that code-expert reimplements on every `file-issues` call into a first-class API
- Implemented in both SQLite (`api.py`) and PostgreSQL (`pg.py`) backends
- Groups results by blocker: `{blockers: {blocker_id: {text, gated: [{id, text}]}}, gated_count, blocker_count}`
- Skips superseded nodes (OUT by design, not bugs)
- Supports `visible_to` access tag filtering

## Test plan
- [x] 6 SQLite tests: no gates, active gate, satisfied gate, multiple gated per blocker, superseded excluded, blocker text
- [x] 5 PostgreSQL tests: no gates, active gate, satisfied gate, multiple per blocker, blocker text
- [x] All 617 existing tests pass (no regressions)
- [x] All 89 PG tests pass (no regressions)
- [x] CLI `reasons list-gated --help` works

Generated with [Claude Code](https://claude.com/claude-code)