### PR TITLE
Add remove-justification command

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -609,6 +609,14 @@ def convert_to_premise(node_id: str, db_path: str = DEFAULT_DB) -> dict:
         return net.convert_to_premise(node_id)
 
 
+def remove_justification(
+    node_id: str, index: int, db_path: str = DEFAULT_DB
+) -> dict:
+    """Remove a single justification by index and propagate."""
+    with _with_network(db_path, write=True) as net:
+        return net.remove_justification(node_id, index)
+
+
 def summarize(
     summary_id: str,
     text: str,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -79,6 +79,27 @@ def cmd_add_justification(args):
         sys.exit(1)
 
 
+def cmd_remove_justification(args):
+    try:
+        result = api.remove_justification(
+            node_id=args.node_id,
+            index=args.index,
+            db_path=args.db,
+        )
+        removed = result["removed"]
+        ants = ", ".join(removed["antecedents"])
+        label = f" [{removed['label']}]" if removed["label"] else ""
+        print(f"Removed justification {args.index} from {result['node_id']}")
+        print(f"  Was: {removed['type']}({ants}){label}")
+        print(f"  Truth value: {result['old_truth_value']} → {result['new_truth_value']}")
+        print(f"  Remaining justifications: {result['remaining']}")
+        if result["changed"]:
+            print(f"  Cascade: {', '.join(result['changed'])}")
+    except (KeyError, ValueError, IndexError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
 def _print_cascade(result):
     """Print cascade results, splitting went_out from went_in."""
     went_out = result.get("went_out", [])
@@ -1316,6 +1337,11 @@ def main():
     p.add_argument("--label", help="Justification label")
     p.add_argument("-n", "--namespace", help="Namespace prefix")
 
+    # remove-justification
+    p = sub.add_parser("remove-justification", help="Remove a justification by index")
+    p.add_argument("node_id", help="Node to remove justification from")
+    p.add_argument("index", type=int, help="0-based justification index (see 'show' output)")
+
     # retract
     p = sub.add_parser("retract", help="Retract a node (mark OUT + cascade)")
     p.add_argument("node_id", help="Node to retract")
@@ -1632,6 +1658,7 @@ def main():
         "init": cmd_init,
         "add": cmd_add,
         "add-justification": cmd_add_justification,
+        "remove-justification": cmd_remove_justification,
         "retract": cmd_retract,
         "assert": cmd_assert,
         "what-if": cmd_what_if,

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -643,6 +643,70 @@ class Network:
             "changed": changed,
         }
 
+    def remove_justification(self, node_id: str, index: int) -> dict:
+        """Remove a single justification by index and propagate."""
+        if node_id not in self.nodes:
+            raise KeyError(f"Node '{node_id}' not found")
+
+        node = self.nodes[node_id]
+
+        if not node.justifications:
+            raise ValueError(f"Node '{node_id}' is a premise (no justifications)")
+
+        if index < 0 or index >= len(node.justifications):
+            raise IndexError(
+                f"Justification index {index} out of range "
+                f"(node has {len(node.justifications)})"
+            )
+
+        if len(node.justifications) == 1:
+            raise ValueError(
+                f"Node '{node_id}' has only one justification; "
+                f"use 'convert-to-premise' or 'retract' instead"
+            )
+
+        old_value = node.truth_value
+        removed = node.justifications.pop(index)
+
+        # Clean up dependents for antecedents/outlist that no longer appear
+        # in any remaining justification
+        remaining_refs = set()
+        for j in node.justifications:
+            remaining_refs.update(j.antecedents)
+            remaining_refs.update(j.outlist)
+
+        for ant_id in removed.antecedents:
+            if ant_id not in remaining_refs and ant_id in self.nodes:
+                self.nodes[ant_id].dependents.discard(node_id)
+        for out_id in removed.outlist:
+            if out_id not in remaining_refs and out_id in self.nodes:
+                self.nodes[out_id].dependents.discard(node_id)
+
+        new_value = self._compute_truth(node)
+        changed = []
+
+        if old_value != new_value:
+            node.truth_value = new_value
+            changed.append(node_id)
+            changed.extend(self._propagate(node_id))
+
+        self._log("remove-justification", node_id, new_value)
+
+        removed_dict = {
+            "type": removed.type,
+            "antecedents": removed.antecedents,
+            "outlist": removed.outlist,
+            "label": removed.label,
+        }
+        return {
+            "node_id": node_id,
+            "old_truth_value": old_value,
+            "new_truth_value": new_value,
+            "removed": removed_dict,
+            "remaining": len(node.justifications),
+            "changed": changed,
+        }
+
     def summarize(
         self,
         summary_id: str,

--- a/tests/test_remove_justification.py
+++ b/tests/test_remove_justification.py
@@ -1,0 +1,187 @@
+"""Tests for remove-justification: removing individual justifications by index."""
+
+import pytest
+
+from reasons_lib import Justification, api
+from reasons_lib.network import Network
+
+
+class TestNetworkRemoveJustification:
+    def test_remove_one_of_two(self):
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node("b", "Premise B")
+        net.add_node(
+            "c", "Derived C",
+            justifications=[
+                Justification(type="SL", antecedents=["a"], label="first"),
+                Justification(type="SL", antecedents=["b"], label="second"),
+            ],
+        )
+        result = net.remove_justification("c", 0)
+        assert result["removed"]["label"] == "first"
+        assert result["remaining"] == 1
+        assert len(net.nodes["c"].justifications) == 1
+        assert net.nodes["c"].justifications[0].label == "second"
+
+    def test_remove_causes_out(self):
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node("b", "Premise B")
+        net.retract("b")
+        net.add_node(
+            "c", "Derived C",
+            justifications=[
+                Justification(type="SL", antecedents=["a"]),
+                Justification(type="SL", antecedents=["b"]),
+            ],
+        )
+        assert net.nodes["c"].truth_value == "IN"
+        result = net.remove_justification("c", 0)
+        assert result["old_truth_value"] == "IN"
+        assert result["new_truth_value"] == "OUT"
+
+    def test_remove_propagates_cascade(self):
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node("b", "Premise B")
+        net.retract("b")
+        net.add_node(
+            "c", "Derived C",
+            justifications=[
+                Justification(type="SL", antecedents=["a"]),
+                Justification(type="SL", antecedents=["b"]),
+            ],
+        )
+        net.add_node(
+            "d", "Derived D",
+            justifications=[Justification(type="SL", antecedents=["c"])],
+        )
+        assert net.nodes["d"].truth_value == "IN"
+        result = net.remove_justification("c", 0)
+        assert "d" in result["changed"]
+        assert net.nodes["d"].truth_value == "OUT"
+
+    def test_remove_cleans_dependents(self):
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node("b", "Premise B")
+        net.add_node(
+            "c", "Derived C",
+            justifications=[
+                Justification(type="SL", antecedents=["a"]),
+                Justification(type="SL", antecedents=["b"]),
+            ],
+        )
+        assert "c" in net.nodes["a"].dependents
+        assert "c" in net.nodes["b"].dependents
+        net.remove_justification("c", 0)
+        assert "c" not in net.nodes["a"].dependents
+        assert "c" in net.nodes["b"].dependents
+
+    def test_remove_keeps_shared_dependent(self):
+        """If a node appears in multiple justifications, don't remove from dependents."""
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node("b", "Premise B")
+        net.add_node(
+            "c", "Derived C",
+            justifications=[
+                Justification(type="SL", antecedents=["a", "b"]),
+                Justification(type="SL", antecedents=["a"]),
+            ],
+        )
+        net.remove_justification("c", 0)
+        assert "c" in net.nodes["a"].dependents
+
+    def test_remove_outlist_cleans_dependents(self):
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node("blocker", "Blocker")
+        net.retract("blocker")
+        net.add_node(
+            "c", "Gated C",
+            justifications=[
+                Justification(type="SL", antecedents=["a"], outlist=["blocker"]),
+                Justification(type="SL", antecedents=["a"]),
+            ],
+        )
+        assert "c" in net.nodes["blocker"].dependents
+        net.remove_justification("c", 0)
+        assert "c" not in net.nodes["blocker"].dependents
+
+    def test_error_on_premise(self):
+        net = Network()
+        net.add_node("a", "Premise A")
+        with pytest.raises(ValueError, match="premise"):
+            net.remove_justification("a", 0)
+
+    def test_error_on_single_justification(self):
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node(
+            "b", "Derived B",
+            justifications=[Justification(type="SL", antecedents=["a"])],
+        )
+        with pytest.raises(ValueError, match="only one justification"):
+            net.remove_justification("b", 0)
+
+    def test_error_on_bad_index(self):
+        net = Network()
+        net.add_node("a", "Premise A")
+        net.add_node("b", "Premise B")
+        net.add_node(
+            "c", "Derived C",
+            justifications=[
+                Justification(type="SL", antecedents=["a"]),
+                Justification(type="SL", antecedents=["b"]),
+            ],
+        )
+        with pytest.raises(IndexError, match="out of range"):
+            net.remove_justification("c", 5)
+
+    def test_error_on_missing_node(self):
+        net = Network()
+        with pytest.raises(KeyError, match="not found"):
+            net.remove_justification("nonexistent", 0)
+
+
+class TestApiRemoveJustification:
+    def test_api_remove_justification(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        api.add_node("a", "Premise A", db_path=db)
+        api.add_node("b", "Premise B", db_path=db)
+        api.add_node("c", "Derived C", sl="a", db_path=db)
+        api.add_justification("c", sl="b", db_path=db)
+
+        node = api.show_node("c", db_path=db)
+        assert len(node["justifications"]) == 2
+
+        result = api.remove_justification("c", 0, db_path=db)
+        assert result["remaining"] == 1
+
+        node = api.show_node("c", db_path=db)
+        assert len(node["justifications"]) == 1
+
+
+class TestCliRemoveJustification:
+    def test_cli_remove_justification(self, tmp_path):
+        import subprocess
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        api.add_node("a", "Premise A", db_path=db)
+        api.add_node("b", "Premise B", db_path=db)
+        api.add_node("c", "Derived C", sl="a", db_path=db)
+        api.add_justification("c", sl="b", label="keep-this", db_path=db)
+
+        result = subprocess.run(
+            ["uv", "run", "reasons", "--db", db, "remove-justification", "c", "0"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "Removed justification 0" in result.stdout
+
+        node = api.show_node("c", db_path=db)
+        assert len(node["justifications"]) == 1
+        assert node["justifications"][0]["label"] == "keep-this"


### PR DESCRIPTION
## Summary

- Add `remove-justification` command to remove individual justifications by 0-based index
- Correctly cleans up dependents index (only removes refs not used by remaining justifications)
- Propagates truth value changes after removal
- Guards against removing from premises, single-justification nodes, and out-of-range indices
- 12 tests covering network, API, and CLI layers

Closes #124

## Test plan

- [x] `uv run pytest tests/test_remove_justification.py -v` — 12 tests pass
- [x] Full suite: 837 passed, 107 skipped
- [ ] Manual: `reasons show <node>` to see indices, `reasons remove-justification <node> <index>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
