### PR TITLE
Auto-register repo path on import-agent and sync-agent

### DIFF
--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -20,14 +20,21 @@ def resolve_source_path(
     source: str,
     repos: dict[str, Path] | None = None,
     db_dir: Path | None = None,
+    agent: str | None = None,
 ) -> Path | None:
     """Resolve a source string like 'repo-name/path/to/file.md' to an absolute path.
 
-    Tries db_dir first (for expert repos where sources live next to reasons.db),
-    then repos dict, then ~/git/<repo-name> fallback.
+    Tries agent repo first (for agent-imported beliefs where source is relative
+    to the agent's repo), then db_dir (for expert repos where sources live next
+    to reasons.db), then repos dict by first path component, then ~/git/ fallback.
     """
     if not source:
         return None
+
+    if agent and repos and agent in repos:
+        p = repos[agent] / source
+        if p.exists():
+            return p
 
     if db_dir:
         p = db_dir / source
@@ -66,6 +73,9 @@ def check_stale(
         {"node_id": str, "old_hash": str, "new_hash": None,
          "source": str, "source_path": None, "reason": "source_deleted"}
     """
+    if repos is None and network.repos:
+        repos = {k: Path(v) for k, v in network.repos.items()}
+
     results = []
 
     for nid, node in sorted(network.nodes.items()):
@@ -74,7 +84,8 @@ def check_stale(
         if not node.source or not node.source_hash:
             continue
 
-        path = resolve_source_path(node.source, repos, db_dir)
+        agent = node.metadata.get("agent") if node.metadata else None
+        path = resolve_source_path(node.source, repos, db_dir, agent=agent)
         if path is None:
             results.append({
                 "node_id": nid,
@@ -114,6 +125,9 @@ def hash_sources(
     Returns a list of dicts for each node that was hashed:
         {"node_id": str, "source": str, "hash": str, "was_empty": bool}
     """
+    if repos is None and network.repos:
+        repos = {k: Path(v) for k, v in network.repos.items()}
+
     results = []
 
     for nid, node in sorted(network.nodes.items()):
@@ -122,7 +136,8 @@ def hash_sources(
         if node.source_hash and not force:
             continue
 
-        path = resolve_source_path(node.source, repos, db_dir)
+        agent = node.metadata.get("agent") if node.metadata else None
+        path = resolve_source_path(node.source, repos, db_dir, agent=agent)
         if path is None:
             continue
 

--- a/reasons_lib/import_agent.py
+++ b/reasons_lib/import_agent.py
@@ -17,6 +17,8 @@ Usage:
     reasons sync-agent aap-expert ~/git/aap-expert/beliefs.md
 """
 
+from pathlib import Path
+
 from . import Justification, Nogood
 from .import_beliefs import parse_beliefs, parse_nogoods
 from .network import Network
@@ -270,6 +272,9 @@ def _import_claims(network, agent_name, claims, source_path, nogoods):
         network, agent_name, source_path
     )
 
+    if source_path:
+        network.repos[agent_name] = str(Path(source_path).resolve().parent)
+
     ordered = _topo_sort_claims(claims)
 
     imported = 0
@@ -335,6 +340,9 @@ def _sync_claims(network, agent_name, claims, source_path, nogoods):
     active_id, inactive_id, created_premise = _ensure_agent_nodes(
         network, agent_name, source_path
     )
+
+    if source_path:
+        network.repos[agent_name] = str(Path(source_path).resolve().parent)
 
     remote_ids = {f"{prefix}{c['id']}" for c in claims}
 

--- a/tests/test_check_stale.py
+++ b/tests/test_check_stale.py
@@ -63,6 +63,27 @@ class TestResolveSourcePath:
         result = resolve_source_path("entries/topic.md", repos={"entries": repo_dir}, db_dir=db_dir)
         assert result == db_dir / "entries" / "topic.md"
 
+    def test_resolve_via_agent_repo(self, tmp_path):
+        agent_dir = tmp_path / "agent-repo"
+        entry_dir = agent_dir / "entries" / "2026"
+        entry_dir.mkdir(parents=True)
+        f = entry_dir / "topic.md"
+        f.write_text("content")
+        repos = {"code": agent_dir}
+        result = resolve_source_path("entries/2026/topic.md", repos=repos, agent="code")
+        assert result == f
+
+    def test_agent_repo_takes_precedence_over_split(self, tmp_path):
+        agent_dir = tmp_path / "agent-repo"
+        entries_dir = tmp_path / "entries-repo"
+        for d in (agent_dir / "entries", entries_dir):
+            d.mkdir(parents=True)
+        (agent_dir / "entries" / "topic.md").write_text("agent version")
+        (entries_dir / "topic.md").write_text("entries version")
+        repos = {"code": agent_dir, "entries": entries_dir}
+        result = resolve_source_path("entries/topic.md", repos=repos, agent="code")
+        assert result == agent_dir / "entries" / "topic.md"
+
     def test_falls_back_to_repo_when_not_in_db_dir(self, tmp_path):
         db_dir = tmp_path / "expert"
         db_dir.mkdir()
@@ -166,6 +187,47 @@ class TestCheckStale:
 
         results = check_stale(net, repos={"r": tmp_path})
         assert len(results) == 2
+
+    def test_agent_imported_node_resolves_via_agent_repo(self, tmp_path):
+        agent_dir = tmp_path / "agent-repo"
+        entry_dir = agent_dir / "entries"
+        entry_dir.mkdir(parents=True)
+        f = entry_dir / "topic.md"
+        f.write_text("original content")
+        h = hashlib.sha256(b"original content").hexdigest()
+
+        net = Network()
+        net.repos["code"] = str(agent_dir)
+        net.add_node(
+            "code:topic-belief", "Topic belief",
+            source="entries/topic.md", source_hash=h,
+            metadata={"agent": "code"},
+        )
+
+        results = check_stale(net)
+        assert results == []
+
+    def test_agent_imported_node_detects_stale(self, tmp_path):
+        agent_dir = tmp_path / "agent-repo"
+        entry_dir = agent_dir / "entries"
+        entry_dir.mkdir(parents=True)
+        f = entry_dir / "topic.md"
+        f.write_text("original content")
+        h = hashlib.sha256(b"original content").hexdigest()
+
+        net = Network()
+        net.repos["code"] = str(agent_dir)
+        net.add_node(
+            "code:topic-belief", "Topic belief",
+            source="entries/topic.md", source_hash=h,
+            metadata={"agent": "code"},
+        )
+
+        f.write_text("updated content")
+        results = check_stale(net)
+        assert len(results) == 1
+        assert results[0]["node_id"] == "code:topic-belief"
+        assert results[0]["reason"] == "content_changed"
 
 
 class TestHashSources:

--- a/tests/test_import_agent.py
+++ b/tests/test_import_agent.py
@@ -448,6 +448,14 @@ def test_retracted_json_belief_survives_propagate(db, tmp_path):
     assert b["truth_value"] == "OUT", "dependent of retracted premise resurrected"
 
 
+def test_import_agent_registers_repo(db, beliefs_file):
+    api.import_agent("test-agent", beliefs_file, db_path=db)
+    repos = api.list_repos(db_path=db)["repos"]
+    assert "test-agent" in repos
+    from pathlib import Path
+    assert repos["test-agent"] == str(Path(beliefs_file).resolve().parent)
+
+
 def test_import_agent_nogoods(db, beliefs_file):
     result = api.import_agent("test-agent", beliefs_file, db_path=db)
     assert result["nogoods_imported"] == 1

--- a/tests/test_sync_agent.py
+++ b/tests/test_sync_agent.py
@@ -516,3 +516,17 @@ class TestSyncAgentRevocation:
 
         node = api.show_node("test-agent:alpha-fact", db_path=db)
         assert node["truth_value"] == "OUT"
+
+
+class TestSyncRegistersRepo:
+
+    def test_sync_registers_repo(self, initial_import):
+        db, tmp_path = initial_import
+        p = tmp_path / "beliefs.md"
+        p.write_text(INITIAL_BELIEFS)
+        api.sync_agent("test-agent", str(p), db_path=db)
+
+        repos = api.list_repos(db_path=db)["repos"]
+        assert "test-agent" in repos
+        from pathlib import Path
+        assert repos["test-agent"] == str(Path(str(p)).resolve().parent)


### PR DESCRIPTION
## Summary
- Sets `net.repos[agent_name]` to the parent directory of the beliefs file in both `_import_claims` and `_sync_claims`
- Eliminates the need for manual `reasons add-repo` calls after importing/syncing agent beliefs
- `check-stale` can now resolve source paths for agent-imported beliefs automatically

## Test plan
- [x] `uv run pytest tests/test_import_agent.py tests/test_sync_agent.py -v` — 38 passed
- [x] `uv run pytest tests/ -v` — 650 passed, 106 skipped

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)