### PR TITLE
Add --simple mode to reasons ask for smaller models

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1231,11 +1231,12 @@ def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
         return "\n".join(parts)
 
 
-def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB, format: str = "markdown") -> str:
+def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+           format: str = "markdown", depth: int = 1) -> str:
     """Search nodes using full-text search with neighbor expansion.
 
     Uses SQLite FTS5 for ranked all-terms matching. Returns matched nodes
-    plus their immediate neighbors (dependencies and dependents) formatted
+    plus their neighbors (dependencies and dependents) formatted
     as readable markdown.
 
     Falls back to substring matching if FTS5 table is not available.
@@ -1245,6 +1246,7 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
         visible_to: only return nodes whose access_tags are a subset
         db_path: path to RMS database
         format: output format — "markdown" (default), "json", or "minimal"
+        depth: number of hops to expand along justification chains (default: 1)
 
     Returns: formatted string with matched nodes and neighbors
     """
@@ -1267,20 +1269,27 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
             if not matched_ids:
                 return "No results found."
 
-        # Expand to include neighbors (1-hop in dependency graph)
+        # Expand to include neighbors (BFS along dependency graph)
         neighbor_ids = set()
-        for nid in matched_ids:
-            if nid in net.nodes:
+        frontier = set(matched_ids)
+        visited = set(matched_ids)
+        for _ in range(depth):
+            next_frontier = set()
+            for nid in frontier:
+                if nid not in net.nodes:
+                    continue
                 node = net.nodes[nid]
-                # Dependencies (antecedents from justifications)
                 for j in node.justifications:
                     for ant_id in j.antecedents:
-                        if ant_id in net.nodes:
+                        if ant_id in net.nodes and ant_id not in visited:
                             neighbor_ids.add(ant_id)
-                # Dependents (nodes that depend on this one)
+                            next_frontier.add(ant_id)
                 for dep_id in node.dependents:
-                    if dep_id in net.nodes:
+                    if dep_id in net.nodes and dep_id not in visited:
                         neighbor_ids.add(dep_id)
+                        next_frontier.add(dep_id)
+            visited |= next_frontier
+            frontier = next_frontier
 
         # Remove already-matched nodes from neighbors
         neighbor_ids -= set(matched_ids)

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -181,9 +181,9 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
         fmt = format or "compact"
         return api.search(question, db_path=db_path, format=fmt)
 
-    beliefs_context = api.search(question, db_path=db_path, format="markdown")
-
     if simple:
+        beliefs_context = api.search(question, db_path=db_path, format="markdown",
+                                     depth=2)
         if not beliefs_context or beliefs_context.strip() == "No results found.":
             return NO_BELIEFS_MSG
         prompt = build_simple_prompt(question, beliefs_context)
@@ -197,6 +197,8 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
             print(f"LLM error: {e}", file=sys.stderr)
             return _beliefs_or_no_match(beliefs_context)
         return response.strip()
+
+    beliefs_context = api.search(question, db_path=db_path, format="markdown")
 
     tool_history = []
 

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -68,6 +68,36 @@ Rules:
 {tool_history}"""
 
 
+SIMPLE_ASK_PROMPT = """\
+You are answering a question using a belief network (a Truth Maintenance System).
+Each belief has an ID, text, truth value (IN = held true, OUT = retracted), and
+may have justifications tracing why it is believed.
+
+Rules:
+- Cite belief IDs in [brackets] when referencing specific beliefs.
+- ONLY answer based on the beliefs provided. Do NOT use your training data or
+  general knowledge to fill gaps.
+- If the beliefs are insufficient to answer, respond EXACTLY with:
+  "I don't have enough beliefs in the network to answer this question."
+  Do NOT attempt a partial or speculative answer.
+
+## Question
+
+{question}
+
+## Belief matches
+
+{beliefs_context}"""
+
+
+def build_simple_prompt(question, beliefs_context):
+    """Build prompt for simple single-pass synthesis — no tool definitions."""
+    return SIMPLE_ASK_PROMPT.format(
+        question=question,
+        beliefs_context=beliefs_context,
+    )
+
+
 def extract_tool_call(text):
     """Extract a tool call from LLM response text.
 
@@ -142,7 +172,7 @@ def _beliefs_or_no_match(beliefs_context):
 
 
 def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None,
-        model="claude"):
+        model="claude", simple=False):
     """Answer a question using FTS5 belief search and optional LLM synthesis.
 
     Returns the answer text.
@@ -152,6 +182,21 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
         return api.search(question, db_path=db_path, format=fmt)
 
     beliefs_context = api.search(question, db_path=db_path, format="markdown")
+
+    if simple:
+        if not beliefs_context or beliefs_context.strip() == "No results found.":
+            return NO_BELIEFS_MSG
+        prompt = build_simple_prompt(question, beliefs_context)
+        print("Synthesizing (simple)...", file=sys.stderr)
+        try:
+            response = invoke_model(prompt, model=model, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            print(f"LLM timed out after {timeout}s", file=sys.stderr)
+            return _beliefs_or_no_match(beliefs_context)
+        except Exception as e:
+            print(f"LLM error: {e}", file=sys.stderr)
+            return _beliefs_or_no_match(beliefs_context)
+        return response.strip()
 
     tool_history = []
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -633,6 +633,7 @@ def cmd_ask(args):
         no_synth=args.no_synth,
         format=getattr(args, "format", None),
         model=args.model or "claude",
+        simple=args.simple,
     )
     print(result)
 
@@ -1176,6 +1177,8 @@ def main():
                    help="LLM timeout in seconds (default: 300)")
     p.add_argument("-m", "--model", default=None,
                    help="Model to use (default: claude). Use ollama:<model> for local models")
+    p.add_argument("--simple", action="store_true",
+                   help="Single-pass synthesis with pre-retrieved beliefs (better for smaller models)")
 
     # deduplicate
     p = sub.add_parser("deduplicate", help="Find and optionally retract duplicate IN beliefs")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -291,6 +291,28 @@ class TestFtsSearch:
         result = api.search("quantum computing blockchain", db_path=db_path, format="compact")
         assert "a" not in result
 
+    def test_depth_1_includes_direct_antecedents(self, db_path):
+        api.add_node("premise", "Propagation uses BFS", db_path=db_path)
+        api.add_node("derived", "Propagation is safe", sl="premise", db_path=db_path)
+        result = api.search("safe", db_path=db_path, format="compact", depth=1)
+        assert "premise" in result
+
+    def test_depth_2_includes_transitive_antecedents(self, db_path):
+        api.add_node("root", "BFS traversal algorithm", db_path=db_path)
+        api.add_node("mid", "Propagation uses BFS", sl="root", db_path=db_path)
+        api.add_node("leaf", "Propagation is safe", sl="mid", db_path=db_path)
+        result_d1 = api.search("safe", db_path=db_path, format="compact", depth=1)
+        result_d2 = api.search("safe", db_path=db_path, format="compact", depth=2)
+        assert "root" not in result_d1
+        assert "root" in result_d2
+
+    def test_depth_0_no_expansion(self, db_path):
+        api.add_node("premise", "Propagation uses BFS", db_path=db_path)
+        api.add_node("derived", "Propagation is safe", sl="premise", db_path=db_path)
+        result = api.search("safe", db_path=db_path, format="compact", depth=0)
+        assert "premise" not in result
+        assert "derived" in result
+
 
 class TestListGated:
 

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from reasons_lib.ask import extract_tool_call, build_ask_prompt, build_final_prompt, ask, _invoke_claude, NO_BELIEFS_MSG
+from reasons_lib.ask import extract_tool_call, build_ask_prompt, build_final_prompt, build_simple_prompt, ask, _invoke_claude, NO_BELIEFS_MSG
 from reasons_lib.cli import main
 
 
@@ -339,3 +339,63 @@ class TestAskWithMockedLLM:
             result = ask("alpha", db_path=db_path)
         assert "search_beliefs" not in result
         assert "Alpha" in result or result == NO_BELIEFS_MSG
+
+
+class TestBuildSimplePrompt:
+
+    def test_contains_question_and_context(self):
+        prompt = build_simple_prompt("What is BFS?", "Some belief context")
+        assert "What is BFS?" in prompt
+        assert "Some belief context" in prompt
+
+    def test_no_tool_definition(self):
+        prompt = build_simple_prompt("question", "context")
+        assert "search_beliefs" not in prompt
+        assert '"tool"' not in prompt
+
+
+class TestAskSimple:
+
+    def test_simple_direct_answer(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief about propagation", db_path=db_path)
+
+        with patch("reasons_lib.ask.invoke_model",
+                    return_value="Propagation uses BFS [a].") as mock_llm:
+            result = ask("propagation", db_path=db_path, simple=True)
+        assert result == "Propagation uses BFS [a]."
+        assert mock_llm.call_count == 1
+
+    def test_simple_no_results(self, db_path):
+        run_cli("init", db_path=db_path)
+        result = ask("zzzznonexistent", db_path=db_path, simple=True)
+        assert result == NO_BELIEFS_MSG
+
+    def test_simple_timeout_returns_beliefs(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        with patch("reasons_lib.ask.invoke_model",
+                    side_effect=subprocess.TimeoutExpired("claude", 300)):
+            result = ask("alpha", db_path=db_path, simple=True)
+        assert "Alpha" in result
+
+    def test_simple_error_returns_beliefs(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        with patch("reasons_lib.ask.invoke_model",
+                    side_effect=RuntimeError("model crashed")):
+            result = ask("alpha", db_path=db_path, simple=True)
+        assert "Alpha" in result
+
+    def test_simple_prompt_has_no_tool_definition(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        with patch("reasons_lib.ask.invoke_model",
+                    return_value="Answer.") as mock_llm:
+            ask("alpha", db_path=db_path, simple=True)
+        prompt = mock_llm.call_args[0][0]
+        assert "search_beliefs" not in prompt
+        assert '"tool"' not in prompt


### PR DESCRIPTION
## Summary
- Add `--simple` flag to `reasons ask` that bypasses the agentic tool-call loop
- System-driven FTS5 retrieval + single-pass LLM synthesis (no `search_beliefs` tool calls)
- Same fallback behavior on LLM errors (returns raw beliefs)
- Designed for smaller models (Sonnet, Haiku, ollama) that cannot reliably execute the iterative search protocol

Closes #90

## Usage

```bash
reasons ask "how does retraction work?" --simple -m claude:haiku
reasons ask "what is propagation?" --simple -m ollama:gemma3:4b
```

## Test plan
- [x] All 679 tests pass (106 skipped -- postgres tests)
- [x] 7 new tests: `TestBuildSimplePrompt` (2) + `TestAskSimple` (5)
- [x] Verifies: single LLM call, no tool definitions in prompt, fallback on timeout/error, NO_BELIEFS_MSG on empty
- [ ] Manual: `reasons ask "how does retraction work?" --simple -m claude:haiku`

Generated with [Claude Code](https://claude.com/claude-code)