### PR TITLE
Support configurable LLM providers

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1567,11 +1567,12 @@ If none are genuinely negative, return: []
 
 def list_negative(
     visible_to: list[str] | None = None,
+    model: str = "claude",
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """Find IN beliefs that describe problems, defects, or risks.
 
-    Uses keyword pre-filtering then LLM classification via claude -p.
+    Uses keyword pre-filtering then LLM classification via an LLM.
 
     Returns: {"negative": [{"id": str, "text": str}, ...],
               "count": int, "candidates": int, "total": int}
@@ -1605,7 +1606,8 @@ def list_negative(
         lines = [f"- [{nid}] `{text}`" for nid, text in candidates]
         prompt = NEGATIVE_CLASSIFY_PROMPT.format(candidates="\n".join(lines))
 
-        response = ask._invoke_claude(prompt)
+        from .llm import invoke_model
+        response = invoke_model(prompt, model=model)
 
         negative_ids = set()
         for match in re.finditer(r"\[.*?\]", response, re.DOTALL):

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -1,17 +1,16 @@
 """Ask natural language questions against a belief network.
 
 Uses FTS5 search to find relevant beliefs, then optionally synthesizes
-an answer via `claude -p` with a tool loop that allows the LLM to
+an answer via an LLM with a tool loop that allows the model to
 request additional belief searches.
 """
 
 import json
-import os
-import shutil
 import subprocess
 import sys
 
 from . import api
+from .llm import invoke_model
 
 
 ASK_PROMPT = """\
@@ -127,29 +126,8 @@ def build_final_prompt(question, beliefs_context, tool_history=None):
 
 
 def _invoke_claude(prompt, timeout=300):
-    """Call `claude -p` with the given prompt. Returns response text.
-
-    Raises FileNotFoundError if claude is not in PATH.
-    Raises RuntimeError if claude exits non-zero.
-    Raises subprocess.TimeoutExpired on timeout.
-    """
-    if not shutil.which("claude"):
-        raise FileNotFoundError("'claude' CLI not found in PATH")
-
-    # Strip CLAUDECODE to avoid recursive invocation inside Claude Code
-    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
-
-    result = subprocess.run(
-        ["claude", "-p"],
-        input=prompt,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        env=env,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"claude failed: {result.stderr}")
-    return result.stdout
+    """Call the default LLM (claude). Backward-compat wrapper."""
+    return invoke_model(prompt, model="claude", timeout=timeout)
 
 
 MAX_ITERATIONS = 3
@@ -163,7 +141,8 @@ def _beliefs_or_no_match(beliefs_context):
     return beliefs_context
 
 
-def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None):
+def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None,
+        model="claude"):
     """Answer a question using FTS5 belief search and optional LLM synthesis.
 
     Returns the answer text.
@@ -186,7 +165,7 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
               file=sys.stderr)
 
         try:
-            response = _invoke_claude(prompt, timeout=timeout)
+            response = invoke_model(prompt, model=model, timeout=timeout)
         except subprocess.TimeoutExpired:
             print(f"LLM timed out after {timeout}s", file=sys.stderr)
             return _beliefs_or_no_match(beliefs_context)
@@ -213,7 +192,7 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
             print(f"Synthesizing (final)...", file=sys.stderr)
             prompt = build_final_prompt(question, beliefs_context, tool_history)
             try:
-                response = _invoke_claude(prompt, timeout=timeout)
+                response = invoke_model(prompt, model=model, timeout=timeout)
             except subprocess.TimeoutExpired:
                 print(f"LLM timed out after {timeout}s", file=sys.stderr)
                 return _beliefs_or_no_match(beliefs_context)

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -632,6 +632,7 @@ def cmd_ask(args):
         timeout=args.timeout,
         no_synth=args.no_synth,
         format=getattr(args, "format", None),
+        model=args.model or "claude",
     )
     print(result)
 
@@ -693,9 +694,7 @@ def _derive_one_round(args, round_num=None):
 
     Used by cmd_derive for both single-round and --exhaust mode.
     """
-    import asyncio
-    import os
-    import shutil
+    import subprocess
 
     from .derive import (
         build_prompt,
@@ -751,44 +750,16 @@ def _derive_one_round(args, round_num=None):
 
     # Model invocation via CLI
     model = args.model or "claude"
-    model_commands = {
-        "claude": ["claude", "-p"],
-        "gemini": ["gemini", "-p", ""],
-    }
-
-    if model not in model_commands:
-        print(f"{prefix}Unknown model: {model}. Available: {list(model_commands.keys())}",
-              file=sys.stderr)
-        return -1
-
-    cmd = model_commands[model]
-    if not shutil.which(cmd[0]):
-        print(f"{prefix}Error: '{cmd[0]}' CLI not found in PATH", file=sys.stderr)
-        return -1
 
     print(f"{prefix}Deriving with {model}...", file=sys.stderr)
 
-    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
-
-    async def _invoke():
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
-        stdout, stderr = await asyncio.wait_for(
-            proc.communicate(prompt.encode()),
-            timeout=args.timeout,
-        )
-        if proc.returncode != 0:
-            raise RuntimeError(f"Model failed: {stderr.decode()}")
-        return stdout.decode()
-
+    from .llm import invoke_model
     try:
-        response = asyncio.run(_invoke())
-    except TimeoutError:
+        response = invoke_model(prompt, model=model, timeout=args.timeout)
+    except FileNotFoundError as e:
+        print(f"{prefix}Error: {e}", file=sys.stderr)
+        return -1
+    except subprocess.TimeoutExpired:
         print(f"{prefix}Model timed out after {args.timeout}s", file=sys.stderr)
         return -1
     except Exception as e:
@@ -947,6 +918,7 @@ def cmd_list_gated(args):
 def cmd_list_negative(args):
     result = api.list_negative(
         visible_to=_parse_visible_to(args),
+        model=getattr(args, "model", None) or "claude",
         db_path=args.db,
     )
 
@@ -1098,7 +1070,7 @@ def main():
     p.add_argument("-o", "--output", default="proposed-derivations.md",
                    help="Output file for proposals (default: proposed-derivations.md)")
     p.add_argument("-m", "--model", default=None,
-                   help="Model to use: claude or gemini (default: claude)")
+                   help="Model to use (default: claude). Use ollama:<model> for local models")
     p.add_argument("--auto", action="store_true",
                    help="Automatically add proposals (no review step)")
     p.add_argument("--dry-run", action="store_true",
@@ -1202,6 +1174,8 @@ def main():
                    help="Output format for --no-synth (default: compact)")
     p.add_argument("--timeout", type=int, default=300,
                    help="LLM timeout in seconds (default: 300)")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude). Use ollama:<model> for local models")
 
     # deduplicate
     p = sub.add_parser("deduplicate", help="Find and optionally retract duplicate IN beliefs")
@@ -1220,6 +1194,8 @@ def main():
 
     p = sub.add_parser("list-negative", help="Find IN beliefs describing problems/defects/risks (LLM-classified)")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude). Use ollama:<model> for local models")
 
     sub.add_parser("namespaces", help="List all agent namespaces in the database")
 

--- a/reasons_lib/llm.py
+++ b/reasons_lib/llm.py
@@ -1,0 +1,58 @@
+"""Shared LLM invocation via CLI subprocesses.
+
+Supports named models (claude, gemini) and ollama models via
+'ollama:<model>' syntax. All invocations pipe prompts to stdin
+and read responses from stdout.
+"""
+
+import os
+import shutil
+import subprocess
+
+
+MODEL_COMMANDS = {
+    "claude": ["claude", "-p"],
+    "gemini": ["gemini", "-p", ""],
+}
+
+
+def resolve_model_cmd(model: str) -> list[str]:
+    """Resolve a model name to a CLI command list.
+
+    Supports named models ('claude', 'gemini') and ollama models
+    via 'ollama:<model>' syntax (e.g. 'ollama:gemma3:4b').
+    """
+    if model in MODEL_COMMANDS:
+        return MODEL_COMMANDS[model]
+    if model.startswith("ollama:"):
+        ollama_model = model.split(":", 1)[1]
+        return ["ollama", "run", ollama_model]
+    available = list(MODEL_COMMANDS) + ["ollama:<model>"]
+    raise ValueError(f"Unknown model: {model}. Available: {available}")
+
+
+def invoke_model(prompt: str, model: str = "claude", timeout: int = 300) -> str:
+    """Invoke an LLM via CLI subprocess. Returns response text.
+
+    Raises FileNotFoundError if the model binary is not in PATH.
+    Raises RuntimeError if the model exits non-zero.
+    Raises subprocess.TimeoutExpired on timeout.
+    """
+    cmd = resolve_model_cmd(model)
+    binary = cmd[0]
+    if not shutil.which(binary):
+        raise FileNotFoundError(f"'{binary}' CLI not found in PATH")
+
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"{model} failed: {result.stderr}")
+    return result.stdout

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -350,26 +350,26 @@ class TestListGated:
 class TestListNegative:
 
     def test_empty_db(self, db_path):
-        with patch("reasons_lib.ask._invoke_claude") as mock_claude:
+        with patch("reasons_lib.llm.invoke_model") as mock_llm:
             result = api.list_negative(db_path=db_path)
             assert result == {"negative": [], "count": 0, "candidates": 0, "total": 0}
-            mock_claude.assert_not_called()
+            mock_llm.assert_not_called()
 
     def test_no_keyword_matches(self, db_path):
         api.add_node("a", "The sky is blue", db_path=db_path)
         api.add_node("b", "Water flows downhill", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude") as mock_claude:
+        with patch("reasons_lib.llm.invoke_model") as mock_llm:
             result = api.list_negative(db_path=db_path)
             assert result["count"] == 0
             assert result["candidates"] == 0
             assert result["total"] == 2
-            mock_claude.assert_not_called()
+            mock_llm.assert_not_called()
 
     def test_classifies_negatives(self, db_path):
         api.add_node("a", "The auth module has a bug in token refresh", db_path=db_path)
         api.add_node("b", "Error handling logs all failures", db_path=db_path)
         api.add_node("c", "The sky is blue", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude", return_value='["a"]'):
+        with patch("reasons_lib.llm.invoke_model", return_value='["a"]'):
             result = api.list_negative(db_path=db_path)
             assert result["count"] == 1
             assert result["candidates"] == 2
@@ -379,7 +379,7 @@ class TestListNegative:
     def test_llm_filters_all(self, db_path):
         api.add_node("a", "Error handling is comprehensive", db_path=db_path)
         api.add_node("b", "Failure modes are well documented", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude", return_value='[]'):
+        with patch("reasons_lib.llm.invoke_model", return_value='[]'):
             result = api.list_negative(db_path=db_path)
             assert result["count"] == 0
             assert result["candidates"] == 2
@@ -389,19 +389,19 @@ class TestListNegative:
         api.add_node("a", "There is a critical bug here", db_path=db_path)
         api.add_node("b", "This has a missing check", db_path=db_path)
         multiline = '[\n  "a",\n  "b"\n]'
-        with patch("reasons_lib.ask._invoke_claude", return_value=multiline):
+        with patch("reasons_lib.llm.invoke_model", return_value=multiline):
             result = api.list_negative(db_path=db_path)
             assert result["count"] == 2
 
     def test_malformed_llm_response(self, db_path):
         api.add_node("a", "There is a critical bug here", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude", return_value="Sorry, I cannot do that."):
+        with patch("reasons_lib.llm.invoke_model", return_value="Sorry, I cannot do that."):
             result = api.list_negative(db_path=db_path)
             assert result["count"] == 0
 
     def test_llm_returns_unknown_ids(self, db_path):
         api.add_node("a", "There is a critical bug here", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude", return_value='["a", "nonexistent", "also-fake"]'):
+        with patch("reasons_lib.llm.invoke_model", return_value='["a", "nonexistent", "also-fake"]'):
             result = api.list_negative(db_path=db_path)
             assert result["count"] == 1
             assert result["negative"][0]["id"] == "a"
@@ -409,24 +409,24 @@ class TestListNegative:
     def test_prose_with_brackets_before_json(self, db_path):
         api.add_node("a", "There is a critical bug here", db_path=db_path)
         response = 'Based on [the analysis], here are the negative beliefs: ["a"]'
-        with patch("reasons_lib.ask._invoke_claude", return_value=response):
+        with patch("reasons_lib.llm.invoke_model", return_value=response):
             result = api.list_negative(db_path=db_path)
             assert result["count"] == 1
             assert result["negative"][0]["id"] == "a"
 
     def test_claude_not_found_propagates(self, db_path):
         api.add_node("a", "There is a critical bug here", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude", side_effect=FileNotFoundError("'claude' CLI not found in PATH")):
+        with patch("reasons_lib.llm.invoke_model", side_effect=FileNotFoundError("'claude' CLI not found in PATH")):
             with pytest.raises(FileNotFoundError):
                 api.list_negative(db_path=db_path)
 
     def test_visible_to(self, db_path):
         api.add_node("a", "Auth has a critical bug", access_tags=["internal"], db_path=db_path)
         api.add_node("b", "API has a missing validation", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude", return_value='["b"]') as mock_claude:
+        with patch("reasons_lib.llm.invoke_model", return_value='["b"]') as mock_llm:
             result = api.list_negative(visible_to=["public"], db_path=db_path)
             assert result["count"] == 1
             assert result["total"] == 1
             assert result["negative"][0]["id"] == "b"
-            prompt = mock_claude.call_args[0][0]
+            prompt = mock_llm.call_args[0][0]
             assert "critical bug" not in prompt

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -165,7 +165,7 @@ class TestCmdAskNoSynth:
 class TestInvokeClaude:
 
     def test_claude_not_in_path(self):
-        with patch("shutil.which", return_value=None):
+        with patch("reasons_lib.llm.shutil.which", return_value=None):
             with pytest.raises(FileNotFoundError, match="claude"):
                 _invoke_claude("test prompt")
 
@@ -175,7 +175,7 @@ class TestAskNoBeliefs:
     def test_empty_network_llm_declines(self, db_path):
         run_cli("init", db_path=db_path)
         refusal = "I don't have enough beliefs in the network to answer this question."
-        with patch("reasons_lib.ask._invoke_claude", return_value=refusal):
+        with patch("reasons_lib.ask.invoke_model", return_value=refusal):
             result = ask("what is the meaning of life", db_path=db_path)
         assert "don't have enough beliefs" in result
 
@@ -183,20 +183,20 @@ class TestAskNoBeliefs:
         run_cli("init", db_path=db_path)
         run_cli("add", "alpha", "Alpha belief about propagation", db_path=db_path)
         refusal = "I don't have enough beliefs in the network to answer this question."
-        with patch("reasons_lib.ask._invoke_claude", return_value=refusal):
+        with patch("reasons_lib.ask.invoke_model", return_value=refusal):
             result = ask("zzzznonexistent", db_path=db_path)
         assert "don't have enough beliefs" in result
 
     def test_timeout_on_empty_returns_no_beliefs_message(self, db_path):
         run_cli("init", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude",
+        with patch("reasons_lib.ask.invoke_model",
                     side_effect=subprocess.TimeoutExpired("claude", 300)):
             result = ask("nothing matches", db_path=db_path)
         assert result == NO_BELIEFS_MSG
 
     def test_error_on_empty_returns_no_beliefs_message(self, db_path):
         run_cli("init", db_path=db_path)
-        with patch("reasons_lib.ask._invoke_claude",
+        with patch("reasons_lib.ask.invoke_model",
                     side_effect=RuntimeError("claude crashed")):
             result = ask("nothing matches", db_path=db_path)
         assert result == NO_BELIEFS_MSG
@@ -207,13 +207,13 @@ class TestAskNoBeliefs:
 
         calls = [0]
 
-        def mock_invoke(prompt, timeout=300):
+        def mock_invoke(prompt, model="claude", timeout=300):
             calls[0] += 1
             if calls[0] == 1:
                 return '{"tool": "search_beliefs", "query": "retraction"}'
             raise subprocess.TimeoutExpired("claude", 300)
 
-        with patch("reasons_lib.ask._invoke_claude", side_effect=mock_invoke):
+        with patch("reasons_lib.ask.invoke_model", side_effect=mock_invoke):
             result = ask("zzzznothing", db_path=db_path)
         assert "retraction" in result.lower()
         assert result != NO_BELIEFS_MSG
@@ -224,13 +224,13 @@ class TestAskNoBeliefs:
 
         calls = [0]
 
-        def mock_invoke(prompt, timeout=300):
+        def mock_invoke(prompt, model="claude", timeout=300):
             calls[0] += 1
             if calls[0] == 1:
                 return '{"tool": "search_beliefs", "query": "zzzznothing"}'
             raise subprocess.TimeoutExpired("claude", 300)
 
-        with patch("reasons_lib.ask._invoke_claude", side_effect=mock_invoke):
+        with patch("reasons_lib.ask.invoke_model", side_effect=mock_invoke):
             result = ask("propagation", db_path=db_path)
         assert "propagation" in result.lower()
         assert result != NO_BELIEFS_MSG
@@ -242,7 +242,7 @@ class TestAskWithMockedLLM:
         run_cli("init", db_path=db_path)
         run_cli("add", "a", "Alpha belief", db_path=db_path)
 
-        with patch("reasons_lib.ask._invoke_claude", return_value="The answer is alpha."):
+        with patch("reasons_lib.ask.invoke_model", return_value="The answer is alpha."):
             result = ask("what is alpha?", db_path=db_path)
         assert result == "The answer is alpha."
 
@@ -257,12 +257,12 @@ class TestAskWithMockedLLM:
         ]
         call_count = [0]
 
-        def mock_invoke(prompt, timeout=300):
+        def mock_invoke(prompt, model="claude", timeout=300):
             idx = call_count[0]
             call_count[0] += 1
             return responses[idx]
 
-        with patch("reasons_lib.ask._invoke_claude", side_effect=mock_invoke):
+        with patch("reasons_lib.ask.invoke_model", side_effect=mock_invoke):
             result = ask("how does retraction work?", db_path=db_path)
         assert "retraction" in result.lower() or "Retraction" in result
         assert call_count[0] == 2
@@ -273,13 +273,13 @@ class TestAskWithMockedLLM:
 
         calls = [0]
 
-        def mock_invoke(prompt, timeout=300):
+        def mock_invoke(prompt, model="claude", timeout=300):
             calls[0] += 1
             if calls[0] <= 3:
                 return '{"tool": "search_beliefs", "query": "more"}'
             return "The answer based on alpha [a]."
 
-        with patch("reasons_lib.ask._invoke_claude", side_effect=mock_invoke):
+        with patch("reasons_lib.ask.invoke_model", side_effect=mock_invoke):
             result = ask("alpha", db_path=db_path)
         assert calls[0] == 4
         assert "alpha" in result.lower()
@@ -289,7 +289,7 @@ class TestAskWithMockedLLM:
         run_cli("init", db_path=db_path)
         run_cli("add", "a", "Alpha belief", db_path=db_path)
 
-        with patch("reasons_lib.ask._invoke_claude",
+        with patch("reasons_lib.ask.invoke_model",
                     side_effect=subprocess.TimeoutExpired("claude", 300)):
             result = ask("alpha", db_path=db_path)
         assert "a" in result
@@ -298,7 +298,7 @@ class TestAskWithMockedLLM:
         run_cli("init", db_path=db_path)
         run_cli("add", "a", "Alpha belief", db_path=db_path)
 
-        with patch("reasons_lib.ask._invoke_claude",
+        with patch("reasons_lib.ask.invoke_model",
                     side_effect=RuntimeError("claude crashed")):
             result = ask("alpha", db_path=db_path)
         assert "a" in result
@@ -307,7 +307,7 @@ class TestAskWithMockedLLM:
         run_cli("init", db_path=db_path)
         run_cli("add", "a", "Alpha", db_path=db_path)
 
-        with patch("reasons_lib.ask._invoke_claude",
+        with patch("reasons_lib.ask.invoke_model",
                     return_value='{"tool": "unknown_tool", "query": "x"}'):
             result = ask("question", db_path=db_path)
         assert "unknown_tool" in result
@@ -318,13 +318,13 @@ class TestAskWithMockedLLM:
 
         calls = [0]
 
-        def mock_invoke(prompt, timeout=300):
+        def mock_invoke(prompt, model="claude", timeout=300):
             calls[0] += 1
             if calls[0] <= 3:
                 return '{"tool": "search_beliefs", "query": "more"}'
             raise subprocess.TimeoutExpired("claude", 300)
 
-        with patch("reasons_lib.ask._invoke_claude", side_effect=mock_invoke):
+        with patch("reasons_lib.ask.invoke_model", side_effect=mock_invoke):
             result = ask("alpha", db_path=db_path)
         assert calls[0] == 4
         assert "search_beliefs" not in result
@@ -334,7 +334,7 @@ class TestAskWithMockedLLM:
         run_cli("init", db_path=db_path)
         run_cli("add", "a", "Alpha belief", db_path=db_path)
 
-        with patch("reasons_lib.ask._invoke_claude",
+        with patch("reasons_lib.ask.invoke_model",
                     return_value='{"tool": "search_beliefs", "query": "more"}'):
             result = ask("alpha", db_path=db_path)
         assert "search_beliefs" not in result

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,72 @@
+"""Tests for the shared LLM invocation module."""
+
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib.llm import invoke_model, resolve_model_cmd
+
+
+class TestResolveModelCmd:
+
+    def test_resolve_claude(self):
+        assert resolve_model_cmd("claude") == ["claude", "-p"]
+
+    def test_resolve_gemini(self):
+        assert resolve_model_cmd("gemini") == ["gemini", "-p", ""]
+
+    def test_resolve_ollama_model(self):
+        assert resolve_model_cmd("ollama:gemma3:4b") == ["ollama", "run", "gemma3:4b"]
+
+    def test_resolve_ollama_with_tag(self):
+        assert resolve_model_cmd("ollama:qwen3.5:27b") == ["ollama", "run", "qwen3.5:27b"]
+
+    def test_resolve_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown model"):
+            resolve_model_cmd("gpt-4")
+
+
+class TestInvokeModel:
+
+    def test_missing_binary_raises(self):
+        with patch("reasons_lib.llm.shutil.which", return_value=None):
+            with pytest.raises(FileNotFoundError, match="not found in PATH"):
+                invoke_model("hello", model="claude")
+
+    def test_invokes_subprocess(self):
+        mock_result = type("Result", (), {"returncode": 0, "stdout": "response", "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result) as mock_run:
+            result = invoke_model("hello", model="claude", timeout=60)
+            assert result == "response"
+            mock_run.assert_called_once()
+            args = mock_run.call_args
+            assert args[0][0] == ["claude", "-p"]
+            assert args[1]["input"] == "hello"
+            assert args[1]["timeout"] == 60
+
+    def test_nonzero_exit_raises(self):
+        mock_result = type("Result", (), {"returncode": 1, "stdout": "", "stderr": "error msg"})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="claude failed"):
+                invoke_model("hello", model="claude")
+
+    def test_ollama_command(self):
+        mock_result = type("Result", (), {"returncode": 0, "stdout": "ollama response", "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/ollama"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result) as mock_run:
+            result = invoke_model("hello", model="ollama:gemma3:4b")
+            assert result == "ollama response"
+            args = mock_run.call_args
+            assert args[0][0] == ["ollama", "run", "gemma3:4b"]
+
+    def test_strips_claudecode_env(self):
+        mock_result = type("Result", (), {"returncode": 0, "stdout": "ok", "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result) as mock_run, \
+             patch.dict("os.environ", {"CLAUDECODE": "1", "HOME": "/home/test"}):
+            invoke_model("hello", model="claude")
+            env = mock_run.call_args[1]["env"]
+            assert "CLAUDECODE" not in env
+            assert "HOME" in env


### PR DESCRIPTION
## Summary
- Extract shared `invoke_model()` into `reasons_lib/llm.py`, replacing scattered subprocess logic in ask, derive, and list-negative
- Add `-m/--model` flag to `ask`, `derive`, and `list-negative` CLI commands
- Support `claude`, `gemini`, and `ollama:<model>` syntax (e.g., `ollama:gemma3:4b`, `ollama:qwen3.5:27b`)
- Remote ollama hosts work via `OLLAMA_HOST` env var (already supported by ollama CLI)

Closes #49

## Test plan
- [x] All 668 tests pass (106 skipped — postgres tests)
- [x] New `tests/test_llm.py` covers resolve_model_cmd and invoke_model (10 tests)
- [x] Updated mocks in test_ask.py and test_api.py for new invocation path
- [ ] Manual: `reasons ask "what is retraction?" -m claude`
- [ ] Manual: `reasons ask "what is retraction?" -m ollama:gemma3:4b` (if ollama available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)