### PR TITLE
Add review-beliefs command (#96)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1690,6 +1690,89 @@ def list_negative(
         }
 
 
+def review_beliefs(
+    belief_ids: list[str] | None = None,
+    model: str = "claude",
+    timeout: int = 300,
+    min_depth: int | None = None,
+    depends_on: str | None = None,
+    sample: int | None = None,
+    visible_to: list[str] | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Review derived beliefs for validity, sufficiency, and necessity.
+
+    Uses an LLM to evaluate whether each derived belief's reasoning
+    from antecedents to conclusion is sound.
+
+    Returns: {"results": [...], "reviewed": int, "invalid": int,
+              "insufficient": int, "unnecessary": int, "total_derived": int}
+    """
+    from .derive import _get_depth
+    from .review import review_beliefs as _review
+
+    result = export_network(db_path=db_path)
+    nodes = result.get("nodes", {})
+
+    all_derived = {
+        k: v for k, v in nodes.items()
+        if v.get("truth_value") == "IN"
+        and v.get("justifications")
+        and len(v["justifications"]) > 0
+    }
+    total_derived = len(all_derived)
+
+    candidates = dict(all_derived)
+
+    if belief_ids:
+        candidates = {k: v for k, v in candidates.items() if k in belief_ids}
+
+    if visible_to is not None:
+        tags = set(visible_to)
+        candidates = {
+            k: v for k, v in candidates.items()
+            if not v.get("metadata", {}).get("access_tags")
+            or all(t in tags for t in v["metadata"]["access_tags"])
+        }
+
+    if min_depth is not None:
+        memo = {}
+        candidates = {
+            k: v for k, v in candidates.items()
+            if _get_depth(k, nodes, all_derived, memo) >= min_depth
+        }
+
+    if depends_on:
+        candidates = {
+            k: v for k, v in candidates.items()
+            if any(
+                depends_on in j.get("antecedents", [])
+                for j in v.get("justifications", [])
+            )
+        }
+
+    if sample is not None and len(candidates) > sample:
+        import random
+        sampled_keys = random.sample(sorted(candidates.keys()), sample)
+        candidates = {k: candidates[k] for k in sampled_keys}
+
+    review_ids = sorted(candidates.keys())
+    results = _review(nodes, belief_ids=review_ids, model=model, timeout=timeout)
+
+    invalid = sum(1 for r in results if not r.get("valid", True))
+    insufficient = sum(1 for r in results if not r.get("sufficient", True))
+    unnecessary = sum(1 for r in results if not r.get("necessary", True))
+
+    return {
+        "results": results,
+        "reviewed": len(review_ids),
+        "invalid": invalid,
+        "insufficient": insufficient,
+        "unnecessary": unnecessary,
+        "total_derived": total_derived,
+    }
+
+
 def _rewrite_dependents(net, old_id: str, new_id: str):
     """Rewrite justifications that reference old_id to point at new_id.
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -940,6 +940,76 @@ def cmd_list_negative(args):
           f"({result['candidates']} candidates from {result['total']} IN nodes)")
 
 
+def cmd_review_beliefs(args):
+    model = getattr(args, "model", None) or "claude"
+    result = api.review_beliefs(
+        belief_ids=args.ids or None,
+        model=model,
+        timeout=args.timeout,
+        min_depth=args.min_depth,
+        depends_on=args.depends_on,
+        sample=args.sample,
+        visible_to=_parse_visible_to(args),
+        db_path=args.db,
+    )
+
+    reviews = result["results"]
+    if not reviews:
+        print("No derived beliefs to review.")
+        return
+
+    invalid = [r for r in reviews if not r.get("valid", True)]
+    insufficient = [r for r in reviews if not r.get("sufficient", True)]
+    unnecessary = [r for r in reviews if not r.get("necessary", True)]
+
+    for r in reviews:
+        flags = []
+        if not r.get("valid", True):
+            flags.append("INVALID")
+        if not r.get("sufficient", True):
+            flags.append("INSUFFICIENT")
+        if not r.get("necessary", True):
+            unneeded = r.get("unnecessary_antecedents", [])
+            flag = "UNNECESSARY"
+            if unneeded:
+                flag += f"({', '.join(unneeded)})"
+            flags.append(flag)
+
+        if flags:
+            print(f"  [{' | '.join(flags)}] {r['id']}")
+            if r.get("comment"):
+                print(f"    {r['comment']}")
+
+    print(f"\nReviewed {result['reviewed']} of {result['total_derived']} derived beliefs")
+    print(f"  Invalid: {result['invalid']}  Insufficient: {result['insufficient']}"
+          f"  Unnecessary: {result['unnecessary']}")
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write("# Belief Review Findings\n\n")
+            for r in reviews:
+                v = "PASS" if r.get("valid", True) else "FAIL"
+                s = "PASS" if r.get("sufficient", True) else "FAIL"
+                n = "PASS" if r.get("necessary", True) else "FAIL"
+                f.write(f"### {r['id']}\n")
+                f.write(f"- Valid: {v}\n- Sufficient: {s}\n- Necessary: {n}\n")
+                if r.get("unnecessary_antecedents"):
+                    f.write(f"- Unnecessary antecedents: {', '.join(r['unnecessary_antecedents'])}\n")
+                if r.get("comment"):
+                    f.write(f"- Comment: {r['comment']}\n")
+                f.write("\n")
+        print(f"\nWrote findings to {args.output}")
+
+    if args.auto_retract and not args.dry_run and invalid:
+        print(f"\nRetracting {len(invalid)} invalid belief(s)...")
+        for r in invalid:
+            try:
+                api.retract(r["id"], reason=f"review-beliefs: {r.get('comment', 'invalid')}", db_path=args.db)
+                print(f"  RETRACTED {r['id']}")
+            except Exception as e:
+                print(f"  ERROR retracting {r['id']}: {e}", file=sys.stderr)
+
+
 def cmd_namespaces(args):
     result = api.list_namespaces(db_path=args.db)
     if not result["namespaces"]:
@@ -1215,6 +1285,28 @@ def main():
 
     sub.add_parser("namespaces", help="List all agent namespaces in the database")
 
+    # review-beliefs
+    p = sub.add_parser("review-beliefs", help="Review derived beliefs for validity, sufficiency, and necessity")
+    p.add_argument("ids", nargs="*", help="Specific belief IDs to review (default: all derived)")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude). Use ollama:<model> for local models")
+    p.add_argument("--timeout", type=int, default=300,
+                   help="LLM timeout in seconds (default: 300)")
+    p.add_argument("--min-depth", type=int, default=None,
+                   help="Only review beliefs at this depth or deeper")
+    p.add_argument("--depends-on", default=None,
+                   help="Only review beliefs depending on this node")
+    p.add_argument("--sample", type=int, default=None,
+                   help="Randomly sample N beliefs to review")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report findings without taking action")
+    p.add_argument("--auto-retract", action="store_true",
+                   help="Retract beliefs found invalid")
+    p.add_argument("-o", "--output", default=None,
+                   help="Write findings to markdown file")
+    p.add_argument("--visible-to", metavar="TAG,TAG",
+                   help="Only review nodes whose access_tags are a subset of these tags")
+
     # list
     p = sub.add_parser("list", help="List nodes with filters")
     p.add_argument("--status", choices=["IN", "OUT"], help="Filter by truth value")
@@ -1273,6 +1365,7 @@ def main():
         "list": cmd_list,
         "list-gated": cmd_list_gated,
         "list-negative": cmd_list_negative,
+        "review-beliefs": cmd_review_beliefs,
         "namespaces": cmd_namespaces,
     }
     commands[args.command](args)

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1004,7 +1004,7 @@ def cmd_review_beliefs(args):
         print(f"\nRetracting {len(invalid)} invalid belief(s)...")
         for r in invalid:
             try:
-                api.retract(r["id"], reason=f"review-beliefs: {r.get('comment', 'invalid')}", db_path=args.db)
+                api.retract_node(r["id"], reason=f"review-beliefs: {r.get('comment', 'invalid')}", db_path=args.db)
                 print(f"  RETRACTED {r['id']}")
             except Exception as e:
                 print(f"  ERROR retracting {r['id']}: {e}", file=sys.stderr)

--- a/reasons_lib/review.py
+++ b/reasons_lib/review.py
@@ -1,0 +1,185 @@
+"""Review derived beliefs for validity, sufficiency, and necessity.
+
+Feeds each derived belief and its full justification chain back to an
+LLM to evaluate whether the derivation is semantically sound, not just
+structurally valid.
+"""
+
+import json
+import re
+import sys
+
+from .llm import invoke_model
+
+REVIEW_BATCH_SIZE = 20
+
+REVIEW_PROMPT = """\
+You are auditing derived beliefs in a Truth Maintenance System (TMS).
+Each belief below was derived from its antecedents by an earlier LLM pass.
+The system validated that the antecedents exist, but did not verify that
+the reasoning from antecedents to conclusion is sound.
+
+For each belief, evaluate three axes:
+
+1. **Valid**: Does this conclusion logically follow from its antecedents?
+   The antecedent texts are provided. Does the claim represent a sound
+   inference, or is it a plausible-sounding leap?
+
+2. **Sufficient**: Are the listed antecedents enough to support this
+   conclusion, or does the derivation require additional unstated
+   assumptions?
+
+3. **Necessary**: Are all antecedents load-bearing? Could any be removed
+   without weakening the conclusion?
+
+Return ONLY a JSON array. For each belief, one object:
+
+```json
+[
+  {{
+    "id": "belief-id",
+    "valid": true,
+    "sufficient": true,
+    "necessary": false,
+    "unnecessary_antecedents": ["ant-id-1"],
+    "comment": "brief explanation"
+  }}
+]
+```
+
+Rules:
+- Return one object per belief reviewed, in the same order as presented.
+- "unnecessary_antecedents" should be empty [] if all are necessary.
+- "comment" should be a single sentence explaining the most important finding.
+- Be rigorous: a conclusion that sounds reasonable but doesn't follow
+  strictly from the antecedents is NOT valid.
+
+## Beliefs to review
+
+{beliefs}"""
+
+
+def format_belief_for_review(node_id, nodes):
+    """Format one derived belief with antecedent texts for LLM review."""
+    node = nodes.get(node_id)
+    if not node:
+        return ""
+
+    lines = [f"### {node_id}"]
+    lines.append(f"Claim: {node.get('text', '')}")
+
+    justs = node.get("justifications", [])
+    if justs:
+        j = justs[0]
+        antecedents = j.get("antecedents", [])
+        outlist = j.get("outlist", [])
+        label = j.get("label", "")
+
+        if antecedents:
+            lines.append("Antecedents:")
+            for ant_id in antecedents:
+                ant_node = nodes.get(ant_id)
+                if ant_node:
+                    lines.append(f"- {ant_id}: {ant_node.get('text', '')}")
+                else:
+                    lines.append(f"- {ant_id}: (not found in network)")
+
+        if outlist:
+            lines.append("Unless (must be OUT):")
+            for out_id in outlist:
+                out_node = nodes.get(out_id)
+                if out_node:
+                    lines.append(f"- {out_id}: {out_node.get('text', '')}")
+                else:
+                    lines.append(f"- {out_id}: (not found in network)")
+
+        if label:
+            lines.append(f"Label: {label}")
+
+    return "\n".join(lines)
+
+
+def parse_review_response(response):
+    """Extract review results JSON array from LLM response.
+
+    Scans for a JSON array in the response text. Returns list of dicts
+    with defaults for missing fields.
+    """
+    for match in re.finditer(r"\[.*\]", response, re.DOTALL):
+        try:
+            items = json.loads(match.group())
+            if not isinstance(items, list):
+                continue
+            results = []
+            for item in items:
+                if not isinstance(item, dict) or "id" not in item:
+                    continue
+                results.append({
+                    "id": item["id"],
+                    "valid": item.get("valid", True),
+                    "sufficient": item.get("sufficient", True),
+                    "necessary": item.get("necessary", True),
+                    "unnecessary_antecedents": item.get("unnecessary_antecedents", []),
+                    "comment": item.get("comment", ""),
+                })
+            if results:
+                return results
+        except json.JSONDecodeError:
+            continue
+    return []
+
+
+def review_beliefs(nodes, belief_ids=None, model="claude", timeout=300,
+                   batch_size=REVIEW_BATCH_SIZE):
+    """Review derived beliefs for validity, sufficiency, and necessity.
+
+    Args:
+        nodes: Dict of node_id -> node data from export_network().
+        belief_ids: Optional list of specific IDs to review.
+            If None, reviews all derived IN beliefs.
+        model: LLM model to use for review.
+        timeout: LLM timeout in seconds.
+        batch_size: Number of beliefs per LLM call.
+
+    Returns: list of review result dicts.
+    """
+    if belief_ids is None:
+        belief_ids = [
+            nid for nid, node in sorted(nodes.items())
+            if node.get("truth_value") == "IN"
+            and node.get("justifications")
+            and len(node["justifications"]) > 0
+        ]
+    else:
+        belief_ids = [
+            nid for nid in belief_ids
+            if nid in nodes
+            and nodes[nid].get("justifications")
+            and len(nodes[nid]["justifications"]) > 0
+        ]
+
+    if not belief_ids:
+        return []
+
+    all_results = []
+    total_batches = (len(belief_ids) + batch_size - 1) // batch_size
+
+    for i in range(0, len(belief_ids), batch_size):
+        batch = belief_ids[i:i + batch_size]
+        batch_num = i // batch_size + 1
+        print(f"  Reviewing batch {batch_num}/{total_batches} "
+              f"({len(batch)} beliefs)...", file=sys.stderr)
+
+        beliefs_text = "\n\n".join(
+            format_belief_for_review(nid, nodes) for nid in batch
+        )
+        prompt = REVIEW_PROMPT.format(beliefs=beliefs_text)
+
+        try:
+            response = invoke_model(prompt, model=model, timeout=timeout)
+            results = parse_review_response(response)
+            all_results.extend(results)
+        except Exception as e:
+            print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
+
+    return all_results

--- a/reasons_lib/review.py
+++ b/reasons_lib/review.py
@@ -6,7 +6,6 @@ structurally valid.
 """
 
 import json
-import re
 import sys
 
 from .llm import invoke_model
@@ -102,30 +101,33 @@ def format_belief_for_review(node_id, nodes):
 def parse_review_response(response):
     """Extract review results JSON array from LLM response.
 
-    Scans for a JSON array in the response text. Returns list of dicts
-    with defaults for missing fields.
+    Tries json.JSONDecoder.raw_decode at each '[' position to handle
+    prose brackets before the JSON array and trailing text after it.
     """
-    for match in re.finditer(r"\[.*\]", response, re.DOTALL):
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(response):
+        if ch != "[":
+            continue
         try:
-            items = json.loads(match.group())
-            if not isinstance(items, list):
-                continue
-            results = []
-            for item in items:
-                if not isinstance(item, dict) or "id" not in item:
-                    continue
-                results.append({
-                    "id": item["id"],
-                    "valid": item.get("valid", True),
-                    "sufficient": item.get("sufficient", True),
-                    "necessary": item.get("necessary", True),
-                    "unnecessary_antecedents": item.get("unnecessary_antecedents", []),
-                    "comment": item.get("comment", ""),
-                })
-            if results:
-                return results
+            items, _ = decoder.raw_decode(response, i)
         except json.JSONDecodeError:
             continue
+        if not isinstance(items, list):
+            continue
+        results = []
+        for item in items:
+            if not isinstance(item, dict) or "id" not in item:
+                continue
+            results.append({
+                "id": item["id"],
+                "valid": item.get("valid", True),
+                "sufficient": item.get("sufficient", True),
+                "necessary": item.get("necessary", True),
+                "unnecessary_antecedents": item.get("unnecessary_antecedents", []),
+                "comment": item.get("comment", ""),
+            })
+        if results:
+            return results
     return []
 
 

--- a/reasons_lib/review.py
+++ b/reasons_lib/review.py
@@ -48,6 +48,8 @@ Return ONLY a JSON array. For each belief, one object:
 
 Rules:
 - Return one object per belief reviewed, in the same order as presented.
+- A belief may have multiple justifications (alternative support paths).
+  It is valid if ANY justification is sound. Evaluate each independently.
 - "unnecessary_antecedents" should be empty [] if all are necessary.
 - "comment" should be a single sentence explaining the most important finding.
 - Be rigorous: a conclusion that sounds reasonable but doesn't follow
@@ -68,11 +70,13 @@ def format_belief_for_review(node_id, nodes):
     lines.append(f"Claim: {node.get('text', '')}")
 
     justs = node.get("justifications", [])
-    if justs:
-        j = justs[0]
+    for ji, j in enumerate(justs):
         antecedents = j.get("antecedents", [])
         outlist = j.get("outlist", [])
         label = j.get("label", "")
+
+        if len(justs) > 1:
+            lines.append(f"Justification {ji + 1}/{len(justs)}:")
 
         if antecedents:
             lines.append("Antecedents:")

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -175,6 +175,18 @@ class TestParseReviewResponse:
         assert len(results) == 1
         assert results[0]["id"] == "derived-ab"
 
+    def test_prose_brackets_before_json(self):
+        response = (
+            "I checked [see antecedents] and [the outlist] carefully.\n\n"
+            '[{"id": "derived-ab", "valid": false, "sufficient": true, '
+            '"necessary": true, "unnecessary_antecedents": [], '
+            '"comment": "does not follow"}]'
+        )
+        results = parse_review_response(response)
+        assert len(results) == 1
+        assert results[0]["id"] == "derived-ab"
+        assert results[0]["valid"] is False
+
     def test_non_list_json_skipped(self):
         response = '{"id": "derived-ab", "valid": true}'
         results = parse_review_response(response)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -114,6 +114,39 @@ class TestFormatBeliefForReview:
         result = format_belief_for_review("does-not-exist", nodes)
         assert result == ""
 
+    def test_multiple_justifications(self):
+        nodes = _make_nodes()
+        nodes["multi-just"] = {
+            "text": "Supported by two independent paths",
+            "truth_value": "IN",
+            "justifications": [
+                {
+                    "type": "SL",
+                    "antecedents": ["premise-a", "premise-b"],
+                    "outlist": [],
+                    "label": "path one",
+                },
+                {
+                    "type": "SL",
+                    "antecedents": ["premise-c"],
+                    "outlist": [],
+                    "label": "path two",
+                },
+            ],
+        }
+        result = format_belief_for_review("multi-just", nodes)
+        assert "Justification 1/2:" in result
+        assert "Justification 2/2:" in result
+        assert "premise-a: A is true" in result
+        assert "premise-c: C is true" in result
+        assert "Label: path one" in result
+        assert "Label: path two" in result
+
+    def test_single_justification_no_numbering(self):
+        nodes = _make_nodes()
+        result = format_belief_for_review("derived-ab", nodes)
+        assert "Justification 1/" not in result
+
     def test_no_justifications(self):
         nodes = _make_nodes()
         result = format_belief_for_review("premise-a", nodes)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,6 +1,8 @@
 """Tests for the review module (derived belief validation)."""
 
 import json
+import sys
+from io import StringIO
 from unittest.mock import patch, call
 
 import pytest
@@ -12,6 +14,23 @@ from reasons_lib.review import (
     REVIEW_BATCH_SIZE,
 )
 from reasons_lib import api
+from reasons_lib.cli import main
+
+
+def run_cli(*args, db_path=None):
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+        except SystemExit as e:
+            return stdout.getvalue(), stderr.getvalue(), e.code
+    return stdout.getvalue(), stderr.getvalue(), 0
 
 
 def _make_nodes():
@@ -309,3 +328,110 @@ class TestReviewBeliefsApi:
         assert result["invalid"] == 1
         assert result["insufficient"] == 1
         assert result["unnecessary"] == 1
+
+    def test_visible_to_filter(self, db_path):
+        api.add_node("tagged-derived", "tagged belief",
+                      sl="premise-a,premise-b", label="tagged",
+                      access_tags=["secret"],
+                      db_path=db_path)
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+            {"id": "derived-abc", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_beliefs(visible_to=["public"], db_path=db_path)
+        # tagged-derived requires "secret" tag, so excluded; only 2 untagged derived remain
+        assert result["reviewed"] == 2
+
+
+class TestCmdReviewBeliefs:
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("premise-b", "B is true", db_path=db)
+        api.add_node("derived-ab", "AB combined", sl="premise-a,premise-b",
+                      label="combined", db_path=db)
+        return db
+
+    def _mock_review(self, response_data):
+        mock_response = json.dumps(response_data)
+        return type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+
+    def test_auto_retract_retracts_invalid(self, db_path):
+        mock_result = self._mock_review([
+            {"id": "derived-ab", "valid": False, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [],
+             "comment": "conclusion does not follow"},
+        ])
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            stdout, stderr, code = run_cli(
+                "review-beliefs", "--auto-retract", db_path=db_path)
+        assert "RETRACTED derived-ab" in stdout
+        # Verify it was actually retracted in the DB
+        result = api.show_node("derived-ab", db_path=db_path)
+        assert result["truth_value"] == "OUT"
+
+    def test_dry_run_prevents_retraction(self, db_path):
+        mock_result = self._mock_review([
+            {"id": "derived-ab", "valid": False, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [],
+             "comment": "conclusion does not follow"},
+        ])
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            stdout, stderr, code = run_cli(
+                "review-beliefs", "--auto-retract", "--dry-run", db_path=db_path)
+        assert "RETRACTED" not in stdout
+        # Verify it was NOT retracted
+        result = api.show_node("derived-ab", db_path=db_path)
+        assert result["truth_value"] == "IN"
+
+    def test_output_writes_findings_file(self, db_path, tmp_path):
+        output_file = str(tmp_path / "findings.md")
+        mock_result = self._mock_review([
+            {"id": "derived-ab", "valid": False, "sufficient": True,
+             "necessary": False, "unnecessary_antecedents": ["premise-b"],
+             "comment": "not valid and unnecessary antecedent"},
+        ])
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            stdout, stderr, code = run_cli(
+                "review-beliefs", "-o", output_file, db_path=db_path)
+        assert f"Wrote findings to {output_file}" in stdout
+        with open(output_file) as f:
+            content = f.read()
+        assert "# Belief Review Findings" in content
+        assert "### derived-ab" in content
+        assert "- Valid: FAIL" in content
+        assert "- Sufficient: PASS" in content
+        assert "- Necessary: FAIL" in content
+        assert "- Unnecessary antecedents: premise-b" in content
+        assert "- Comment: not valid and unnecessary antecedent" in content
+
+    def test_displays_flags_for_issues(self, db_path):
+        mock_result = self._mock_review([
+            {"id": "derived-ab", "valid": False, "sufficient": False,
+             "necessary": False, "unnecessary_antecedents": ["premise-a"],
+             "comment": "all three axes fail"},
+        ])
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            stdout, stderr, code = run_cli(
+                "review-beliefs", "--dry-run", db_path=db_path)
+        assert "INVALID" in stdout
+        assert "INSUFFICIENT" in stdout
+        assert "UNNECESSARY(premise-a)" in stdout
+        assert "all three axes fail" in stdout
+
+    def test_no_derived_beliefs_message(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        api.add_node("just-a-premise", "simple fact", db_path=db)
+        stdout, stderr, code = run_cli("review-beliefs", db_path=db)
+        assert "No derived beliefs to review." in stdout

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,311 @@
+"""Tests for the review module (derived belief validation)."""
+
+import json
+from unittest.mock import patch, call
+
+import pytest
+
+from reasons_lib.review import (
+    format_belief_for_review,
+    parse_review_response,
+    review_beliefs,
+    REVIEW_BATCH_SIZE,
+)
+from reasons_lib import api
+
+
+def _make_nodes():
+    """Build a minimal exported nodes dict for testing."""
+    return {
+        "premise-a": {
+            "text": "A is true",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "premise-b": {
+            "text": "B is true",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "premise-c": {
+            "text": "C is true",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "derived-ab": {
+            "text": "A and B together imply AB",
+            "truth_value": "IN",
+            "justifications": [{
+                "type": "SL",
+                "antecedents": ["premise-a", "premise-b"],
+                "outlist": [],
+                "label": "combined observation",
+            }],
+        },
+        "gated-abc": {
+            "text": "ABC holds unless C is present",
+            "truth_value": "OUT",
+            "justifications": [{
+                "type": "SL",
+                "antecedents": ["premise-a", "premise-b"],
+                "outlist": ["premise-c"],
+                "label": "gated on C",
+            }],
+        },
+        "derived-deep": {
+            "text": "Deep conclusion from AB",
+            "truth_value": "IN",
+            "justifications": [{
+                "type": "SL",
+                "antecedents": ["derived-ab", "premise-c"],
+                "outlist": [],
+                "label": "deeper reasoning",
+            }],
+        },
+    }
+
+
+class TestFormatBeliefForReview:
+
+    def test_formats_belief_with_antecedents(self):
+        nodes = _make_nodes()
+        result = format_belief_for_review("derived-ab", nodes)
+        assert "### derived-ab" in result
+        assert "A and B together imply AB" in result
+        assert "premise-a: A is true" in result
+        assert "premise-b: B is true" in result
+        assert "Label: combined observation" in result
+
+    def test_includes_outlist(self):
+        nodes = _make_nodes()
+        result = format_belief_for_review("gated-abc", nodes)
+        assert "Unless (must be OUT):" in result
+        assert "premise-c: C is true" in result
+
+    def test_missing_antecedent_graceful(self):
+        nodes = _make_nodes()
+        nodes["derived-ab"]["justifications"][0]["antecedents"] = [
+            "premise-a", "nonexistent"
+        ]
+        result = format_belief_for_review("derived-ab", nodes)
+        assert "nonexistent: (not found in network)" in result
+
+    def test_missing_node_returns_empty(self):
+        nodes = _make_nodes()
+        result = format_belief_for_review("does-not-exist", nodes)
+        assert result == ""
+
+    def test_no_justifications(self):
+        nodes = _make_nodes()
+        result = format_belief_for_review("premise-a", nodes)
+        assert "### premise-a" in result
+        assert "Antecedents:" not in result
+
+
+class TestParseReviewResponse:
+
+    def test_parses_valid_json(self):
+        response = json.dumps([{
+            "id": "derived-ab",
+            "valid": True,
+            "sufficient": True,
+            "necessary": False,
+            "unnecessary_antecedents": ["premise-b"],
+            "comment": "premise-b is redundant",
+        }])
+        results = parse_review_response(response)
+        assert len(results) == 1
+        assert results[0]["id"] == "derived-ab"
+        assert results[0]["valid"] is True
+        assert results[0]["necessary"] is False
+        assert results[0]["unnecessary_antecedents"] == ["premise-b"]
+
+    def test_extracts_from_surrounding_prose(self):
+        response = (
+            "Here are my findings:\n\n"
+            '[{"id": "derived-ab", "valid": false, "sufficient": true, '
+            '"necessary": true, "unnecessary_antecedents": [], '
+            '"comment": "conclusion does not follow"}]\n\n'
+            "Hope this helps!"
+        )
+        results = parse_review_response(response)
+        assert len(results) == 1
+        assert results[0]["valid"] is False
+
+    def test_malformed_json_returns_empty(self):
+        response = "This is not JSON at all."
+        results = parse_review_response(response)
+        assert results == []
+
+    def test_missing_fields_get_defaults(self):
+        response = json.dumps([{"id": "derived-ab"}])
+        results = parse_review_response(response)
+        assert len(results) == 1
+        assert results[0]["valid"] is True
+        assert results[0]["sufficient"] is True
+        assert results[0]["necessary"] is True
+        assert results[0]["unnecessary_antecedents"] == []
+        assert results[0]["comment"] == ""
+
+    def test_skips_items_without_id(self):
+        response = json.dumps([
+            {"valid": True},
+            {"id": "derived-ab", "valid": False},
+        ])
+        results = parse_review_response(response)
+        assert len(results) == 1
+        assert results[0]["id"] == "derived-ab"
+
+    def test_non_list_json_skipped(self):
+        response = '{"id": "derived-ab", "valid": true}'
+        results = parse_review_response(response)
+        assert results == []
+
+
+class TestReviewBeliefs:
+
+    def test_reviews_batch(self):
+        nodes = _make_nodes()
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            results = review_beliefs(nodes, belief_ids=["derived-ab"], model="claude")
+        assert len(results) == 1
+        assert results[0]["id"] == "derived-ab"
+
+    def test_empty_derived_returns_empty(self):
+        nodes = {
+            "premise-a": {
+                "text": "A is true",
+                "truth_value": "IN",
+                "justifications": [],
+            },
+        }
+        results = review_beliefs(nodes)
+        assert results == []
+
+    def test_filters_to_existing_ids(self):
+        nodes = _make_nodes()
+        mock_response = json.dumps([])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            results = review_beliefs(nodes, belief_ids=["nonexistent"])
+        assert results == []
+
+    def test_batch_size_respected(self):
+        nodes = _make_nodes()
+        # derived-ab and derived-deep are the only derived IN beliefs
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result) as mock_run:
+            results = review_beliefs(nodes, batch_size=1)
+        # 2 derived IN beliefs (derived-ab, derived-deep) = 2 batches
+        assert mock_run.call_count == 2
+
+    def test_timeout_passed_through(self):
+        nodes = _make_nodes()
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result) as mock_run:
+            review_beliefs(nodes, belief_ids=["derived-ab"], timeout=600)
+        assert mock_run.call_args[1]["timeout"] == 600
+
+    def test_llm_error_continues(self):
+        nodes = _make_nodes()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=RuntimeError("LLM failed")):
+            results = review_beliefs(nodes, belief_ids=["derived-ab"])
+        assert results == []
+
+
+class TestReviewBeliefsApi:
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("premise-b", "B is true", db_path=db)
+        api.add_node("derived-ab", "AB combined", sl="premise-a,premise-b",
+                      label="combined", db_path=db)
+        api.add_node("premise-c", "C is true", db_path=db)
+        api.add_node("derived-abc", "ABC combined",
+                      sl="derived-ab,premise-c", label="deeper", db_path=db)
+        return db
+
+    def test_filters_to_derived_only(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+            {"id": "derived-abc", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_beliefs(db_path=db_path)
+        assert result["reviewed"] == 2
+        assert result["total_derived"] == 2
+
+    def test_min_depth_filter(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-abc", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_beliefs(min_depth=2, db_path=db_path)
+        # derived-abc is depth 2 (depends on derived-ab which is depth 1)
+        assert result["reviewed"] == 1
+
+    def test_sample_limits_count(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_beliefs(sample=1, db_path=db_path)
+        assert result["reviewed"] == 1
+
+    def test_depends_on_filter(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-abc", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_beliefs(depends_on="derived-ab", db_path=db_path)
+        # Only derived-abc depends on derived-ab
+        assert result["reviewed"] == 1
+
+    def test_returns_summary_counts(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": False, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "invalid"},
+            {"id": "derived-abc", "valid": True, "sufficient": False,
+             "necessary": False, "unnecessary_antecedents": ["premise-c"],
+             "comment": "insufficient and unnecessary"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_beliefs(db_path=db_path)
+        assert result["invalid"] == 1
+        assert result["insufficient"] == 1
+        assert result["unnecessary"] == 1


### PR DESCRIPTION
## Summary

- Adds `reasons review-beliefs` command that uses an LLM to evaluate derived beliefs on three axes: **validity** (does the conclusion follow from antecedents?), **sufficiency** (are antecedents enough?), and **necessity** (are all antecedents load-bearing?)
- New module `reasons_lib/review.py` with batched LLM classification following the `list_negative` pattern
- API layer with filtering by belief IDs, min depth, depends-on, sample size, and access tags
- CLI supports `--dry-run`, `--auto-retract`, `--output`, `--sample`, `--min-depth`, `--depends-on`

## Test plan

- [x] 22 new tests in `tests/test_review.py` (formatting, parsing, batching, API filtering, summary counts)
- [x] Full suite passes (753 passed, 106 skipped)
- [ ] Manual: `reasons review-beliefs --sample 5 --dry-run`
- [ ] Manual: `reasons review-beliefs --min-depth 10 --dry-run`

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)