### PR TITLE
Resolve source paths relative to db directory for check-stale

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1098,19 +1098,23 @@ def check_stale(
 
     Returns: {"stale": list[dict], "checked": int, "stale_count": int}
     """
+    from pathlib import Path as P
     from .check_stale import check_stale as _check
 
-    repo_paths = None
-    if repos:
-        from pathlib import Path as P
-        repo_paths = {k: P(v) for k, v in repos.items()}
+    db_dir = P(db_path).resolve().parent
 
     with _with_network(db_path) as net:
+        repo_paths = repos
+        if repo_paths is None and net.repos:
+            repo_paths = net.repos
+        if repo_paths:
+            repo_paths = {k: P(v) for k, v in repo_paths.items()}
+
         in_with_source = sum(
             1 for n in net.nodes.values()
             if n.truth_value == "IN" and n.source and n.source_hash
         )
-        results = _check(net, repo_paths)
+        results = _check(net, repo_paths, db_dir=db_dir)
         return {
             "stale": results,
             "checked": in_with_source,
@@ -1127,15 +1131,19 @@ def hash_sources(
 
     Returns: {"hashed": list[dict], "count": int}
     """
+    from pathlib import Path as P
     from .check_stale import hash_sources as _hash
 
-    repo_paths = None
-    if repos:
-        from pathlib import Path as P
-        repo_paths = {k: P(v) for k, v in repos.items()}
+    db_dir = P(db_path).resolve().parent
 
     with _with_network(db_path, write=True) as net:
-        results = _hash(net, repo_paths, force=force)
+        repo_paths = repos
+        if repo_paths is None and net.repos:
+            repo_paths = net.repos
+        if repo_paths:
+            repo_paths = {k: P(v) for k, v in repo_paths.items()}
+
+        results = _hash(net, repo_paths, force=force, db_dir=db_dir)
         return {"hashed": results, "count": len(results)}
 
 

--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -16,18 +16,26 @@ def hash_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def resolve_source_path(source: str, repos: dict[str, Path] | None = None) -> Path | None:
+def resolve_source_path(
+    source: str,
+    repos: dict[str, Path] | None = None,
+    db_dir: Path | None = None,
+) -> Path | None:
     """Resolve a source string like 'repo-name/path/to/file.md' to an absolute path.
 
-    If repos is provided, uses it as a mapping of repo names to paths.
-    Otherwise tries ~/git/<repo-name>/path/to/file.md.
+    Tries db_dir first (for expert repos where sources live next to reasons.db),
+    then repos dict, then ~/git/<repo-name> fallback.
     """
     if not source:
         return None
 
+    if db_dir:
+        p = db_dir / source
+        if p.exists():
+            return p
+
     parts = source.split("/", 1)
     if len(parts) < 2:
-        # No slash — treat as a bare filename in current directory
         p = Path(source)
         return p if p.exists() else None
 
@@ -44,6 +52,7 @@ def resolve_source_path(source: str, repos: dict[str, Path] | None = None) -> Pa
 def check_stale(
     network: Network,
     repos: dict[str, Path] | None = None,
+    db_dir: Path | None = None,
 ) -> list[dict]:
     """Check all IN nodes for source staleness.
 
@@ -65,7 +74,7 @@ def check_stale(
         if not node.source or not node.source_hash:
             continue
 
-        path = resolve_source_path(node.source, repos)
+        path = resolve_source_path(node.source, repos, db_dir)
         if path is None:
             results.append({
                 "node_id": nid,
@@ -95,6 +104,7 @@ def hash_sources(
     network: Network,
     repos: dict[str, Path] | None = None,
     force: bool = False,
+    db_dir: Path | None = None,
 ) -> list[dict]:
     """Backfill source hashes for nodes that have a source path but no stored hash.
 
@@ -112,7 +122,7 @@ def hash_sources(
         if node.source_hash and not force:
             continue
 
-        path = resolve_source_path(node.source, repos)
+        path = resolve_source_path(node.source, repos, db_dir)
         if path is None:
             continue
 

--- a/tests/test_check_stale.py
+++ b/tests/test_check_stale.py
@@ -45,8 +45,49 @@ class TestResolveSourcePath:
         result = resolve_source_path("")
         assert result is None
 
+    def test_resolve_relative_to_db_dir(self, tmp_path):
+        entry_dir = tmp_path / "entries" / "2026"
+        entry_dir.mkdir(parents=True)
+        f = entry_dir / "topic.md"
+        f.write_text("content")
+        result = resolve_source_path("entries/2026/topic.md", db_dir=tmp_path)
+        assert result == f
+
+    def test_db_dir_takes_precedence(self, tmp_path):
+        db_dir = tmp_path / "expert"
+        repo_dir = tmp_path / "repo"
+        for d in (db_dir / "entries", repo_dir / "entries"):
+            d.mkdir(parents=True)
+        (db_dir / "entries" / "topic.md").write_text("db version")
+        (repo_dir / "entries" / "topic.md").write_text("repo version")
+        result = resolve_source_path("entries/topic.md", repos={"entries": repo_dir}, db_dir=db_dir)
+        assert result == db_dir / "entries" / "topic.md"
+
+    def test_falls_back_to_repo_when_not_in_db_dir(self, tmp_path):
+        db_dir = tmp_path / "expert"
+        db_dir.mkdir()
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        f = repo_dir / "file.md"
+        f.write_text("content")
+        result = resolve_source_path("myrepo/file.md", repos={"myrepo": repo_dir}, db_dir=db_dir)
+        assert result == f
+
 
 class TestCheckStale:
+
+    def test_fresh_node_via_db_dir(self, tmp_path):
+        entry_dir = tmp_path / "entries"
+        entry_dir.mkdir()
+        f = entry_dir / "topic.md"
+        f.write_text("original content")
+        h = hashlib.sha256(b"original content").hexdigest()
+
+        net = Network()
+        net.add_node("a", "Premise A", source="entries/topic.md", source_hash=h)
+
+        results = check_stale(net, db_dir=tmp_path)
+        assert results == []
 
     def test_fresh_node(self, tmp_path):
         f = tmp_path / "source.md"

--- a/tests/test_check_stale.py
+++ b/tests/test_check_stale.py
@@ -170,6 +170,20 @@ class TestCheckStale:
 
 class TestHashSources:
 
+    def test_backfills_via_db_dir(self, tmp_path):
+        entry_dir = tmp_path / "entries"
+        entry_dir.mkdir()
+        f = entry_dir / "topic.md"
+        f.write_text("content")
+
+        net = Network()
+        net.add_node("a", "Node A", source="entries/topic.md")
+
+        results = hash_sources(net, db_dir=tmp_path)
+        assert len(results) == 1
+        assert results[0]["node_id"] == "a"
+        assert net.nodes["a"].source_hash != ""
+
     def test_backfills_empty_hash(self, tmp_path):
         f = tmp_path / "source.md"
         f.write_text("content")


### PR DESCRIPTION
## Summary

- `resolve_source_path()` now tries the db directory first (where `reasons.db` lives), then falls back to configured repos or `~/git/<name>/`
- `api.check_stale()` and `api.hash_sources()` compute `db_dir` from `db_path` and pass it through
- Both API functions now also load `net.repos` from the database as fallback when no explicit repos parameter is given

Fixes #76

## Test plan

- [x] `test_resolve_relative_to_db_dir` — source found via db_dir
- [x] `test_db_dir_takes_precedence` — db_dir checked before repos
- [x] `test_falls_back_to_repo_when_not_in_db_dir` — repos used when not in db_dir
- [x] `test_fresh_node_via_db_dir` — end-to-end check_stale with db_dir
- [x] Full test suite: 638 passed, 0 regressions

Generated with [Claude Code](https://claude.com/claude-code)