### PR TITLE
Support claude:<model> syntax for submodel selection

### DIFF
--- a/reasons_lib/llm.py
+++ b/reasons_lib/llm.py
@@ -1,8 +1,9 @@
 """Shared LLM invocation via CLI subprocesses.
 
-Supports named models (claude, gemini) and ollama models via
-'ollama:<model>' syntax. All invocations pipe prompts to stdin
-and read responses from stdout.
+Supports named models (claude, gemini), Claude submodels via
+'claude:<model>' syntax, and ollama models via 'ollama:<model>'
+syntax. All invocations pipe prompts to stdin and read responses
+from stdout.
 """
 
 import os
@@ -19,15 +20,19 @@ MODEL_COMMANDS = {
 def resolve_model_cmd(model: str) -> list[str]:
     """Resolve a model name to a CLI command list.
 
-    Supports named models ('claude', 'gemini') and ollama models
+    Supports named models ('claude', 'gemini'), Claude submodels
+    via 'claude:<model>' (e.g. 'claude:sonnet'), and ollama models
     via 'ollama:<model>' syntax (e.g. 'ollama:gemma3:4b').
     """
     if model in MODEL_COMMANDS:
         return MODEL_COMMANDS[model]
+    if model.startswith("claude:"):
+        submodel = model.split(":", 1)[1]
+        return ["claude", "-p", "--model", submodel]
     if model.startswith("ollama:"):
         ollama_model = model.split(":", 1)[1]
         return ["ollama", "run", ollama_model]
-    available = list(MODEL_COMMANDS) + ["ollama:<model>"]
+    available = list(MODEL_COMMANDS) + ["claude:<model>", "ollama:<model>"]
     raise ValueError(f"Unknown model: {model}. Available: {available}")
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -21,6 +21,12 @@ class TestResolveModelCmd:
     def test_resolve_ollama_with_tag(self):
         assert resolve_model_cmd("ollama:qwen3.5:27b") == ["ollama", "run", "qwen3.5:27b"]
 
+    def test_resolve_claude_submodel(self):
+        assert resolve_model_cmd("claude:sonnet") == ["claude", "-p", "--model", "sonnet"]
+
+    def test_resolve_claude_submodel_full_name(self):
+        assert resolve_model_cmd("claude:claude-sonnet-4-6") == ["claude", "-p", "--model", "claude-sonnet-4-6"]
+
     def test_resolve_unknown_raises(self):
         with pytest.raises(ValueError, match="Unknown model"):
             resolve_model_cmd("gpt-4")


### PR DESCRIPTION
## Summary
- Add `claude:<model>` syntax to `resolve_model_cmd()` (e.g., `claude:sonnet`, `claude:haiku`, `claude:claude-sonnet-4-6`)
- Passes `--model <submodel>` to the `claude -p` CLI
- Follows the same colon pattern as `ollama:<model>`

## Test plan
- [x] `test_resolve_claude_submodel` — `claude:sonnet` resolves to `["claude", "-p", "--model", "sonnet"]`
- [x] `test_resolve_claude_submodel_full_name` — `claude:claude-sonnet-4-6` works
- [x] Manual: `echo "test" | claude -p --model sonnet` and `--model haiku` both work
- [x] All 12 test_llm.py tests pass

Generated with [Claude Code](https://claude.com/claude-code)