### PR TITLE
Add cluster-based derive for cross-domain discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = []
 test = ["pytest", "pytest-cov"]
 pg = ["psycopg[binary]>=3.1"]
 test-pg = ["psycopg[binary]>=3.1", "pytest", "pytest-cov"]
+cluster = ["sentence-transformers>=2.2", "scikit-learn>=1.2"]
 
 [project.scripts]
 reasons = "reasons_lib.cli:main"

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -721,7 +721,8 @@ def cmd_deduplicate(args):
         print(f"  reasons deduplicate --accept {output}")
 
 
-def _derive_one_round(args, round_num=None, report_state=None):
+def _derive_one_round(args, round_num=None, report_state=None,
+                      cluster_cache=None):
     """Run a single derive round. Returns number of beliefs added (0 = saturated).
 
     Used by cmd_derive for both single-round and --exhaust mode.
@@ -756,6 +757,8 @@ def _derive_one_round(args, round_num=None, report_state=None):
         budget=args.budget, sample=args.sample, seed=args.seed,
         min_depth=args.min_depth, max_depth_filter=args.max_depth,
         premises_only=args.premises, has_dependents=args.has_dependents,
+        cluster=args.cluster, cluster_cache=cluster_cache,
+        embedding_model=args.embedding_model, n_clusters=args.n_clusters,
     )
 
     print(f"{prefix}Network: {stats['total_in']} IN beliefs, "
@@ -767,7 +770,10 @@ def _derive_one_round(args, round_num=None, report_state=None):
         lo = stats.get("min_depth", 0)
         hi = stats.get("max_depth_filter", "∞")
         print(f"{prefix}Depth filter: {lo}–{hi}", file=sys.stderr)
-    if stats.get("sample"):
+    if stats.get("cluster"):
+        print(f"{prefix}Clustering: {stats['n_clusters']} clusters, "
+              f"model={stats['embedding_model']}", file=sys.stderr)
+    elif stats.get("sample"):
         print(f"{prefix}Sampling: {stats['budget']} beliefs (random)", file=sys.stderr)
     elif stats.get("budget", 300) != 300:
         print(f"{prefix}Budget: {stats['budget']} beliefs", file=sys.stderr)
@@ -891,6 +897,23 @@ def _write_derive_report(report_state, status):
 def cmd_derive(args):
     from datetime import datetime
 
+    if args.cluster and args.sample:
+        print("Error: --cluster and --sample are mutually exclusive.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    cluster_cache = None
+    if args.cluster:
+        try:
+            from .cluster import ClusterCache
+            print("Loading embedding model...", file=sys.stderr)
+            cluster_cache = ClusterCache(
+                model_name=args.embedding_model or "all-MiniLM-L6-v2"
+            )
+        except ImportError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
     report_state = None
     if not args.no_report:
         ts = datetime.now().isoformat(timespec="seconds")
@@ -913,6 +936,8 @@ def cmd_derive(args):
                 "has_dependents": args.has_dependents,
                 "budget": args.budget,
                 "sample": args.sample,
+                "cluster": args.cluster,
+                "embedding_model": args.embedding_model,
             },
             "rounds": [],
         }
@@ -925,7 +950,8 @@ def cmd_derive(args):
             print(f"Round {round_num}/{max_rounds}", file=sys.stderr)
             print(f"{'=' * 40}", file=sys.stderr)
             added = _derive_one_round(args, round_num=round_num,
-                                      report_state=report_state)
+                                      report_state=report_state,
+                                      cluster_cache=cluster_cache)
             if added < 0:
                 print(f"\nExhaust stopped: error in round {round_num}.",
                       file=sys.stderr)
@@ -939,7 +965,8 @@ def cmd_derive(args):
             print(f"\nExhaust complete: hit max rounds ({max_rounds}). "
                   f"Total added: {total_added}.", file=sys.stderr)
     else:
-        added = _derive_one_round(args, report_state=report_state)
+        added = _derive_one_round(args, report_state=report_state,
+                                  cluster_cache=cluster_cache)
         if added < 0:
             sys.exit(1)
 
@@ -1418,6 +1445,13 @@ def main():
                    help="Directory for JSON reports (default: reviews/)")
     p.add_argument("--no-report", action="store_true",
                    help="Suppress JSON report generation")
+    p.add_argument("--cluster", action="store_true",
+                   help="Use semantic clustering to sample across domains")
+    p.add_argument("--embedding-model", default=None,
+                   help="Sentence-transformers model for --cluster "
+                        "(default: all-MiniLM-L6-v2)")
+    p.add_argument("--n-clusters", type=int, default=None,
+                   help="Override automatic cluster count for --cluster")
 
     # accept
     p = sub.add_parser("accept", help="Accept proposals from a derive proposals file")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -938,6 +938,7 @@ def cmd_derive(args):
                 "sample": args.sample,
                 "cluster": args.cluster,
                 "embedding_model": args.embedding_model,
+                "n_clusters": args.n_clusters,
             },
             "rounds": [],
         }

--- a/reasons_lib/cluster.py
+++ b/reasons_lib/cluster.py
@@ -1,0 +1,143 @@
+"""Semantic clustering for cross-domain belief selection.
+
+Embeds belief texts using sentence-transformers and clusters with KMeans
+to enable cross-cluster sampling in the derive pipeline.
+
+Requires: pip install 'ftl-reasons[cluster]'
+"""
+
+import random
+from hashlib import sha256
+
+try:
+    from sentence_transformers import SentenceTransformer
+    import numpy as np
+    from sklearn.cluster import KMeans
+    HAS_CLUSTER_DEPS = True
+except ImportError:
+    SentenceTransformer = None
+    np = None
+    KMeans = None
+    HAS_CLUSTER_DEPS = False
+
+DEFAULT_MODEL = "all-MiniLM-L6-v2"
+
+
+def _require_cluster_deps():
+    if not HAS_CLUSTER_DEPS:
+        raise ImportError(
+            "sentence-transformers and scikit-learn are required for --cluster mode. "
+            "Install them with: pip install 'ftl-reasons[cluster]'"
+        )
+
+
+class ClusterCache:
+    """Cache embeddings across derive rounds for --exhaust mode."""
+
+    def __init__(self, model_name=DEFAULT_MODEL):
+        _require_cluster_deps()
+        self.model = SentenceTransformer(model_name)
+        self.model_name = model_name
+        self._cache = {}
+
+    def embed(self, beliefs):
+        """Embed belief texts, using cache for previously seen beliefs.
+
+        Args:
+            beliefs: {node_id: text} dict
+
+        Returns:
+            (ids_list, embeddings_array) — ordered consistently
+        """
+        ids = sorted(beliefs.keys())
+        uncached_ids = []
+        uncached_texts = []
+
+        for nid in ids:
+            text = beliefs[nid]
+            key = (nid, sha256(text.encode()).hexdigest()[:16])
+            if key not in self._cache:
+                uncached_ids.append(nid)
+                uncached_texts.append(text)
+
+        if uncached_texts:
+            new_embeddings = self.model.encode(uncached_texts, show_progress_bar=False)
+            for i, nid in enumerate(uncached_ids):
+                text = beliefs[nid]
+                key = (nid, sha256(text.encode()).hexdigest()[:16])
+                self._cache[key] = new_embeddings[i]
+
+        embeddings = []
+        for nid in ids:
+            text = beliefs[nid]
+            key = (nid, sha256(text.encode()).hexdigest()[:16])
+            embeddings.append(self._cache[key])
+
+        return ids, np.array(embeddings)
+
+
+def cluster_beliefs(beliefs, budget, seed=None, n_clusters=None,
+                    cache=None, model_name=DEFAULT_MODEL):
+    """Cluster beliefs and sample across cluster boundaries.
+
+    Args:
+        beliefs: {node_id: text} for IN non-derived beliefs
+        budget: max beliefs to select
+        seed: random seed for KMeans and sampling
+        n_clusters: override automatic cluster count
+        cache: optional ClusterCache for embedding reuse
+        model_name: sentence-transformers model name
+
+    Returns:
+        (selected_ids, cluster_stats) where cluster_stats contains
+        n_clusters, cluster_sizes, and embedding_model.
+    """
+    _require_cluster_deps()
+
+    if len(beliefs) <= budget:
+        return list(beliefs.keys()), {
+            "n_clusters": 1,
+            "cluster_sizes": [len(beliefs)],
+            "embedding_model": model_name,
+        }
+
+    if cache is None:
+        cache = ClusterCache(model_name)
+
+    ids, embeddings = cache.embed(beliefs)
+
+    if n_clusters is None:
+        k = len(beliefs) // 5
+        k = min(k, budget // 3, 20)
+        k = max(k, 2)
+    else:
+        k = max(n_clusters, 2)
+
+    k = min(k, len(beliefs))
+
+    km = KMeans(n_clusters=k, random_state=seed, n_init=10)
+    labels = km.fit_predict(embeddings)
+
+    clusters = {}
+    for i, nid in enumerate(ids):
+        clusters.setdefault(labels[i], []).append(nid)
+
+    cluster_sizes = [len(clusters[c]) for c in sorted(clusters)]
+
+    rng = random.Random(seed)
+    base_per = budget // k
+    remainder = budget % k
+
+    selected = []
+    sorted_labels = sorted(clusters, key=lambda c: -len(clusters[c]))
+    for i, label in enumerate(sorted_labels):
+        members = clusters[label]
+        alloc = base_per + (1 if i < remainder else 0)
+        alloc = min(alloc, len(members))
+        selected.extend(rng.sample(members, alloc))
+
+    return selected, {
+        "n_clusters": k,
+        "cluster_sizes": cluster_sizes,
+        "embedding_model": cache.model_name,
+    }

--- a/reasons_lib/cluster.py
+++ b/reasons_lib/cluster.py
@@ -111,7 +111,7 @@ def cluster_beliefs(beliefs, budget, seed=None, n_clusters=None,
         k = min(k, budget // 3, 20)
         k = max(k, 2)
     else:
-        k = max(n_clusters, 2)
+        k = max(n_clusters, 1)
 
     k = min(k, len(beliefs))
 

--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -179,7 +179,7 @@ def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
         n_clusters: Override automatic cluster count.
 
     Returns:
-        (section_text, cluster_stats) if cluster=True, else section_text.
+        (section_text, cluster_stats) — cluster_stats is None when cluster=False.
     """
     lines = []
     rng = random.Random(seed) if sample else None
@@ -315,7 +315,7 @@ def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
                     lines.append(f"- `{belief_id}`: {text}")
                     count += 1
 
-    return "\n".join(lines)
+    return "\n".join(lines), None
 
 
 def _build_derived_section(nodes, derived):
@@ -488,17 +488,12 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
             parts.append(f"  - {name}: {len(agents[name])} beliefs")
         agents_stats = "\n".join(parts)
 
-    cluster_stats = None
-    result = _build_beliefs_section(
+    beliefs_section, cluster_stats = _build_beliefs_section(
         nodes, derived, agents, max_beliefs=budget,
         sample=sample, seed=seed,
         cluster=cluster, cluster_cache=cluster_cache,
         embedding_model=embedding_model, n_clusters=n_clusters,
     )
-    if cluster:
-        beliefs_section, cluster_stats = result
-    else:
-        beliefs_section = result
     derived_section = _build_derived_section(nodes, derived)
 
     prompt = DERIVE_PROMPT.format(

--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -164,18 +164,74 @@ def _sample_beliefs(belief_ids, budget, rng=None):
 
 
 def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
-                           sample=False, seed=None):
+                           sample=False, seed=None,
+                           cluster=False, cluster_cache=None,
+                           embedding_model=None, n_clusters=None):
     """Build a compact beliefs section for the derive prompt.
 
     Args:
         max_beliefs: Maximum number of beliefs to include (budget).
         sample: If True, randomly sample beliefs instead of alphabetical truncation.
         seed: Random seed for reproducible sampling.
+        cluster: If True, use semantic clustering to sample across domains.
+        cluster_cache: Optional ClusterCache for embedding reuse across rounds.
+        embedding_model: Sentence-transformers model name for clustering.
+        n_clusters: Override automatic cluster count.
+
+    Returns:
+        (section_text, cluster_stats) if cluster=True, else section_text.
     """
     lines = []
     rng = random.Random(seed) if sample else None
     in_nodes = {k: v for k, v in nodes.items()
                 if v.get("truth_value") == "IN" and k not in derived}
+
+    if cluster:
+        from .cluster import cluster_beliefs as _cluster
+        belief_texts = {k: v["text"] for k, v in in_nodes.items()}
+        selected_ids, cluster_stats = _cluster(
+            belief_texts, max_beliefs, seed=seed, n_clusters=n_clusters,
+            cache=cluster_cache, model_name=embedding_model or "all-MiniLM-L6-v2",
+        )
+        selected_set = set(selected_ids)
+
+        if agents:
+            for agent_name in sorted(agents, key=lambda a: -len(agents[a])):
+                agent_sel = sorted(k for k in selected_ids
+                                   if k.startswith(f"{agent_name}:"))
+                agent_total = sum(1 for k in in_nodes if k.startswith(f"{agent_name}:"))
+                if not agent_sel:
+                    continue
+                lines.append(f"\n### Agent: {agent_name} ({agent_total} beliefs, "
+                             f"showing {len(agent_sel)})")
+                for belief_id in agent_sel:
+                    text = in_nodes[belief_id]["text"][:120]
+                    lines.append(f"- `{belief_id}`: {text}")
+            local_sel = sorted(k for k in selected_ids if ":" not in k)
+            if local_sel:
+                local_total = sum(1 for k in in_nodes if ":" not in k)
+                lines.append(f"\n### Local beliefs ({local_total} beliefs, "
+                             f"showing {len(local_sel)})")
+                for belief_id in local_sel:
+                    text = in_nodes[belief_id]["text"][:120]
+                    lines.append(f"- `{belief_id}`: {text}")
+        else:
+            groups = defaultdict(list)
+            for k in selected_ids:
+                prefix = k.split("-")[0] if "-" in k else k
+                groups[prefix].append(k)
+            all_groups = defaultdict(list)
+            for k in in_nodes:
+                prefix = k.split("-")[0] if "-" in k else k
+                all_groups[prefix].append(k)
+            for prefix in sorted(groups, key=lambda p: -len(all_groups.get(p, []))):
+                lines.append(f"\n### {prefix} ({len(all_groups.get(prefix, []))} beliefs, "
+                             f"showing {len(groups[prefix])})")
+                for belief_id in sorted(groups[prefix]):
+                    text = in_nodes[belief_id]["text"][:120]
+                    lines.append(f"- `{belief_id}`: {text}")
+
+        return "\n".join(lines), cluster_stats
 
     if agents:
         # Allocate budget proportionally across agents
@@ -344,7 +400,9 @@ def parse_proposals(response):
 
 def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
                  seed=None, min_depth=None, max_depth_filter=None,
-                 premises_only=False, has_dependents=False):
+                 premises_only=False, has_dependents=False,
+                 cluster=False, cluster_cache=None, embedding_model=None,
+                 n_clusters=None):
     """Build the full derive prompt from a network's nodes dict.
 
     Args:
@@ -356,6 +414,10 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
         seed: Random seed for reproducible sampling.
         min_depth: Only include beliefs at this depth or deeper.
         max_depth_filter: Only include beliefs at this depth or shallower.
+        cluster: If True, use semantic clustering to sample across domains.
+        cluster_cache: Optional ClusterCache for embedding reuse across rounds.
+        embedding_model: Sentence-transformers model name for clustering.
+        n_clusters: Override automatic cluster count.
 
     Returns: (prompt_text, stats_dict)
     """
@@ -427,10 +489,17 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
             parts.append(f"  - {name}: {len(agents[name])} beliefs")
         agents_stats = "\n".join(parts)
 
-    beliefs_section = _build_beliefs_section(
+    cluster_stats = None
+    result = _build_beliefs_section(
         nodes, derived, agents, max_beliefs=budget,
         sample=sample, seed=seed,
+        cluster=cluster, cluster_cache=cluster_cache,
+        embedding_model=embedding_model, n_clusters=n_clusters,
     )
+    if cluster:
+        beliefs_section, cluster_stats = result
+    else:
+        beliefs_section = result
     derived_section = _build_derived_section(nodes, derived)
 
     prompt = DERIVE_PROMPT.format(
@@ -459,6 +528,11 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
         stats["max_depth_filter"] = max_depth_filter
     stats["budget"] = budget
     stats["sample"] = sample
+    if cluster and cluster_stats:
+        stats["cluster"] = True
+        stats["n_clusters"] = cluster_stats["n_clusters"]
+        stats["cluster_sizes"] = cluster_stats["cluster_sizes"]
+        stats["embedding_model"] = cluster_stats["embedding_model"]
 
     return prompt, stats
 

--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -193,7 +193,6 @@ def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
             belief_texts, max_beliefs, seed=seed, n_clusters=n_clusters,
             cache=cluster_cache, model_name=embedding_model or "all-MiniLM-L6-v2",
         )
-        selected_set = set(selected_ids)
 
         if agents:
             for agent_name in sorted(agents, key=lambda a: -len(agents[a])):

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,0 +1,108 @@
+"""Tests for semantic clustering in derive pipeline.
+
+Tests are skipped when sentence-transformers/scikit-learn are not installed.
+Install with: pip install 'ftl-reasons[cluster]'
+"""
+
+import pytest
+
+try:
+    from reasons_lib.cluster import (
+        cluster_beliefs, ClusterCache, _require_cluster_deps, HAS_CLUSTER_DEPS,
+    )
+except ImportError:
+    HAS_CLUSTER_DEPS = False
+
+skip_no_cluster = pytest.mark.skipif(
+    not HAS_CLUSTER_DEPS,
+    reason="sentence-transformers and scikit-learn not installed"
+)
+
+
+def test_require_cluster_deps_message():
+    """Error message mentions install command when deps missing."""
+    if HAS_CLUSTER_DEPS:
+        pytest.skip("deps are installed, can't test missing-dep path")
+    from reasons_lib.cluster import _require_cluster_deps
+    with pytest.raises(ImportError, match="ftl-reasons\\[cluster\\]"):
+        _require_cluster_deps()
+
+
+@skip_no_cluster
+def test_cluster_beliefs_under_budget():
+    beliefs = {f"b-{i}": f"Belief number {i}" for i in range(5)}
+    selected, stats = cluster_beliefs(beliefs, budget=10, seed=42)
+    assert set(selected) == set(beliefs.keys())
+    assert stats["n_clusters"] == 1
+
+
+@skip_no_cluster
+def test_cluster_beliefs_selects_budget():
+    beliefs = {f"b-{i}": f"Belief about topic {i} with some text" for i in range(50)}
+    selected, stats = cluster_beliefs(beliefs, budget=20, seed=42)
+    assert len(selected) == 20
+    assert stats["n_clusters"] >= 2
+
+
+@skip_no_cluster
+def test_cluster_beliefs_reproducible():
+    beliefs = {f"b-{i}": f"Belief about topic {i}" for i in range(50)}
+    sel1, _ = cluster_beliefs(beliefs, budget=20, seed=42)
+    sel2, _ = cluster_beliefs(beliefs, budget=20, seed=42)
+    assert sel1 == sel2
+
+
+@skip_no_cluster
+def test_cluster_beliefs_cross_domain():
+    auth_beliefs = {f"auth-{i}": f"Authentication and login security check {i}"
+                    for i in range(25)}
+    db_beliefs = {f"db-{i}": f"Database query performance and indexing {i}"
+                  for i in range(25)}
+    beliefs = {**auth_beliefs, **db_beliefs}
+    selected, stats = cluster_beliefs(beliefs, budget=20, seed=42)
+    has_auth = any(k.startswith("auth-") for k in selected)
+    has_db = any(k.startswith("db-") for k in selected)
+    assert has_auth and has_db, (
+        f"Expected beliefs from both domains, got: {selected}"
+    )
+
+
+@skip_no_cluster
+def test_cluster_cache_reuse():
+    beliefs = {f"b-{i}": f"Belief number {i}" for i in range(20)}
+    cache = ClusterCache()
+    ids1, emb1 = cache.embed(beliefs)
+    initial_cache_size = len(cache._cache)
+    ids2, emb2 = cache.embed(beliefs)
+    assert len(cache._cache) == initial_cache_size
+    assert ids1 == ids2
+
+
+@skip_no_cluster
+def test_cluster_cache_incremental():
+    beliefs1 = {f"b-{i}": f"Belief number {i}" for i in range(10)}
+    cache = ClusterCache()
+    cache.embed(beliefs1)
+    size_after_first = len(cache._cache)
+
+    beliefs2 = {**beliefs1, **{f"new-{i}": f"New belief {i}" for i in range(5)}}
+    cache.embed(beliefs2)
+    assert len(cache._cache) == size_after_first + 5
+
+
+@skip_no_cluster
+def test_cluster_stats_shape():
+    beliefs = {f"b-{i}": f"Belief about topic {i}" for i in range(30)}
+    _, stats = cluster_beliefs(beliefs, budget=15, seed=42)
+    assert "n_clusters" in stats
+    assert "cluster_sizes" in stats
+    assert "embedding_model" in stats
+    assert isinstance(stats["cluster_sizes"], list)
+    assert sum(stats["cluster_sizes"]) == 30
+
+
+@skip_no_cluster
+def test_cluster_n_clusters_override():
+    beliefs = {f"b-{i}": f"Belief about topic {i}" for i in range(50)}
+    _, stats = cluster_beliefs(beliefs, budget=20, seed=42, n_clusters=5)
+    assert stats["n_clusters"] == 5

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -894,3 +894,26 @@ def test_derive_exhaust_report_has_rounds(simple_network, tmp_path):
     assert len(report["rounds"]) == 2
     assert report["rounds"][0]["added"] >= 1
     assert report["rounds"][1]["added"] == 0
+
+
+# --- Cluster integration tests ---
+
+try:
+    from reasons_lib.cluster import HAS_CLUSTER_DEPS
+except ImportError:
+    HAS_CLUSTER_DEPS = False
+
+skip_no_cluster = pytest.mark.skipif(
+    not HAS_CLUSTER_DEPS,
+    reason="sentence-transformers and scikit-learn not installed"
+)
+
+
+@skip_no_cluster
+def test_build_prompt_with_cluster(simple_network):
+    nodes = api.export_network(db_path=simple_network)["nodes"]
+    prompt, stats = build_prompt(nodes, cluster=True, budget=10, seed=42)
+    assert stats.get("cluster") is True
+    assert "n_clusters" in stats
+    assert "embedding_model" in stats
+    assert len(prompt) > 0

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -917,3 +917,13 @@ def test_build_prompt_with_cluster(simple_network):
     assert "n_clusters" in stats
     assert "embedding_model" in stats
     assert len(prompt) > 0
+
+
+@skip_no_cluster
+def test_build_prompt_cluster_with_agents(agent_network):
+    nodes = api.export_network(db_path=agent_network)["nodes"]
+    prompt, stats = build_prompt(nodes, cluster=True, budget=10, seed=42)
+    assert stats.get("cluster") is True
+    assert stats["agents"] == 2
+    assert "Agent: agent-a" in prompt
+    assert "Agent: agent-b" in prompt

--- a/tests/test_derive_budget.py
+++ b/tests/test_derive_budget.py
@@ -73,7 +73,7 @@ class TestCountLinearNotQuadratic:
             {"agent-a": [f"b{i}" for i in range(6)]},
             local_beliefs=[f"local-{i}" for i in range(20)],
         )
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
         local_shown = _count_local_shown(output)
         assert local_shown > 5, "Bug regression: locals starved to floor"
         assert local_shown == 15
@@ -84,7 +84,7 @@ class TestCountLinearNotQuadratic:
             {"agent-a": [f"b{i}" for i in range(10)]},
             local_beliefs=[f"local-{i}" for i in range(50)],
         )
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
         agent_shown = _count_agent_shown(output, "agent-a")
         local_shown = _count_local_shown(output)
         total_used = agent_shown + local_shown
@@ -104,7 +104,7 @@ class TestMultiAgent:
             },
             local_beliefs=[f"local-{i}" for i in range(30)],
         )
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
         a_shown = _count_agent_shown(output, "agent-a")
         b_shown = _count_agent_shown(output, "agent-b")
         local_shown = _count_local_shown(output)
@@ -120,7 +120,7 @@ class TestMultiAgent:
             },
             local_beliefs=[f"local-{i}" for i in range(30)],
         )
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=30)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=30)
         total_agent = sum(
             _count_agent_shown(output, a) for a in ["alpha", "beta", "gamma"]
         )
@@ -143,7 +143,7 @@ class TestBudgetFloor:
             {"agent-a": [f"b{i}" for i in range(50)]},
             local_beliefs=[f"local-{i}" for i in range(10)],
         )
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
         local_shown = _count_local_shown(output)
         assert local_shown >= 5
 
@@ -158,7 +158,7 @@ class TestBudgetFloor:
             {"agent-a": [f"b{i}" for i in range(200)]},
             local_beliefs=[f"local-{i}" for i in range(10)],
         )
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
         local_shown = _count_local_shown(output)
         assert local_shown == 5
 
@@ -173,7 +173,7 @@ class TestEdgeCases:
             {"agent-a": ["only-one"]},
             local_beliefs=[f"local-{i}" for i in range(10)],
         )
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
         agent_shown = _count_agent_shown(output, "agent-a")
         local_shown = _count_local_shown(output)
         assert agent_shown == 1
@@ -184,7 +184,7 @@ class TestEdgeCases:
         nodes = {f"belief-{i}": {"truth_value": "IN", "text": f"Belief {i}"}
                  for i in range(10)}
         derived = {}
-        output = _build_beliefs_section(nodes, derived, agents=None, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents=None, max_beliefs=20)
         assert "Agent:" not in output
         assert "belief-" in output
 
@@ -194,18 +194,18 @@ class TestEdgeCases:
             {"agent-a": [f"b{i}" for i in range(5)]},
             local_beliefs=[],
         )
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
         assert "Local beliefs" not in output
         assert "Agent: agent-a" in output
 
     def test_empty_network(self):
         """Zero beliefs: no crash, produces output."""
-        output = _build_beliefs_section({}, {}, agents=None, max_beliefs=20)
+        output, _ = _build_beliefs_section({}, {}, agents=None, max_beliefs=20)
         assert isinstance(output, str)
 
     def test_empty_network_with_agents(self):
         """Agents dict provided but no matching nodes."""
-        output = _build_beliefs_section(
+        output, _ = _build_beliefs_section(
             {}, {}, agents={"agent-a": ["agent-a:missing"]}, max_beliefs=20,
         )
         assert isinstance(output, str)
@@ -223,7 +223,7 @@ class TestEdgeCases:
         }
         derived = {"agent-a:derived-1": nodes["agent-a:derived-1"]}
         agents = {"agent-a": ["agent-a:premise-1", "agent-a:premise-2", "agent-a:derived-1"]}
-        output = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
+        output, _ = _build_beliefs_section(nodes, derived, agents, max_beliefs=20)
         assert "Agent: agent-a" in output
 
 
@@ -237,7 +237,7 @@ class TestSampling:
             {"agent-a": [f"b{i}" for i in range(6)]},
             local_beliefs=[f"local-{i}" for i in range(20)],
         )
-        output = _build_beliefs_section(
+        output, _ = _build_beliefs_section(
             nodes, derived, agents, max_beliefs=20, sample=True, seed=42,
         )
         local_shown = _count_local_shown(output)
@@ -249,10 +249,10 @@ class TestSampling:
             {"agent-a": [f"b{i}" for i in range(20)]},
             local_beliefs=[f"local-{i}" for i in range(20)],
         )
-        out1 = _build_beliefs_section(
+        out1, _ = _build_beliefs_section(
             nodes, derived, agents, max_beliefs=15, sample=True, seed=99,
         )
-        out2 = _build_beliefs_section(
+        out2, _ = _build_beliefs_section(
             nodes, derived, agents, max_beliefs=15, sample=True, seed=99,
         )
         assert out1 == out2


### PR DESCRIPTION
## Summary
- Adds `--cluster` mode to `reasons derive` that embeds beliefs with sentence-transformers, clusters with KMeans, and samples across cluster boundaries for cross-domain derivation (closes #111)
- New optional dependency group: `pip install 'ftl-reasons[cluster]'` (sentence-transformers + scikit-learn)
- `ClusterCache` reuses embeddings across `--exhaust` rounds to avoid redundant computation
- New flags: `--cluster`, `--embedding-model`, `--n-clusters`
- Gracefully skips cluster tests when deps not installed; clear error message if `--cluster` used without deps

## Test plan
- [x] 8 unit tests in `test_cluster.py` (under_budget, selects_budget, reproducible, cross_domain, cache_reuse, cache_incremental, stats_shape, n_clusters_override)
- [x] 1 integration test in `test_derive.py` (`test_build_prompt_with_cluster`)
- [x] Full suite: 824 passed, 107 skipped
- [x] Smoke test: `reasons derive --cluster --budget 50 --dry-run` against 521-belief expert DB — 16 clusters found
- [x] `--cluster --sample` correctly errors as mutually exclusive

Generated with [Claude Code](https://claude.com/claude-code)
