### PR TITLE
Add list-negative command with LLM classification

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1575,14 +1575,14 @@ def list_negative(
         response = ask._invoke_claude(prompt)
 
         negative_ids = set()
-        match = re.search(r"\[.*?\]", response, re.DOTALL)
-        if match:
+        for match in re.finditer(r"\[.*?\]", response, re.DOTALL):
             try:
                 ids = json.loads(match.group())
                 if isinstance(ids, list):
                     negative_ids = set(ids)
+                    break
             except json.JSONDecodeError:
-                pass
+                continue
 
         candidate_map = {nid: text for nid, text in candidates}
         negative = [

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1569,7 +1569,7 @@ def list_negative(
         if not candidates:
             return empty
 
-        lines = [f"- [{nid}] {text}" for nid, text in candidates]
+        lines = [f"- [{nid}] `{text}`" for nid, text in candidates]
         prompt = NEGATIVE_CLASSIFY_PROMPT.format(candidates="\n".join(lines))
 
         response = ask._invoke_claude(prompt)

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -7,6 +7,7 @@ or argparse. Each function opens the database, operates, saves, and closes.
 All functions return dicts suitable for JSON serialization.
 """
 
+import json
 import re
 from pathlib import Path
 
@@ -1498,6 +1499,108 @@ def list_gated(
                         })
         gated_count = sum(len(b["gated"]) for b in blockers.values())
         return {"blockers": blockers, "gated_count": gated_count, "blocker_count": len(blockers)}
+
+
+NEGATIVE_TERMS = [
+    'bug', 'defect', 'missing', 'fail', 'error', 'broken', 'incorrect',
+    'wrong', 'risk', 'gap', 'lack', 'vulnerable', 'insecure', 'stale',
+    'outdated', 'deprecated', 'fragile', 'brittle', 'hack', 'workaround',
+    'technical debt', 'tech debt', 'not implemented', 'unimplemented',
+    'incomplete', 'inconsistent', 'unclear', 'confusing', 'problem',
+    'issue', 'concern', 'warning', 'danger', 'threat', 'weakness',
+    'limitation', 'constraint', 'bottleneck', 'blocker', 'obstacle',
+    'undermines', 'concentrated', 'single point of failure', 'no tests',
+    'untested', 'not tested', 'hard-coded', 'hardcoded', 'tight coupling',
+    'tightly coupled', 'monolithic', 'legacy', 'unmaintained',
+]
+
+NEGATIVE_CLASSIFY_PROMPT = """\
+You are classifying beliefs from a Truth Maintenance System.
+Each belief below passed a keyword filter for negative terms.
+Identify which are GENUINELY NEGATIVE — they assert something is
+a problem, defect, risk, gap, limitation, or concern.
+
+EXCLUDE beliefs that merely DESCRIBE error handling, failure modes,
+or warning mechanisms as part of normal system behavior.
+
+Return ONLY a JSON array of the IDs of genuinely negative beliefs.
+Example: ["belief-1", "belief-3"]
+If none are genuinely negative, return: []
+
+## Candidates
+
+{candidates}"""
+
+
+def list_negative(
+    visible_to: list[str] | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Find IN beliefs that describe problems, defects, or risks.
+
+    Uses keyword pre-filtering then LLM classification via claude -p.
+
+    Returns: {"negative": [{"id": str, "text": str}, ...],
+              "count": int, "candidates": int, "total": int}
+    """
+    from . import ask
+
+    with _with_network(db_path) as net:
+        in_nodes = []
+        for nid, node in sorted(net.nodes.items()):
+            if node.truth_value != "IN":
+                continue
+            if visible_to is not None and not _is_visible(node, visible_to):
+                continue
+            in_nodes.append((nid, node.text))
+
+        total = len(in_nodes)
+        empty = {"negative": [], "count": 0, "candidates": 0, "total": total}
+
+        if not in_nodes:
+            return empty
+
+        candidates = []
+        for nid, text in in_nodes:
+            text_lower = text.lower()
+            if any(term in text_lower for term in NEGATIVE_TERMS):
+                candidates.append((nid, text))
+
+        if not candidates:
+            return empty
+
+        lines = [f"- [{nid}] {text}" for nid, text in candidates]
+        prompt = NEGATIVE_CLASSIFY_PROMPT.format(candidates="\n".join(lines))
+
+        response = ask._invoke_claude(prompt)
+
+        negative_ids = set()
+        for line in response.strip().split("\n"):
+            line = line.strip()
+            if not line.startswith("["):
+                continue
+            try:
+                ids = json.loads(line)
+                if isinstance(ids, list):
+                    negative_ids = set(ids)
+                    break
+            except json.JSONDecodeError:
+                continue
+
+        candidate_map = {nid: text for nid, text in candidates}
+        negative = [
+            {"id": nid, "text": candidate_map[nid]}
+            for nid in negative_ids
+            if nid in candidate_map
+        ]
+        negative.sort(key=lambda x: x["id"])
+
+        return {
+            "negative": negative,
+            "count": len(negative),
+            "candidates": len(candidates),
+            "total": total,
+        }
 
 
 def _rewrite_dependents(net, old_id: str, new_id: str):

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1575,17 +1575,14 @@ def list_negative(
         response = ask._invoke_claude(prompt)
 
         negative_ids = set()
-        for line in response.strip().split("\n"):
-            line = line.strip()
-            if not line.startswith("["):
-                continue
+        match = re.search(r"\[.*?\]", response, re.DOTALL)
+        if match:
             try:
-                ids = json.loads(line)
+                ids = json.loads(match.group())
                 if isinstance(ids, list):
                     negative_ids = set(ids)
-                    break
             except json.JSONDecodeError:
-                continue
+                pass
 
         candidate_map = {nid: text for nid, text in candidates}
         negative = [

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -940,6 +940,23 @@ def cmd_list_gated(args):
     print(f"{result['blocker_count']} blocker(s) gating {result['gated_count']} belief(s)")
 
 
+def cmd_list_negative(args):
+    result = api.list_negative(
+        visible_to=_parse_visible_to(args),
+        db_path=args.db,
+    )
+
+    if not result["negative"]:
+        print("No negative beliefs found.")
+        return
+
+    for item in result["negative"]:
+        print(f"  [-] {item['id']}: {item['text']}")
+
+    print(f"\n{result['count']} negative belief(s) "
+          f"({result['candidates']} candidates from {result['total']} IN nodes)")
+
+
 def cmd_namespaces(args):
     result = api.list_namespaces(db_path=args.db)
     if not result["namespaces"]:
@@ -1195,6 +1212,9 @@ def main():
     p = sub.add_parser("list-gated", help="List OUT nodes blocked by IN outlist nodes")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
 
+    p = sub.add_parser("list-negative", help="Find IN beliefs describing problems/defects/risks (LLM-classified)")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
+
     sub.add_parser("namespaces", help="List all agent namespaces in the database")
 
     # list
@@ -1254,6 +1274,7 @@ def main():
         "deduplicate": cmd_deduplicate,
         "list": cmd_list,
         "list-gated": cmd_list_gated,
+        "list-negative": cmd_list_negative,
         "namespaces": cmd_namespaces,
     }
     commands[args.command](args)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -353,6 +353,12 @@ class TestListNegative:
             assert result["count"] == 1
             assert result["negative"][0]["id"] == "a"
 
+    def test_claude_not_found_propagates(self, db_path):
+        api.add_node("a", "There is a critical bug here", db_path=db_path)
+        with patch("reasons_lib.ask._invoke_claude", side_effect=FileNotFoundError("'claude' CLI not found in PATH")):
+            with pytest.raises(FileNotFoundError):
+                api.list_negative(db_path=db_path)
+
     def test_visible_to(self, db_path):
         api.add_node("a", "Auth has a critical bug", access_tags=["internal"], db_path=db_path)
         api.add_node("b", "API has a missing validation", db_path=db_path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -346,6 +346,13 @@ class TestListNegative:
             result = api.list_negative(db_path=db_path)
             assert result["count"] == 0
 
+    def test_llm_returns_unknown_ids(self, db_path):
+        api.add_node("a", "There is a critical bug here", db_path=db_path)
+        with patch("reasons_lib.ask._invoke_claude", return_value='["a", "nonexistent", "also-fake"]'):
+            result = api.list_negative(db_path=db_path)
+            assert result["count"] == 1
+            assert result["negative"][0]["id"] == "a"
+
     def test_visible_to(self, db_path):
         api.add_node("a", "Auth has a critical bug", access_tags=["internal"], db_path=db_path)
         api.add_node("b", "API has a missing validation", db_path=db_path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -353,6 +353,14 @@ class TestListNegative:
             assert result["count"] == 1
             assert result["negative"][0]["id"] == "a"
 
+    def test_prose_with_brackets_before_json(self, db_path):
+        api.add_node("a", "There is a critical bug here", db_path=db_path)
+        response = 'Based on [the analysis], here are the negative beliefs: ["a"]'
+        with patch("reasons_lib.ask._invoke_claude", return_value=response):
+            result = api.list_negative(db_path=db_path)
+            assert result["count"] == 1
+            assert result["negative"][0]["id"] == "a"
+
     def test_claude_not_found_propagates(self, db_path):
         api.add_node("a", "There is a critical bug here", db_path=db_path)
         with patch("reasons_lib.ask._invoke_claude", side_effect=FileNotFoundError("'claude' CLI not found in PATH")):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 """Tests for the functional Python API."""
 
+from unittest.mock import patch
+
 import pytest
 
 from reasons_lib import api
@@ -290,3 +292,53 @@ class TestListGated:
         api.add_node("gated", "X is safe", sl="premise", unless="bug-123", db_path=db_path)
         result = api.list_gated(db_path=db_path)
         assert result["blockers"]["bug-123"]["text"] == "File X has a null check missing"
+
+
+class TestListNegative:
+
+    def test_empty_db(self, db_path):
+        with patch("reasons_lib.ask._invoke_claude") as mock_claude:
+            result = api.list_negative(db_path=db_path)
+            assert result == {"negative": [], "count": 0, "candidates": 0, "total": 0}
+            mock_claude.assert_not_called()
+
+    def test_no_keyword_matches(self, db_path):
+        api.add_node("a", "The sky is blue", db_path=db_path)
+        api.add_node("b", "Water flows downhill", db_path=db_path)
+        with patch("reasons_lib.ask._invoke_claude") as mock_claude:
+            result = api.list_negative(db_path=db_path)
+            assert result["count"] == 0
+            assert result["candidates"] == 0
+            assert result["total"] == 2
+            mock_claude.assert_not_called()
+
+    def test_classifies_negatives(self, db_path):
+        api.add_node("a", "The auth module has a bug in token refresh", db_path=db_path)
+        api.add_node("b", "Error handling logs all failures", db_path=db_path)
+        api.add_node("c", "The sky is blue", db_path=db_path)
+        with patch("reasons_lib.ask._invoke_claude", return_value='["a"]'):
+            result = api.list_negative(db_path=db_path)
+            assert result["count"] == 1
+            assert result["candidates"] == 2
+            assert result["total"] == 3
+            assert result["negative"][0]["id"] == "a"
+
+    def test_llm_filters_all(self, db_path):
+        api.add_node("a", "Error handling is comprehensive", db_path=db_path)
+        api.add_node("b", "Failure modes are well documented", db_path=db_path)
+        with patch("reasons_lib.ask._invoke_claude", return_value='[]'):
+            result = api.list_negative(db_path=db_path)
+            assert result["count"] == 0
+            assert result["candidates"] == 2
+            assert result["total"] == 2
+
+    def test_visible_to(self, db_path):
+        api.add_node("a", "Auth has a critical bug", access_tags=["internal"], db_path=db_path)
+        api.add_node("b", "API has a missing validation", db_path=db_path)
+        with patch("reasons_lib.ask._invoke_claude", return_value='["b"]') as mock_claude:
+            result = api.list_negative(visible_to=["public"], db_path=db_path)
+            assert result["count"] == 1
+            assert result["total"] == 1
+            assert result["negative"][0]["id"] == "b"
+            prompt = mock_claude.call_args[0][0]
+            assert "critical bug" not in prompt

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -332,6 +332,20 @@ class TestListNegative:
             assert result["candidates"] == 2
             assert result["total"] == 2
 
+    def test_multiline_json_response(self, db_path):
+        api.add_node("a", "There is a critical bug here", db_path=db_path)
+        api.add_node("b", "This has a missing check", db_path=db_path)
+        multiline = '[\n  "a",\n  "b"\n]'
+        with patch("reasons_lib.ask._invoke_claude", return_value=multiline):
+            result = api.list_negative(db_path=db_path)
+            assert result["count"] == 2
+
+    def test_malformed_llm_response(self, db_path):
+        api.add_node("a", "There is a critical bug here", db_path=db_path)
+        with patch("reasons_lib.ask._invoke_claude", return_value="Sorry, I cannot do that."):
+            result = api.list_negative(db_path=db_path)
+            assert result["count"] == 0
+
     def test_visible_to(self, db_path):
         api.add_node("a", "Auth has a critical bug", access_tags=["internal"], db_path=db_path)
         api.add_node("b", "API has a missing validation", db_path=db_path)


### PR DESCRIPTION
## Summary

- Adds `list-negative` command that finds IN beliefs describing problems, defects, or risks
- Uses keyword pre-filtering to reduce candidates, then `claude -p` for LLM classification
- Returns only genuinely negative beliefs, avoiding false positives from beliefs about error handling mechanisms
- Adds `list_negative()` to `api.py`, `cmd_list_negative` to `cli.py`, and 5 tests with mocked LLM

## Test plan

- [x] 5 new tests pass (empty db, no keyword matches, classifies negatives, filters all, visible_to)
- [x] Full test suite passes (622 tests, 0 failures)
- [ ] Manual test on redhat-expert database with real LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)