### PR TITLE
Add what_if_retract and what_if_assert to PgApi

### DIFF
--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -321,41 +321,41 @@ class PgApi:
 
     def what_if_retract(self, node_id):
         pid = self.project_id
-        with self.conn.cursor() as cur:
-            cur.execute(
-                "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
-                (node_id, pid),
-            )
-            row = cur.fetchone()
-            if not row:
-                self.conn.rollback()
-                raise KeyError(f"Node '{node_id}' not found")
-            if row[0] == "OUT":
-                self.conn.rollback()
-                return {
-                    "node_id": node_id, "already_out": True,
-                    "retracted": [], "restored": [], "total_affected": 0,
-                }
+        try:
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
+                    (node_id, pid),
+                )
+                row = cur.fetchone()
+                if not row:
+                    raise KeyError(f"Node '{node_id}' not found")
+                if row[0] == "OUT":
+                    return {
+                        "node_id": node_id, "already_out": True,
+                        "retracted": [], "restored": [], "total_affected": 0,
+                    }
 
-            cur.execute(
-                "SELECT id, truth_value FROM rms_nodes WHERE project_id = %s",
-                (pid,),
-            )
-            before = {r[0]: r[1] for r in cur.fetchall()}
+                cur.execute(
+                    "SELECT id, truth_value FROM rms_nodes WHERE project_id = %s",
+                    (pid,),
+                )
+                before = {r[0]: r[1] for r in cur.fetchall()}
 
-            cur.execute(
-                "UPDATE rms_nodes SET truth_value = 'OUT' "
-                "WHERE id = %s AND project_id = %s",
-                (node_id, pid),
-            )
-            went_out, went_in = self._propagate(cur, node_id)
+                cur.execute(
+                    "UPDATE rms_nodes SET truth_value = 'OUT' "
+                    "WHERE id = %s AND project_id = %s",
+                    (node_id, pid),
+                )
+                went_out, went_in = self._propagate(cur, node_id)
 
-            changed = went_out + went_in
-            retracted, restored = self._collect_what_if_results(
-                cur, changed, before, node_id,
-            )
+                changed = went_out + went_in
+                retracted, restored = self._collect_what_if_results(
+                    cur, changed, before, node_id,
+                )
+        finally:
+            self.conn.rollback()
 
-        self.conn.rollback()
         retracted.sort(key=lambda c: (c["depth"], c["id"]))
         restored.sort(key=lambda c: (c["depth"], c["id"]))
         return {
@@ -366,41 +366,41 @@ class PgApi:
 
     def what_if_assert(self, node_id):
         pid = self.project_id
-        with self.conn.cursor() as cur:
-            cur.execute(
-                "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
-                (node_id, pid),
-            )
-            row = cur.fetchone()
-            if not row:
-                self.conn.rollback()
-                raise KeyError(f"Node '{node_id}' not found")
-            if row[0] == "IN":
-                self.conn.rollback()
-                return {
-                    "node_id": node_id, "already_in": True,
-                    "retracted": [], "restored": [], "total_affected": 0,
-                }
+        try:
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
+                    (node_id, pid),
+                )
+                row = cur.fetchone()
+                if not row:
+                    raise KeyError(f"Node '{node_id}' not found")
+                if row[0] == "IN":
+                    return {
+                        "node_id": node_id, "already_in": True,
+                        "retracted": [], "restored": [], "total_affected": 0,
+                    }
 
-            cur.execute(
-                "SELECT id, truth_value FROM rms_nodes WHERE project_id = %s",
-                (pid,),
-            )
-            before = {r[0]: r[1] for r in cur.fetchall()}
+                cur.execute(
+                    "SELECT id, truth_value FROM rms_nodes WHERE project_id = %s",
+                    (pid,),
+                )
+                before = {r[0]: r[1] for r in cur.fetchall()}
 
-            cur.execute(
-                "UPDATE rms_nodes SET truth_value = 'IN' "
-                "WHERE id = %s AND project_id = %s",
-                (node_id, pid),
-            )
-            went_out, went_in = self._propagate(cur, node_id)
+                cur.execute(
+                    "UPDATE rms_nodes SET truth_value = 'IN' "
+                    "WHERE id = %s AND project_id = %s",
+                    (node_id, pid),
+                )
+                went_out, went_in = self._propagate(cur, node_id)
 
-            changed = went_out + went_in
-            retracted, restored = self._collect_what_if_results(
-                cur, changed, before, node_id,
-            )
+                changed = went_out + went_in
+                retracted, restored = self._collect_what_if_results(
+                    cur, changed, before, node_id,
+                )
+        finally:
+            self.conn.rollback()
 
-        self.conn.rollback()
         retracted.sort(key=lambda c: (c["depth"], c["id"]))
         restored.sort(key=lambda c: (c["depth"], c["id"]))
         return {

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -317,6 +317,143 @@ class PgApi:
         all_changed = [node_id] + went_out + went_in
         return {"changed": all_changed, "went_out": went_out, "went_in": [node_id] + went_in}
 
+    # ── What-if simulation ──────────────────────────────────────
+
+    def what_if_retract(self, node_id):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                self.conn.rollback()
+                raise KeyError(f"Node '{node_id}' not found")
+            if row[0] == "OUT":
+                self.conn.rollback()
+                return {
+                    "node_id": node_id, "already_out": True,
+                    "retracted": [], "restored": [], "total_affected": 0,
+                }
+
+            cur.execute(
+                "SELECT id, truth_value FROM rms_nodes WHERE project_id = %s",
+                (pid,),
+            )
+            before = {r[0]: r[1] for r in cur.fetchall()}
+
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = 'OUT' "
+                "WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            went_out, went_in = self._propagate(cur, node_id)
+
+            changed = went_out + went_in
+            retracted, restored = self._collect_what_if_results(
+                cur, changed, before, node_id,
+            )
+
+        self.conn.rollback()
+        retracted.sort(key=lambda c: (c["depth"], c["id"]))
+        restored.sort(key=lambda c: (c["depth"], c["id"]))
+        return {
+            "node_id": node_id, "already_out": False,
+            "retracted": retracted, "restored": restored,
+            "total_affected": len(retracted) + len(restored),
+        }
+
+    def what_if_assert(self, node_id):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                self.conn.rollback()
+                raise KeyError(f"Node '{node_id}' not found")
+            if row[0] == "IN":
+                self.conn.rollback()
+                return {
+                    "node_id": node_id, "already_in": True,
+                    "retracted": [], "restored": [], "total_affected": 0,
+                }
+
+            cur.execute(
+                "SELECT id, truth_value FROM rms_nodes WHERE project_id = %s",
+                (pid,),
+            )
+            before = {r[0]: r[1] for r in cur.fetchall()}
+
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = 'IN' "
+                "WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            went_out, went_in = self._propagate(cur, node_id)
+
+            changed = went_out + went_in
+            retracted, restored = self._collect_what_if_results(
+                cur, changed, before, node_id,
+            )
+
+        self.conn.rollback()
+        retracted.sort(key=lambda c: (c["depth"], c["id"]))
+        restored.sort(key=lambda c: (c["depth"], c["id"]))
+        return {
+            "node_id": node_id, "already_in": False,
+            "retracted": retracted, "restored": restored,
+            "total_affected": len(retracted) + len(restored),
+        }
+
+    def _collect_what_if_results(self, cur, changed, before, source_id):
+        pid = self.project_id
+        retracted = []
+        restored = []
+        if not changed:
+            return retracted, restored
+
+        cur.execute(
+            "SELECT id, text, truth_value FROM rms_nodes "
+            "WHERE project_id = %s AND id = ANY(%s)",
+            (pid, list(changed)),
+        )
+        after_states = {r[0]: (r[1], r[2]) for r in cur.fetchall()}
+
+        for nid in changed:
+            if nid not in after_states:
+                continue
+            text, new_tv = after_states[nid]
+            old_tv = before.get(nid)
+            if old_tv == new_tv:
+                continue
+            depth = self._cascade_depth_pg(cur, nid, source_id)
+            dep_count = len(self._find_dependents(cur, [nid]))
+            info = {"id": nid, "text": text, "depth": depth, "dependents": dep_count}
+            if old_tv == "IN" and new_tv == "OUT":
+                retracted.append(info)
+            elif old_tv == "OUT" and new_tv == "IN":
+                restored.append(info)
+        return retracted, restored
+
+    def _cascade_depth_pg(self, cur, target_id, source_id):
+        visited = {source_id}
+        queue = deque([(source_id, 0)])
+        while queue:
+            current_id, depth = queue.popleft()
+            deps = self._find_dependents(cur, [current_id])
+            for dep_id in deps:
+                if dep_id in visited:
+                    continue
+                if dep_id == target_id:
+                    return depth + 1
+                visited.add(dep_id)
+                queue.append((dep_id, depth + 1))
+        return 0
+
     # ── Dialectical operations ─────────────────────────────────
 
     def challenge(self, target_id, reason, challenge_id=None):

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -603,6 +603,7 @@ class TestWhatIf:
         result = pg_api.what_if_retract("blocker")
         assert len(result["restored"]) == 1
         assert result["restored"][0]["id"] == "gated"
+        assert result["restored"][0]["depth"] == 1
         # Verify no mutation
         status = pg_api.show_node("gated")
         assert status["truth_value"] == "OUT"

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -573,6 +573,26 @@ class TestWhatIf:
         assert result["already_in"] is True
         assert result["total_affected"] == 0
 
+    def test_what_if_assert_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.what_if_assert("missing")
+
+    def test_what_if_assert_no_mutation(self, pg_api):
+        pg_api.add_node("a", "Premise A")
+        pg_api.add_node("b", "Derived B", sl="a")
+        pg_api.retract_node("a")
+        pg_api.what_if_assert("a")
+        status = pg_api.get_status()
+        assert status["in_count"] == 0
+
+    def test_what_if_retract_dependents_field(self, pg_api):
+        pg_api.add_node("a", "Premise A")
+        pg_api.add_node("b", "Derived B", sl="a")
+        pg_api.add_node("c", "Derived C", sl="b")
+        result = pg_api.what_if_retract("a")
+        b_info = next(r for r in result["retracted"] if r["id"] == "b")
+        assert b_info["dependents"] == 1  # c depends on b
+
     def test_what_if_retract_with_outlist_restoration(self, pg_api):
         pg_api.add_node("premise", "Supporting premise")
         pg_api.add_node("blocker", "Blocker node")

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -524,6 +524,70 @@ class TestMultiTenancy:
             api2.close()
 
 
+class TestWhatIf:
+
+    def test_what_if_retract_cascade(self, pg_api):
+        pg_api.add_node("a", "Premise A")
+        pg_api.add_node("b", "Derived B", sl="a")
+        pg_api.add_node("c", "Derived C", sl="b")
+        result = pg_api.what_if_retract("a")
+        assert result["already_out"] is False
+        assert result["total_affected"] == 2
+        ids = [r["id"] for r in result["retracted"]]
+        assert "b" in ids
+        assert "c" in ids
+        assert result["retracted"][0]["depth"] == 1  # b
+        assert result["retracted"][1]["depth"] == 2  # c
+
+    def test_what_if_retract_already_out(self, pg_api):
+        pg_api.add_node("a", "Premise A")
+        pg_api.retract_node("a")
+        result = pg_api.what_if_retract("a")
+        assert result["already_out"] is True
+        assert result["total_affected"] == 0
+
+    def test_what_if_retract_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.what_if_retract("missing")
+
+    def test_what_if_retract_no_mutation(self, pg_api):
+        pg_api.add_node("a", "Premise A")
+        pg_api.add_node("b", "Derived B", sl="a")
+        pg_api.what_if_retract("a")
+        status = pg_api.get_status()
+        assert status["in_count"] == 2
+
+    def test_what_if_assert_restores(self, pg_api):
+        pg_api.add_node("a", "Premise A")
+        pg_api.add_node("b", "Derived B", sl="a")
+        pg_api.retract_node("a")
+        result = pg_api.what_if_assert("a")
+        assert result["already_in"] is False
+        assert result["total_affected"] == 1
+        assert result["restored"][0]["id"] == "b"
+        assert result["restored"][0]["depth"] == 1
+
+    def test_what_if_assert_already_in(self, pg_api):
+        pg_api.add_node("a", "Premise A")
+        result = pg_api.what_if_assert("a")
+        assert result["already_in"] is True
+        assert result["total_affected"] == 0
+
+    def test_what_if_retract_with_outlist_restoration(self, pg_api):
+        pg_api.add_node("premise", "Supporting premise")
+        pg_api.add_node("blocker", "Blocker node")
+        pg_api.add_node("gated", "Gated belief", sl="premise", unless="blocker")
+        # gated is OUT because blocker is IN
+        status = pg_api.show_node("gated")
+        assert status["truth_value"] == "OUT"
+        result = pg_api.what_if_retract("blocker")
+        assert len(result["restored"]) == 1
+        assert result["restored"][0]["id"] == "gated"
+        # Verify no mutation
+        status = pg_api.show_node("gated")
+        assert status["truth_value"] == "OUT"
+
+
 class TestChallenge:
 
     def test_challenge_premise(self, pg_api):


### PR DESCRIPTION
## Summary

- Adds `what_if_retract()` and `what_if_assert()` to PgApi for simulating cascade effects without mutating the database
- Uses transaction + ROLLBACK: runs the real retract/assert + propagation, collects before/after diffs, then rolls back
- Includes `_cascade_depth_pg()` for BFS depth computation and `_collect_what_if_results()` shared helper
- Returns `{node_id, already_out/in, retracted, restored, total_affected}` matching the SQLite API signatures

Closes #55

## Test plan

- [x] 7 new PG tests: cascade, already_out, not_found, no_mutation, assert_restores, already_in, outlist_restoration
- [x] Full PG suite passes (96 tests)
- [x] Full non-PG suite passes (627 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)