### PR TITLE
Add porter stemming and progressive query relaxation to FTS search

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1286,27 +1286,39 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
             return _format_markdown(net, matched_ids, neighbor_ids)
 
 
+def _fts_query(conn, terms: list[str]) -> list[str]:
+    fts_query = " ".join(f'"{t}"' for t in terms)
+    cursor = conn.execute(
+        "SELECT id FROM nodes_fts WHERE nodes_fts MATCH ? ORDER BY rank LIMIT 20",
+        (fts_query,),
+    )
+    return [row[0] for row in cursor.fetchall()]
+
+
 def _fts_search(query: str, db_path: str) -> list[str]:
-    """Search using FTS5 full-text index."""
+    """Search using FTS5 full-text index with porter stemming and progressive relaxation."""
     import sqlite3
+    from itertools import combinations
     try:
         conn = sqlite3.connect(db_path)
-        # FTS5 match: all terms must appear (implicit AND)
-        # Quote each term to avoid FTS syntax issues
-        terms = query.strip().split()
-        fts_query = " ".join(f'"{t}"' for t in terms if t)
-        if not fts_query:
+        terms = [t for t in query.strip().split() if t]
+        if not terms:
             conn.close()
             return []
-        cursor = conn.execute(
-            "SELECT id FROM nodes_fts WHERE nodes_fts MATCH ? ORDER BY rank LIMIT 20",
-            (fts_query,),
-        )
-        results = [row[0] for row in cursor.fetchall()]
+
+        results = _fts_query(conn, terms)
+
+        if not results and len(terms) > 2:
+            for n in range(len(terms) - 1, max(0, len(terms) - 3), -1):
+                for combo in combinations(terms, n):
+                    results = _fts_query(conn, list(combo))
+                    if results:
+                        conn.close()
+                        return results
+
         conn.close()
         return results
     except (sqlite3.OperationalError, sqlite3.DatabaseError):
-        # FTS table doesn't exist or query failed
         return []
 
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1301,23 +1301,23 @@ def _fts_search(query: str, db_path: str) -> list[str]:
     from itertools import combinations
     try:
         conn = sqlite3.connect(db_path)
-        terms = [t for t in query.strip().split() if t]
-        if not terms:
+        try:
+            terms = [t for t in query.strip().split() if t]
+            if not terms:
+                return []
+
+            results = _fts_query(conn, terms)
+
+            if not results and len(terms) > 2:
+                for n in range(len(terms) - 1, max(0, len(terms) - 3), -1):
+                    for combo in combinations(terms, n):
+                        results = _fts_query(conn, list(combo))
+                        if results:
+                            return results
+
+            return results
+        finally:
             conn.close()
-            return []
-
-        results = _fts_query(conn, terms)
-
-        if not results and len(terms) > 2:
-            for n in range(len(terms) - 1, max(0, len(terms) - 3), -1):
-                for combo in combinations(terms, n):
-                    results = _fts_query(conn, list(combo))
-                    if results:
-                        conn.close()
-                        return results
-
-        conn.close()
-        return results
     except (sqlite3.OperationalError, sqlite3.DatabaseError):
         return []
 

--- a/reasons_lib/storage.py
+++ b/reasons_lib/storage.py
@@ -57,7 +57,7 @@ CREATE TABLE IF NOT EXISTS network_meta (
     value TEXT NOT NULL
 );
 
-CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(id, text);
+CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(id, text, tokenize="porter unicode61");
 """
 
 
@@ -80,7 +80,8 @@ class Storage:
         with self.conn:
             # Clear and rewrite (simple strategy for small networks)
             self.conn.execute("DELETE FROM justifications")
-            self.conn.execute("DELETE FROM nodes_fts")
+            self.conn.execute("DROP TABLE IF EXISTS nodes_fts")
+            self.conn.execute("CREATE VIRTUAL TABLE nodes_fts USING fts5(id, text, tokenize='porter unicode61')")
             self.conn.execute("DELETE FROM nodes")
             self.conn.execute("DELETE FROM nogoods")
             self.conn.execute("DELETE FROM repos")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -271,9 +271,10 @@ class TestFtsSearch:
         assert "a" in result
 
     def test_porter_stemming_plural(self, db_path):
+        from reasons_lib.api import _fts_search
         api.add_node("a", "max 250 jobs per pipeline", db_path=db_path)
-        result = api.search("job", db_path=db_path)
-        assert "a" in result
+        results = _fts_search("job", db_path)
+        assert "a" in results
 
     def test_progressive_relaxation(self, db_path):
         api.add_node("a", "sandbox access expires after 21 days", db_path=db_path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -280,6 +280,11 @@ class TestFtsSearch:
         result = api.search("sandbox access duration expiration", db_path=db_path)
         assert "a" in result
 
+    def test_two_term_no_relaxation(self, db_path):
+        api.add_node("a", "sandbox access expires", db_path=db_path)
+        result = api.search("sandbox quantum", db_path=db_path, format="compact")
+        assert "a" not in result
+
     def test_no_false_positives(self, db_path):
         api.add_node("a", "the quick brown fox", db_path=db_path)
         result = api.search("quantum computing blockchain", db_path=db_path, format="compact")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -263,6 +263,29 @@ class TestListNodesDepth:
         assert ids == ["mid"]
 
 
+class TestFtsSearch:
+
+    def test_porter_stemming(self, db_path):
+        api.add_node("a", "sandbox access is auto-deactivated after 21 days", db_path=db_path)
+        result = api.search("deactivation", db_path=db_path)
+        assert "a" in result
+
+    def test_porter_stemming_plural(self, db_path):
+        api.add_node("a", "max 250 jobs per pipeline", db_path=db_path)
+        result = api.search("job", db_path=db_path)
+        assert "a" in result
+
+    def test_progressive_relaxation(self, db_path):
+        api.add_node("a", "sandbox access expires after 21 days", db_path=db_path)
+        result = api.search("sandbox access duration expiration", db_path=db_path)
+        assert "a" in result
+
+    def test_no_false_positives(self, db_path):
+        api.add_node("a", "the quick brown fox", db_path=db_path)
+        result = api.search("quantum computing blockchain", db_path=db_path, format="compact")
+        assert "a" not in result
+
+
 class TestListGated:
 
     def test_no_gates(self, db_path):


### PR DESCRIPTION
## Summary

- Adds porter stemmer to FTS5 index so word forms match their stems (e.g. "deactivation" matches "auto-deactivated")
- Adds progressive query relaxation: when strict AND returns nothing and query has >2 terms, drops terms one at a time until results are found
- Drop/recreate FTS table on save() to ensure existing databases get the new tokenizer

Fixes #72

## Test plan

- [x] `test_porter_stemming` — "deactivation" matches "deactivated"
- [x] `test_porter_stemming_plural` — "job" matches "jobs"
- [x] `test_progressive_relaxation` — 4-term query with 1 absent term still finds belief
- [x] `test_no_false_positives` — unrelated terms return nothing
- [x] Full test suite: 633 passed, 0 regressions

Generated with [Claude Code](https://claude.com/claude-code)