### PR TITLE
Batch list-negative LLM classification

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -9,6 +9,7 @@ All functions return dicts suitable for JSON serialization.
 
 import json
 import re
+import sys
 from pathlib import Path
 
 from . import Justification
@@ -1534,6 +1535,8 @@ def list_gated(
         return {"blockers": blockers, "gated_count": gated_count, "blocker_count": len(blockers)}
 
 
+NEGATIVE_BATCH_SIZE = 50
+
 NEGATIVE_TERMS = [
     'bug', 'defect', 'missing', 'fail', 'error', 'broken', 'incorrect',
     'wrong', 'risk', 'gap', 'lack', 'vulnerable', 'insecure', 'stale',
@@ -1603,21 +1606,29 @@ def list_negative(
         if not candidates:
             return empty
 
-        lines = [f"- [{nid}] `{text}`" for nid, text in candidates]
-        prompt = NEGATIVE_CLASSIFY_PROMPT.format(candidates="\n".join(lines))
-
         from .llm import invoke_model
-        response = invoke_model(prompt, model=model)
 
         negative_ids = set()
-        for match in re.finditer(r"\[.*?\]", response, re.DOTALL):
-            try:
-                ids = json.loads(match.group())
-                if isinstance(ids, list):
-                    negative_ids = set(ids)
-                    break
-            except json.JSONDecodeError:
-                continue
+        total_batches = (len(candidates) + NEGATIVE_BATCH_SIZE - 1) // NEGATIVE_BATCH_SIZE
+        for i in range(0, len(candidates), NEGATIVE_BATCH_SIZE):
+            batch = candidates[i:i + NEGATIVE_BATCH_SIZE]
+            lines = [f"- [{nid}] `{text}`" for nid, text in batch]
+            prompt = NEGATIVE_CLASSIFY_PROMPT.format(candidates="\n".join(lines))
+
+            batch_num = i // NEGATIVE_BATCH_SIZE + 1
+            print(f"  Classifying batch {batch_num}/{total_batches} "
+                  f"({len(batch)} candidates)...", file=sys.stderr)
+
+            response = invoke_model(prompt, model=model)
+
+            for match in re.finditer(r"\[.*?\]", response, re.DOTALL):
+                try:
+                    ids = json.loads(match.group())
+                    if isinstance(ids, list):
+                        negative_ids.update(ids)
+                        break
+                except json.JSONDecodeError:
+                    continue
 
         candidate_map = {nid: text for nid, text in candidates}
         negative = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -430,3 +430,34 @@ class TestListNegative:
             assert result["negative"][0]["id"] == "b"
             prompt = mock_llm.call_args[0][0]
             assert "critical bug" not in prompt
+
+    def test_single_batch_calls_llm_once(self, db_path):
+        for i in range(5):
+            api.add_node(f"bug-{i}", f"There is a bug in module {i}", db_path=db_path)
+        with patch("reasons_lib.llm.invoke_model", return_value='["bug-0"]') as mock_llm:
+            result = api.list_negative(db_path=db_path)
+            assert mock_llm.call_count == 1
+            assert result["count"] == 1
+
+    def test_batching_large_set(self, db_path):
+        for i in range(120):
+            api.add_node(f"bug-{i:03d}", f"There is a bug in module {i}", db_path=db_path)
+
+        call_count = [0]
+
+        def mock_invoke(prompt, model="claude"):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return '["bug-010", "bug-020"]'
+            elif call_count[0] == 2:
+                return '["bug-060"]'
+            else:
+                return '[]'
+
+        with patch("reasons_lib.llm.invoke_model", side_effect=mock_invoke):
+            result = api.list_negative(db_path=db_path)
+        assert call_count[0] == 3
+        assert result["count"] == 3
+        assert result["candidates"] == 120
+        found_ids = {n["id"] for n in result["negative"]}
+        assert found_ids == {"bug-010", "bug-020", "bug-060"}


### PR DESCRIPTION
## Summary
- Split keyword-matched candidates into chunks of 50 for LLM classification
- Each batch gets a separate `invoke_model()` call with progress output to stderr
- Results merged by set union of negative IDs across batches
- Prevents timeouts on large networks (596+ IN beliefs)

Closes #87

## Test plan
- [x] All 670 tests pass (106 skipped -- postgres tests)
- [x] New `test_single_batch_calls_llm_once` -- verifies <50 candidates = 1 LLM call
- [x] New `test_batching_large_set` -- 120 candidates split into 3 batches, IDs merged correctly
- [x] All 10 existing TestListNegative tests still pass unchanged
- [ ] Manual: `reasons list-negative` on expert repo (596 IN beliefs)

Generated with [Claude Code](https://claude.com/claude-code)