### PR TITLE
Add referential integrity checks for PgApi JSONB references

### DIFF
--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -151,6 +151,9 @@ class PgApi:
 
             justifications = self._parse_justifications(sl, cp, unless, label)
 
+            if justifications:
+                self._validate_refs(cur, justifications)
+
             for j in justifications:
                 cur.execute(
                     "INSERT INTO rms_justifications (node_id, project_id, type, antecedents, outlist, label) "
@@ -209,6 +212,8 @@ class PgApi:
             justifications = self._parse_justifications(sl, cp, unless, label)
             if not justifications:
                 raise ValueError("No justification specified (use --sl or --cp)")
+
+            self._validate_refs(cur, justifications)
 
             for j in justifications:
                 cur.execute(
@@ -1739,6 +1744,22 @@ class PgApi:
         return "\n".join(lines) if lines else "No results found."
 
     # ── Internal: helpers ───────────────────────────────────────
+
+    def _validate_refs(self, cur, justifications):
+        all_ids = set()
+        for j in justifications:
+            all_ids.update(j["antecedents"])
+            all_ids.update(j["outlist"])
+        if not all_ids:
+            return
+        cur.execute(
+            "SELECT id FROM rms_nodes WHERE project_id = %s AND id = ANY(%s)",
+            (self.project_id, list(all_ids)),
+        )
+        found = {row[0] for row in cur.fetchall()}
+        missing = all_ids - found
+        if missing:
+            raise KeyError(f"Referenced nodes do not exist: {', '.join(sorted(missing))}")
 
     def _parse_justifications(self, sl, cp, unless, label):
         justs = []

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -76,6 +76,16 @@ class TestRefIntegrity:
         with pytest.raises(KeyError, match="ghost"):
             pg_api.add_justification("a", sl="ghost")
 
+    def test_add_justification_phantom_outlist(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        with pytest.raises(KeyError, match="ghost"):
+            pg_api.add_justification("b", sl="a", unless="ghost")
+
+    def test_add_node_multiple_missing(self, pg_api):
+        with pytest.raises(KeyError, match="x.*y|y.*x"):
+            pg_api.add_node("b", "Derived B", sl="x,y")
+
     def test_add_node_valid_refs(self, pg_api):
         pg_api.add_node("a", "Alpha")
         pg_api.add_node("b", "Beta")

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -60,6 +60,33 @@ class TestAddNode:
         assert set(result["metadata"]["access_tags"]) == {"aws", "billing"}
 
 
+class TestRefIntegrity:
+
+    def test_add_node_phantom_antecedent(self, pg_api):
+        with pytest.raises(KeyError, match="ghost"):
+            pg_api.add_node("b", "Derived B", sl="ghost")
+
+    def test_add_node_phantom_outlist(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        with pytest.raises(KeyError, match="ghost"):
+            pg_api.add_node("b", "Derived B", sl="a", unless="ghost")
+
+    def test_add_justification_phantom_antecedent(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        with pytest.raises(KeyError, match="ghost"):
+            pg_api.add_justification("a", sl="ghost")
+
+    def test_add_node_valid_refs(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        result = pg_api.add_node("c", "Derived C", sl="a,b")
+        assert result["truth_value"] == "IN"
+
+    def test_add_node_premise_no_validation(self, pg_api):
+        result = pg_api.add_node("a", "Alpha premise")
+        assert result["truth_value"] == "IN"
+
+
 class TestRetractNode:
 
     def test_retract_premise(self, pg_api):


### PR DESCRIPTION
## Summary

- Adds `_validate_refs` helper that checks all antecedent/outlist node IDs exist in `rms_nodes` before inserting justifications
- Called from both `add_node` and `add_justification` — raises `KeyError` with the missing node IDs
- Premise nodes (no justifications) skip validation

Fixes #61

## Test plan

- [x] `test_add_node_phantom_antecedent` — SL referencing nonexistent node raises KeyError
- [x] `test_add_node_phantom_outlist` — unless referencing nonexistent node raises KeyError
- [x] `test_add_justification_phantom_antecedent` — add_justification with phantom ref raises KeyError
- [x] `test_add_node_valid_refs` — valid refs succeed (sanity check)
- [x] `test_add_node_premise_no_validation` — premise with no refs succeeds
- [x] Full pg test suite: 104 passed, 0 regressions

Generated with [Claude Code](https://claude.com/claude-code)