### PR TITLE
Route cmd_propagate through API layer

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -474,6 +474,12 @@ def assert_node(node_id: str, db_path: str = DEFAULT_DB) -> dict:
         return {"changed": changed, "went_out": went_out, "went_in": went_in}
 
 
+def propagate(db_path: str = DEFAULT_DB) -> dict:
+    with _with_network(db_path, write=True) as net:
+        changed = net.recompute_all()
+    return {"changed": changed}
+
+
 def get_status(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Get all nodes with truth values.
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -400,15 +400,8 @@ def cmd_trace(args):
 
 
 def cmd_propagate(args):
-    from .storage import Storage
-    store = Storage(args.db)
-    net = store.load()
-
-    changed = net.recompute_all()
-
-    store.save(net)
-    store.close()
-
+    result = api.propagate(db_path=args.db)
+    changed = result["changed"]
     if changed:
         print(f"Updated: {', '.join(changed)}")
     else:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,6 +89,30 @@ class TestAssertNode:
         assert result["changed"] == []
 
 
+class TestPropagate:
+
+    def test_no_changes(self, db_path):
+        api.add_node("a", "Premise A", db_path=db_path)
+        result = api.propagate(db_path=db_path)
+        assert result["changed"] == []
+
+    def test_with_changes(self, db_path):
+        api.add_node("a", "Premise A", db_path=db_path)
+        api.add_node("b", "Derived B", sl="a", db_path=db_path)
+        assert api.show_node("b", db_path=db_path)["truth_value"] == "IN"
+        api.retract_node("a", reason="test", db_path=db_path)
+        api.assert_node("a", db_path=db_path)
+        from reasons_lib.storage import Storage
+        store = Storage(db_path)
+        net = store.load()
+        net.nodes["b"].truth_value = "OUT"
+        store.save(net)
+        store.close()
+        result = api.propagate(db_path=db_path)
+        assert "b" in result["changed"]
+        assert api.show_node("b", db_path=db_path)["truth_value"] == "IN"
+
+
 class TestGetStatus:
 
     def test_empty(self, db_path):


### PR DESCRIPTION
## Summary

- Adds `api.propagate()` using the standard `_with_network` context manager pattern
- Updates `cmd_propagate` to delegate to `api.propagate()` instead of directly using Storage → Network
- Adds 2 API-level tests (`test_no_changes`, `test_with_changes`)

Fixes #59

## Test plan

- [x] `pytest tests/test_api.py::TestPropagate -v` — 2 new API tests pass
- [x] `pytest tests/test_cli.py -k propagate -v` — 2 existing CLI tests still pass (output format unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)