### PR TITLE
Add review-beliefs audit trail with last_reviewed metadata

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1781,89 +1781,75 @@ def review_beliefs(
     from .derive import _get_depth
     from .review import review_beliefs as _review
 
-    with _with_network(db_path, write=not dry_run) as net:
-        nodes = {
-            nid: {
-                "text": n.text,
-                "truth_value": n.truth_value,
-                "justifications": [
-                    {"type": j.type, "antecedents": j.antecedents, "outlist": j.outlist, "label": j.label}
-                    for j in n.justifications
-                ],
-                "source": n.source,
-                "source_url": n.source_url,
-                "source_hash": n.source_hash,
-                "date": n.date,
-                "metadata": {k: v for k, v in n.metadata.items() if not k.startswith("_")},
-            }
-            for nid, n in sorted(net.nodes.items())
+    result = export_network(db_path=db_path)
+    nodes = result.get("nodes", {})
+
+    all_derived = {
+        k: v for k, v in nodes.items()
+        if v.get("truth_value") == "IN"
+        and v.get("justifications")
+        and len(v["justifications"]) > 0
+    }
+    total_derived = len(all_derived)
+
+    candidates = dict(all_derived)
+
+    if belief_ids:
+        candidates = {k: v for k, v in candidates.items() if k in belief_ids}
+
+    if visible_to is not None:
+        tags = set(visible_to)
+        candidates = {
+            k: v for k, v in candidates.items()
+            if not v.get("metadata", {}).get("access_tags")
+            or all(t in tags for t in v["metadata"]["access_tags"])
         }
 
-        all_derived = {
-            k: v for k, v in nodes.items()
-            if v.get("truth_value") == "IN"
-            and v.get("justifications")
-            and len(v["justifications"]) > 0
+    if min_depth is not None:
+        memo = {}
+        candidates = {
+            k: v for k, v in candidates.items()
+            if _get_depth(k, nodes, all_derived, memo) >= min_depth
         }
-        total_derived = len(all_derived)
 
-        candidates = dict(all_derived)
+    if depends_on:
+        candidates = {
+            k: v for k, v in candidates.items()
+            if any(
+                depends_on in j.get("antecedents", [])
+                for j in v.get("justifications", [])
+            )
+        }
 
-        if belief_ids:
-            candidates = {k: v for k, v in candidates.items() if k in belief_ids}
+    if sample is not None and len(candidates) > sample:
+        import random
+        sampled_keys = random.sample(sorted(candidates.keys()), sample)
+        candidates = {k: candidates[k] for k in sampled_keys}
 
-        if visible_to is not None:
-            tags = set(visible_to)
-            candidates = {
-                k: v for k, v in candidates.items()
-                if not v.get("metadata", {}).get("access_tags")
-                or all(t in tags for t in v["metadata"]["access_tags"])
-            }
+    review_ids = sorted(candidates.keys())
+    results = _review(nodes, belief_ids=review_ids, model=model, timeout=timeout)
 
-        if min_depth is not None:
-            memo = {}
-            candidates = {
-                k: v for k, v in candidates.items()
-                if _get_depth(k, nodes, all_derived, memo) >= min_depth
-            }
-
-        if depends_on:
-            candidates = {
-                k: v for k, v in candidates.items()
-                if any(
-                    depends_on in j.get("antecedents", [])
-                    for j in v.get("justifications", [])
-                )
-            }
-
-        if sample is not None and len(candidates) > sample:
-            import random
-            sampled_keys = random.sample(sorted(candidates.keys()), sample)
-            candidates = {k: candidates[k] for k in sampled_keys}
-
-        review_ids = sorted(candidates.keys())
-        results = _review(nodes, belief_ids=review_ids, model=model, timeout=timeout)
-
-        if not dry_run:
-            now = datetime.now().isoformat(timespec="seconds")
-            result_map = {r["id"]: r for r in results}
+    if not dry_run and results:
+        now = datetime.now().isoformat(timespec="seconds")
+        result_map = {r["id"]: r for r in results}
+        with _with_network(db_path, write=True) as net:
             for nid in review_ids:
                 if nid in net.nodes and nid in result_map:
                     net.nodes[nid].metadata["last_reviewed"] = now
                     net.nodes[nid].metadata["review_result"] = _classify_review_result(result_map[nid])
 
-        invalid = sum(1 for r in results if not r.get("valid", True))
-        insufficient = sum(1 for r in results if not r.get("sufficient", True))
-        unnecessary = sum(1 for r in results if not r.get("necessary", True))
+    invalid = sum(1 for r in results if not r.get("valid", True))
+    insufficient = sum(1 for r in results if not r.get("sufficient", True))
+    unnecessary = sum(1 for r in results if not r.get("necessary", True))
 
-        return {
-            "results": results,
-            "reviewed": len(review_ids),
-            "invalid": invalid,
-            "insufficient": insufficient,
-            "unnecessary": unnecessary,
-            "total_derived": total_derived,
-        }
+    return {
+        "results": results,
+        "reviewed": len(review_ids),
+        "invalid": invalid,
+        "insufficient": insufficient,
+        "unnecessary": unnecessary,
+        "total_derived": total_derived,
+    }
 
 
 def detect_contradictions(

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1829,8 +1829,9 @@ def review_beliefs(
     review_ids = sorted(candidates.keys())
     results = _review(nodes, belief_ids=review_ids, model=model, timeout=timeout)
 
+    now = datetime.now().isoformat(timespec="seconds")
+
     if not dry_run and results:
-        now = datetime.now().isoformat(timespec="seconds")
         result_map = {r["id"]: r for r in results}
         with _with_network(db_path, write=True) as net:
             for nid in review_ids:
@@ -1849,6 +1850,7 @@ def review_beliefs(
         "insufficient": insufficient,
         "unnecessary": unnecessary,
         "total_derived": total_derived,
+        "timestamp": now,
     }
 
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1529,14 +1529,23 @@ def list_nodes(
     min_depth: int | None = None,
     max_depth: int | None = None,
     visible_to: list[str] | None = None,
+    not_reviewed_since: int | None = None,
+    never_reviewed: bool = False,
+    by_impact: bool = False,
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """List nodes with optional filters.
 
     Returns: {"nodes": list[dict], "count": int}
     """
+    from datetime import datetime, timedelta
+
     with _with_network(db_path) as net:
         memo = {} if (min_depth is not None or max_depth is not None) else None
+        if not_reviewed_since is not None:
+            cutoff = datetime.now() - timedelta(days=not_reviewed_since)
+        else:
+            cutoff = None
         nodes = []
         for nid, node in sorted(net.nodes.items()):
             if namespace and not nid.startswith(f"{namespace}:"):
@@ -1557,6 +1566,21 @@ def list_nodes(
                     continue
                 if max_depth is not None and d > max_depth:
                     continue
+            if never_reviewed:
+                if not node.justifications:
+                    continue
+                if node.metadata.get("last_reviewed"):
+                    continue
+            if cutoff is not None:
+                if not node.justifications:
+                    continue
+                last = node.metadata.get("last_reviewed")
+                if last:
+                    try:
+                        if datetime.fromisoformat(last) >= cutoff:
+                            continue
+                    except ValueError:
+                        pass
             nodes.append({
                 "id": nid,
                 "text": node.text,
@@ -1564,7 +1588,11 @@ def list_nodes(
                 "justification_count": len(node.justifications),
                 "dependent_count": len(node.dependents),
                 "challenges": node.metadata.get("challenges", []),
+                "last_reviewed": node.metadata.get("last_reviewed"),
+                "review_result": node.metadata.get("review_result"),
             })
+        if by_impact:
+            nodes.sort(key=lambda n: -n["dependent_count"])
         return {"nodes": nodes, "count": len(nodes)}
 
 
@@ -1718,6 +1746,16 @@ def list_negative(
         }
 
 
+def _classify_review_result(result: dict) -> str:
+    if not result.get("valid", True):
+        return "invalid"
+    if not result.get("sufficient", True):
+        return "insufficient"
+    if not result.get("necessary", True):
+        return "unnecessary"
+    return "pass"
+
+
 def review_beliefs(
     belief_ids: list[str] | None = None,
     model: str = "claude",
@@ -1726,79 +1764,106 @@ def review_beliefs(
     depends_on: str | None = None,
     sample: int | None = None,
     visible_to: list[str] | None = None,
+    dry_run: bool = False,
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """Review derived beliefs for validity, sufficiency, and necessity.
 
     Uses an LLM to evaluate whether each derived belief's reasoning
-    from antecedents to conclusion is sound.
+    from antecedents to conclusion is sound. Writes last_reviewed and
+    review_result metadata to each reviewed node (unless dry_run=True).
 
     Returns: {"results": [...], "reviewed": int, "invalid": int,
               "insufficient": int, "unnecessary": int, "total_derived": int}
     """
+    from datetime import datetime
+
     from .derive import _get_depth
     from .review import review_beliefs as _review
 
-    result = export_network(db_path=db_path)
-    nodes = result.get("nodes", {})
-
-    all_derived = {
-        k: v for k, v in nodes.items()
-        if v.get("truth_value") == "IN"
-        and v.get("justifications")
-        and len(v["justifications"]) > 0
-    }
-    total_derived = len(all_derived)
-
-    candidates = dict(all_derived)
-
-    if belief_ids:
-        candidates = {k: v for k, v in candidates.items() if k in belief_ids}
-
-    if visible_to is not None:
-        tags = set(visible_to)
-        candidates = {
-            k: v for k, v in candidates.items()
-            if not v.get("metadata", {}).get("access_tags")
-            or all(t in tags for t in v["metadata"]["access_tags"])
+    with _with_network(db_path, write=not dry_run) as net:
+        nodes = {
+            nid: {
+                "text": n.text,
+                "truth_value": n.truth_value,
+                "justifications": [
+                    {"type": j.type, "antecedents": j.antecedents, "outlist": j.outlist, "label": j.label}
+                    for j in n.justifications
+                ],
+                "source": n.source,
+                "source_url": n.source_url,
+                "source_hash": n.source_hash,
+                "date": n.date,
+                "metadata": {k: v for k, v in n.metadata.items() if not k.startswith("_")},
+            }
+            for nid, n in sorted(net.nodes.items())
         }
 
-    if min_depth is not None:
-        memo = {}
-        candidates = {
-            k: v for k, v in candidates.items()
-            if _get_depth(k, nodes, all_derived, memo) >= min_depth
+        all_derived = {
+            k: v for k, v in nodes.items()
+            if v.get("truth_value") == "IN"
+            and v.get("justifications")
+            and len(v["justifications"]) > 0
         }
+        total_derived = len(all_derived)
 
-    if depends_on:
-        candidates = {
-            k: v for k, v in candidates.items()
-            if any(
-                depends_on in j.get("antecedents", [])
-                for j in v.get("justifications", [])
-            )
+        candidates = dict(all_derived)
+
+        if belief_ids:
+            candidates = {k: v for k, v in candidates.items() if k in belief_ids}
+
+        if visible_to is not None:
+            tags = set(visible_to)
+            candidates = {
+                k: v for k, v in candidates.items()
+                if not v.get("metadata", {}).get("access_tags")
+                or all(t in tags for t in v["metadata"]["access_tags"])
+            }
+
+        if min_depth is not None:
+            memo = {}
+            candidates = {
+                k: v for k, v in candidates.items()
+                if _get_depth(k, nodes, all_derived, memo) >= min_depth
+            }
+
+        if depends_on:
+            candidates = {
+                k: v for k, v in candidates.items()
+                if any(
+                    depends_on in j.get("antecedents", [])
+                    for j in v.get("justifications", [])
+                )
+            }
+
+        if sample is not None and len(candidates) > sample:
+            import random
+            sampled_keys = random.sample(sorted(candidates.keys()), sample)
+            candidates = {k: candidates[k] for k in sampled_keys}
+
+        review_ids = sorted(candidates.keys())
+        results = _review(nodes, belief_ids=review_ids, model=model, timeout=timeout)
+
+        if not dry_run:
+            now = datetime.now().isoformat(timespec="seconds")
+            result_map = {r["id"]: r for r in results}
+            for nid in review_ids:
+                if nid in net.nodes and nid in result_map:
+                    net.nodes[nid].metadata["last_reviewed"] = now
+                    net.nodes[nid].metadata["review_result"] = _classify_review_result(result_map[nid])
+
+        invalid = sum(1 for r in results if not r.get("valid", True))
+        insufficient = sum(1 for r in results if not r.get("sufficient", True))
+        unnecessary = sum(1 for r in results if not r.get("necessary", True))
+
+        return {
+            "results": results,
+            "reviewed": len(review_ids),
+            "invalid": invalid,
+            "insufficient": insufficient,
+            "unnecessary": unnecessary,
+            "total_derived": total_derived,
         }
-
-    if sample is not None and len(candidates) > sample:
-        import random
-        sampled_keys = random.sample(sorted(candidates.keys()), sample)
-        candidates = {k: candidates[k] for k in sampled_keys}
-
-    review_ids = sorted(candidates.keys())
-    results = _review(nodes, belief_ids=review_ids, model=model, timeout=timeout)
-
-    invalid = sum(1 for r in results if not r.get("valid", True))
-    insufficient = sum(1 for r in results if not r.get("sufficient", True))
-    unnecessary = sum(1 for r in results if not r.get("necessary", True))
-
-    return {
-        "results": results,
-        "reviewed": len(review_ids),
-        "invalid": invalid,
-        "insufficient": insufficient,
-        "unnecessary": unnecessary,
-        "total_derived": total_derived,
-    }
 
 
 def detect_contradictions(

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -918,6 +918,10 @@ def cmd_list(args):
         db_path=args.db,
     )
 
+    if args.never_reviewed and args.not_reviewed_since is not None:
+        print("Warning: --never-reviewed makes --not-reviewed-since a no-op",
+              file=sys.stderr)
+
     if not result["nodes"]:
         print("No matching nodes.")
         return

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1042,6 +1042,7 @@ def cmd_review_beliefs(args):
                 "min_depth": args.min_depth,
                 "depends_on": args.depends_on,
                 "sample": args.sample,
+                "visible_to": _parse_visible_to(args),
             },
             "reviewed": result["reviewed"],
             "total_derived": result["total_derived"],

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -912,6 +912,9 @@ def cmd_list(args):
         min_depth=args.min_depth,
         max_depth=args.max_depth,
         visible_to=_parse_visible_to(args),
+        not_reviewed_since=args.not_reviewed_since,
+        never_reviewed=args.never_reviewed,
+        by_impact=args.by_impact,
         db_path=args.db,
     )
 
@@ -919,11 +922,18 @@ def cmd_list(args):
         print("No matching nodes.")
         return
 
+    show_review = args.never_reviewed or args.not_reviewed_since is not None
     for node in result["nodes"]:
         marker = "+" if node["truth_value"] == "IN" else "-"
         jinfo = f"  ({node['justification_count']} justification{'s' if node['justification_count'] != 1 else ''})" if node["justification_count"] else "  (premise)"
         deps = f"  [{node['dependent_count']} dependents]" if node["dependent_count"] else ""
-        print(f"  [{marker}] {node['id']}{jinfo}{deps}")
+        review_info = ""
+        if show_review:
+            if node.get("last_reviewed"):
+                review_info = f"  (reviewed: {node['last_reviewed']}, {node.get('review_result', '?')})"
+            elif node.get("justification_count", 0) > 0:
+                review_info = "  (never reviewed)"
+        print(f"  [{marker}] {node['id']}{jinfo}{deps}{review_info}")
 
     print(f"\n{result['count']} node{'s' if result['count'] != 1 else ''}")
 
@@ -966,6 +976,9 @@ def cmd_list_negative(args):
 
 
 def cmd_review_beliefs(args):
+    import json
+    from datetime import datetime
+
     model = getattr(args, "model", None) or "claude"
     result = api.review_beliefs(
         belief_ids=args.ids or None,
@@ -975,6 +988,7 @@ def cmd_review_beliefs(args):
         depends_on=args.depends_on,
         sample=args.sample,
         visible_to=_parse_visible_to(args),
+        dry_run=args.dry_run,
         db_path=args.db,
     )
 
@@ -1008,6 +1022,33 @@ def cmd_review_beliefs(args):
     print(f"\nReviewed {result['reviewed']} of {result['total_derived']} derived beliefs")
     print(f"  Invalid: {result['invalid']}  Insufficient: {result['insufficient']}"
           f"  Unnecessary: {result['unnecessary']}")
+
+    if not args.no_report:
+        report_dir = Path(args.report_dir)
+        report_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        report_path = report_dir / f"review-beliefs-{timestamp}.json"
+        report = {
+            "timestamp": datetime.now().isoformat(timespec="seconds"),
+            "model": model,
+            "timeout": args.timeout,
+            "dry_run": args.dry_run,
+            "filters": {
+                "min_depth": args.min_depth,
+                "depends_on": args.depends_on,
+                "sample": args.sample,
+            },
+            "reviewed": result["reviewed"],
+            "total_derived": result["total_derived"],
+            "summary": {
+                "invalid": result["invalid"],
+                "insufficient": result["insufficient"],
+                "unnecessary": result["unnecessary"],
+            },
+            "results": result["results"],
+        }
+        report_path.write_text(json.dumps(report, indent=2))
+        print(f"  Report: {report_path}")
 
     if args.output:
         with open(args.output, "w") as f:
@@ -1390,6 +1431,10 @@ def main():
                    help="Write findings to markdown file")
     p.add_argument("--visible-to", metavar="TAG,TAG",
                    help="Only review nodes whose access_tags are a subset of these tags")
+    p.add_argument("--report-dir", default="reviews",
+                   help="Directory for JSON reports (default: reviews/)")
+    p.add_argument("--no-report", action="store_true",
+                   help="Skip JSON report generation")
 
     # contradictions
     p = sub.add_parser("contradictions", help="Detect contradictions between IN beliefs")
@@ -1419,6 +1464,12 @@ def main():
     p.add_argument("--max-depth", type=int, default=None,
                    help="Only show beliefs at this depth or shallower")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
+    p.add_argument("--not-reviewed-since", type=int, default=None, metavar="DAYS",
+                   help="Derived beliefs not reviewed in the last N days (or never)")
+    p.add_argument("--never-reviewed", action="store_true",
+                   help="Derived beliefs that have never been reviewed")
+    p.add_argument("--by-impact", action="store_true",
+                   help="Sort output by dependent count (descending)")
 
     args = parser.parse_args()
     if not args.command:

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1034,6 +1034,7 @@ def cmd_review_beliefs(args):
             "timeout": args.timeout,
             "dry_run": args.dry_run,
             "filters": {
+                "belief_ids": args.ids or None,
                 "min_depth": args.min_depth,
                 "depends_on": args.depends_on,
                 "sample": args.sample,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1026,10 +1026,10 @@ def cmd_review_beliefs(args):
     if not args.no_report:
         report_dir = Path(args.report_dir)
         report_dir.mkdir(parents=True, exist_ok=True)
-        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        report_path = report_dir / f"review-beliefs-{timestamp}.json"
+        ts = result["timestamp"]
+        report_path = report_dir / f"review-beliefs-{ts.replace(':', '')}.json"
         report = {
-            "timestamp": datetime.now().isoformat(timespec="seconds"),
+            "timestamp": ts,
             "model": model,
             "timeout": args.timeout,
             "dry_run": args.dry_run,

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -480,3 +480,182 @@ class TestCmdReviewBeliefs:
         api.add_node("just-a-premise", "simple fact", db_path=db)
         stdout, stderr, code = run_cli("review-beliefs", db_path=db)
         assert "No derived beliefs to review." in stdout
+
+    def test_json_report_written(self, db_path, tmp_path):
+        report_dir = str(tmp_path / "reports")
+        mock_result = self._mock_review([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            stdout, stderr, code = run_cli(
+                "review-beliefs", "--report-dir", report_dir, db_path=db_path)
+        assert "Report:" in stdout
+
+        import os
+        reports = [f for f in os.listdir(report_dir) if f.endswith(".json")]
+        assert len(reports) == 1
+
+        with open(os.path.join(report_dir, reports[0])) as f:
+            report = json.load(f)
+        assert "timestamp" in report
+        assert report["reviewed"] == 1
+        assert "results" in report
+        assert len(report["results"]) == 1
+        assert report["results"][0]["id"] == "derived-ab"
+
+    def test_no_report_flag(self, db_path, tmp_path):
+        report_dir = str(tmp_path / "reports")
+        mock_result = self._mock_review([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            stdout, stderr, code = run_cli(
+                "review-beliefs", "--no-report", "--report-dir", report_dir,
+                db_path=db_path)
+        assert "Report:" not in stdout
+        import os
+        assert not os.path.exists(report_dir)
+
+
+class TestReviewBeliefsMetadata:
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("premise-b", "B is true", db_path=db)
+        api.add_node("derived-ab", "AB combined", sl="premise-a,premise-b",
+                      label="combined", db_path=db)
+        api.add_node("premise-c", "C is true", db_path=db)
+        api.add_node("derived-abc", "ABC combined",
+                      sl="derived-ab,premise-c", label="deeper", db_path=db)
+        return db
+
+    def test_metadata_written_after_review(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+            {"id": "derived-abc", "valid": False, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [],
+             "comment": "does not follow"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            api.review_beliefs(db_path=db_path)
+
+        node_ab = api.show_node("derived-ab", db_path=db_path)
+        assert node_ab["metadata"]["last_reviewed"]
+        assert node_ab["metadata"]["review_result"] == "pass"
+
+        node_abc = api.show_node("derived-abc", db_path=db_path)
+        assert node_abc["metadata"]["last_reviewed"]
+        assert node_abc["metadata"]["review_result"] == "invalid"
+
+    def test_dry_run_skips_metadata(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            api.review_beliefs(dry_run=True, db_path=db_path)
+
+        node = api.show_node("derived-ab", db_path=db_path)
+        assert "last_reviewed" not in node["metadata"]
+
+    def test_review_result_classification_priority(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": False, "sufficient": False,
+             "necessary": False, "unnecessary_antecedents": ["premise-b"],
+             "comment": "all fail"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            api.review_beliefs(belief_ids=["derived-ab"], db_path=db_path)
+
+        node = api.show_node("derived-ab", db_path=db_path)
+        assert node["metadata"]["review_result"] == "invalid"
+
+    def test_insufficient_result_classification(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": False,
+             "necessary": True, "unnecessary_antecedents": [],
+             "comment": "not enough"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            api.review_beliefs(belief_ids=["derived-ab"], db_path=db_path)
+
+        node = api.show_node("derived-ab", db_path=db_path)
+        assert node["metadata"]["review_result"] == "insufficient"
+
+
+class TestListNodesReviewFilters:
+
+    @pytest.fixture
+    def db_path(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("premise-b", "B is true", db_path=db)
+        api.add_node("derived-ab", "AB combined", sl="premise-a,premise-b",
+                      label="combined", db_path=db)
+        api.add_node("derived-cd", "CD combined", sl="premise-a,premise-b",
+                      label="combined2", db_path=db)
+        return db
+
+    def test_never_reviewed_filter(self, db_path):
+        result = api.list_nodes(never_reviewed=True, db_path=db_path)
+        ids = [n["id"] for n in result["nodes"]]
+        assert "derived-ab" in ids
+        assert "derived-cd" in ids
+        assert "premise-a" not in ids
+        assert "premise-b" not in ids
+
+    def test_never_reviewed_excludes_reviewed(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            api.review_beliefs(belief_ids=["derived-ab"], db_path=db_path)
+
+        result = api.list_nodes(never_reviewed=True, db_path=db_path)
+        ids = [n["id"] for n in result["nodes"]]
+        assert "derived-ab" not in ids
+        assert "derived-cd" in ids
+
+    def test_not_reviewed_since_includes_never_reviewed(self, db_path):
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            api.review_beliefs(belief_ids=["derived-ab"], db_path=db_path)
+
+        result = api.list_nodes(not_reviewed_since=30, db_path=db_path)
+        ids = [n["id"] for n in result["nodes"]]
+        assert "derived-cd" in ids
+        assert "derived-ab" not in ids
+
+    def test_by_impact_sort(self, db_path):
+        result = api.list_nodes(by_impact=True, db_path=db_path)
+        counts = [n["dependent_count"] for n in result["nodes"]]
+        assert counts == sorted(counts, reverse=True)
+
+    def test_list_includes_review_fields(self, db_path):
+        result = api.list_nodes(db_path=db_path)
+        for node in result["nodes"]:
+            assert "last_reviewed" in node
+            assert "review_result" in node


### PR DESCRIPTION
## Summary

- `review_beliefs()` now writes `last_reviewed` timestamp and `review_result` (pass/invalid/insufficient/unnecessary) to each reviewed node's metadata, creating a persistent audit trail
- `cmd_review_beliefs` automatically writes a structured JSON report to `reviews/` with full results for every reviewed belief (not just failures)
- `reasons list` gains `--never-reviewed`, `--not-reviewed-since DAYS`, and `--by-impact` filters for review-aware querying

Closes #114

## Test plan

- [x] 42 review tests pass (16 new tests added)
- [x] Full test suite passes (806 passed, 106 skipped)
- [ ] Run `reasons review-beliefs --sample 3` on a real network and verify JSON report and metadata
- [ ] Run `reasons list --never-reviewed --status IN` and verify output
- [ ] Run `reasons list --not-reviewed-since 7 --by-impact` and verify sort order