### PR TITLE
Add JSON report generation to derive command

### DIFF
--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -721,10 +721,11 @@ def cmd_deduplicate(args):
         print(f"  reasons deduplicate --accept {output}")
 
 
-def _derive_one_round(args, round_num=None):
+def _derive_one_round(args, round_num=None, report_state=None):
     """Run a single derive round. Returns number of beliefs added (0 = saturated).
 
     Used by cmd_derive for both single-round and --exhaust mode.
+    If report_state is provided, appends round results and writes the report.
     """
     import subprocess
 
@@ -803,6 +804,14 @@ def _derive_one_round(args, round_num=None):
 
     if not proposals:
         print(f"{prefix}No new proposals — network saturated.", file=sys.stderr)
+        if report_state is not None:
+            report_state["rounds"].append({
+                "round": round_num or 1,
+                "network_stats": stats,
+                "proposals_found": 0, "valid": 0,
+                "skipped": [], "applied": [], "added": 0,
+            })
+            _write_derive_report(report_state, "partial")
         return 0
 
     valid, skipped = validate_proposals(proposals, nodes)
@@ -813,7 +822,20 @@ def _derive_one_round(args, round_num=None):
     print(f"\n{prefix}{len(valid)} valid proposals "
           f"({len(skipped)} skipped)", file=sys.stderr)
 
+    round_result = {
+        "round": round_num or 1,
+        "network_stats": stats,
+        "proposals_found": len(proposals),
+        "valid": len(valid),
+        "skipped": [{"id": p["id"], "reason": reason} for p, reason in skipped],
+        "applied": [],
+        "added": 0,
+    }
+
     if not valid:
+        if report_state is not None:
+            report_state["rounds"].append(round_result)
+            _write_derive_report(report_state, "partial")
         return 0
 
     if args.auto or args.exhaust:
@@ -822,20 +844,78 @@ def _derive_one_round(args, round_num=None):
         for p, result in results:
             if isinstance(result, dict):
                 print(f"  Added {p['id']} [{result['truth_value']}]")
+                round_result["applied"].append({
+                    "id": p["id"], "truth_value": result["truth_value"],
+                })
                 added += 1
             else:
                 print(f"  FAIL {p['id']}: {result}", file=sys.stderr)
+        round_result["added"] = added
         if added:
             print(f"\n{prefix}Added {added} derived beliefs.", file=sys.stderr)
+        if report_state is not None:
+            report_state["rounds"].append(round_result)
+            _write_derive_report(report_state, "partial")
         return added
     else:
         output_path = Path(args.output)
         write_proposals_file(valid, output_path)
         print(f"\n{prefix}Wrote {output_path} ({len(valid)} proposals)")
+        round_result["added"] = len(valid)
+        if report_state is not None:
+            report_state["rounds"].append(round_result)
+            _write_derive_report(report_state, "partial")
         return len(valid)
 
 
+def _write_derive_report(report_state, status):
+    """Write derive JSON report to disk."""
+    import json
+    if report_state.get("report_path") is None:
+        return
+    total = sum(r["added"] for r in report_state["rounds"])
+    report = {
+        "timestamp": report_state["ts"],
+        "status": status,
+        "model": report_state["model"],
+        "timeout": report_state["timeout"],
+        "exhaust": report_state["exhaust"],
+        "filters": report_state["filters"],
+        "rounds": report_state["rounds"],
+        "total_added": total,
+    }
+    report_state["report_path"].write_text(json.dumps(report, indent=2))
+
+
 def cmd_derive(args):
+    from datetime import datetime
+
+    report_state = None
+    if not args.no_report:
+        ts = datetime.now().isoformat(timespec="seconds")
+        report_dir = Path(args.report_dir)
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_path = report_dir / f"derive-{ts.replace(':', '')}.json"
+        model = args.model or "claude"
+        report_state = {
+            "report_path": report_path,
+            "ts": ts,
+            "model": model,
+            "timeout": args.timeout,
+            "exhaust": args.exhaust,
+            "filters": {
+                "domain": args.domain,
+                "topic": args.topic,
+                "min_depth": args.min_depth,
+                "max_depth": args.max_depth,
+                "premises": args.premises,
+                "has_dependents": args.has_dependents,
+                "budget": args.budget,
+                "sample": args.sample,
+            },
+            "rounds": [],
+        }
+
     if args.exhaust:
         max_rounds = args.max_rounds
         total_added = 0
@@ -843,7 +923,8 @@ def cmd_derive(args):
             print(f"\n{'=' * 40}", file=sys.stderr)
             print(f"Round {round_num}/{max_rounds}", file=sys.stderr)
             print(f"{'=' * 40}", file=sys.stderr)
-            added = _derive_one_round(args, round_num=round_num)
+            added = _derive_one_round(args, round_num=round_num,
+                                      report_state=report_state)
             if added < 0:
                 print(f"\nExhaust stopped: error in round {round_num}.",
                       file=sys.stderr)
@@ -851,14 +932,19 @@ def cmd_derive(args):
             if added == 0:
                 print(f"\nExhaust complete: saturated after {round_num} rounds. "
                       f"Total added: {total_added}.", file=sys.stderr)
-                return
+                break
             total_added += added
-        print(f"\nExhaust complete: hit max rounds ({max_rounds}). "
-              f"Total added: {total_added}.", file=sys.stderr)
+        else:
+            print(f"\nExhaust complete: hit max rounds ({max_rounds}). "
+                  f"Total added: {total_added}.", file=sys.stderr)
     else:
-        added = _derive_one_round(args)
+        added = _derive_one_round(args, report_state=report_state)
         if added < 0:
             sys.exit(1)
+
+    if report_state is not None:
+        _write_derive_report(report_state, "complete")
+        print(f"  Report: {report_state['report_path']}")
 
 
 def cmd_accept(args):
@@ -1327,6 +1413,10 @@ def main():
                    help="Repeat derive until no new proposals (implies --auto)")
     p.add_argument("--max-rounds", type=int, default=10,
                    help="Maximum rounds for --exhaust (default: 10)")
+    p.add_argument("--report-dir", default="reviews/",
+                   help="Directory for JSON reports (default: reviews/)")
+    p.add_argument("--no-report", action="store_true",
+                   help="Suppress JSON report generation")
 
     # accept
     p = sub.add_parser("accept", help="Accept proposals from a derive proposals file")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -861,7 +861,8 @@ def _derive_one_round(args, round_num=None, report_state=None):
         output_path = Path(args.output)
         write_proposals_file(valid, output_path)
         print(f"\n{prefix}Wrote {output_path} ({len(valid)} proposals)")
-        round_result["added"] = len(valid)
+        round_result["added"] = 0
+        round_result["proposed"] = len(valid)
         if report_state is not None:
             report_state["rounds"].append(round_result)
             _write_derive_report(report_state, "partial")

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -775,3 +775,119 @@ def test_dedup_plan_user_can_edit_kept(db):
     assert node["truth_value"] == "IN"
     node = api.show_node("gl108-validation-disabled", db_path=db)
     assert node["truth_value"] == "OUT"
+
+
+# --- Derive report tests ---
+
+import json
+import sys
+from io import StringIO
+from unittest.mock import patch
+from reasons_lib.cli import main
+
+
+def _run_cli(*args, db_path=None):
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+        except SystemExit as e:
+            return stdout.getvalue(), stderr.getvalue(), e.code
+    return stdout.getvalue(), stderr.getvalue(), 0
+
+
+def _mock_derive_response(proposals):
+    """Build a mock LLM response with DERIVE blocks."""
+    blocks = []
+    for p in proposals:
+        ants = ", ".join(p["antecedents"])
+        blocks.append(
+            f"### DERIVE {p['id']}\n"
+            f"{p['text']}\n"
+            f"- Antecedents: {ants}\n"
+            f"- Label: test derivation"
+        )
+    text = "\n\n".join(blocks)
+    return type("R", (), {"returncode": 0, "stdout": text, "stderr": ""})()
+
+
+def test_derive_report_written(simple_network, tmp_path):
+    report_dir = str(tmp_path / "reports")
+    mock_result = _mock_derive_response([
+        {"id": "new-belief", "text": "A new derived belief",
+         "antecedents": ["fact-a", "fact-b"]},
+    ])
+    with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+         patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+        stdout, stderr, code = _run_cli(
+            "derive", "--auto", "--report-dir", report_dir,
+            db_path=simple_network)
+
+    import os
+    reports = [f for f in os.listdir(report_dir) if f.startswith("derive-")]
+    assert len(reports) == 1
+
+    with open(os.path.join(report_dir, reports[0])) as f:
+        report = json.load(f)
+    assert report["status"] == "complete"
+    assert report["model"] == "claude"
+    assert len(report["rounds"]) == 1
+    assert report["rounds"][0]["proposals_found"] >= 1
+    assert report["rounds"][0]["added"] >= 1
+    assert report["total_added"] >= 1
+
+
+def test_derive_no_report_flag(simple_network, tmp_path):
+    report_dir = str(tmp_path / "reports")
+    mock_result = _mock_derive_response([
+        {"id": "new-belief-2", "text": "Another belief",
+         "antecedents": ["fact-a"]},
+    ])
+    with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+         patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+        stdout, stderr, code = _run_cli(
+            "derive", "--auto", "--no-report", "--report-dir", report_dir,
+            db_path=simple_network)
+
+    assert "Report:" not in stdout
+    import os
+    assert not os.path.exists(report_dir)
+
+
+def test_derive_exhaust_report_has_rounds(simple_network, tmp_path):
+    report_dir = str(tmp_path / "reports")
+    call_count = [0]
+
+    def mock_run(*a, **kw):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return _mock_derive_response([
+                {"id": "round1-belief", "text": "From round 1",
+                 "antecedents": ["fact-a"]},
+            ])
+        # Second round: no proposals (saturated)
+        return type("R", (), {"returncode": 0, "stdout": "No proposals.", "stderr": ""})()
+
+    with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+         patch("reasons_lib.llm.subprocess.run", side_effect=mock_run):
+        stdout, stderr, code = _run_cli(
+            "derive", "--exhaust", "--report-dir", report_dir,
+            db_path=simple_network)
+
+    import os
+    reports = [f for f in os.listdir(report_dir) if f.startswith("derive-")]
+    assert len(reports) == 1
+
+    with open(os.path.join(report_dir, reports[0])) as f:
+        report = json.load(f)
+    assert report["status"] == "complete"
+    assert report["exhaust"] is True
+    assert len(report["rounds"]) == 2
+    assert report["rounds"][0]["added"] >= 1
+    assert report["rounds"][1]["added"] == 0

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -829,6 +829,7 @@ def test_derive_report_written(simple_network, tmp_path):
             "derive", "--auto", "--report-dir", report_dir,
             db_path=simple_network)
 
+    assert code == 0
     import os
     reports = [f for f in os.listdir(report_dir) if f.startswith("derive-")]
     assert len(reports) == 1
@@ -855,6 +856,7 @@ def test_derive_no_report_flag(simple_network, tmp_path):
             "derive", "--auto", "--no-report", "--report-dir", report_dir,
             db_path=simple_network)
 
+    assert code == 0
     assert "Report:" not in stdout
     import os
     assert not os.path.exists(report_dir)
@@ -880,6 +882,7 @@ def test_derive_exhaust_report_has_rounds(simple_network, tmp_path):
             "derive", "--exhaust", "--report-dir", report_dir,
             db_path=simple_network)
 
+    assert code == 0
     import os
     reports = [f for f in os.listdir(report_dir) if f.startswith("derive-")]
     assert len(reports) == 1


### PR DESCRIPTION
## Summary
- Adds structured JSON report output to `derive`, mirroring the `review-beliefs` report pattern
- Reports include per-round proposal counts, applied beliefs, skipped entries, and network stats
- Supports `--exhaust` mode (multi-round reports with `rounds` array), `--report-dir`, and `--no-report` flags
- Reports are written incrementally after each round (partial status) with a final complete write

## Test plan
- [x] `test_derive_report_written` — verifies JSON report created with correct structure after `--auto` derive
- [x] `test_derive_no_report_flag` — `--no-report` suppresses report file creation
- [x] `test_derive_exhaust_report_has_rounds` — exhaust mode produces multi-round report with `exhaust: true`
- [x] Full test suite passes (815 passed, 106 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)