### PR TITLE
Add PostgreSQL backend support via --pg flag

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1774,12 +1774,16 @@ def list_nodes(
 def list_gated(
     visible_to: list[str] | None = None,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Find OUT nodes blocked by IN outlist nodes (active gates).
 
     Returns: {"blockers": {blocker_id: {"text": str, "gated": [{"id": str, "text": str}]}},
               "gated_count": int, "blocker_count": int}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "list_gated",
+                            visible_to=visible_to)
     with _with_network(db_path) as net:
         blockers: dict[str, dict] = {}
         for nid, node in sorted(net.nodes.items()):

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -264,7 +264,20 @@ def add_justification(
     db_path: str = DEFAULT_DB,
     pg_conninfo=None, project_id=None,
 ) -> dict:
-    """Add a new justification to an existing node."""
+    """Add a new justification to an existing node.
+
+    Args:
+        node_id: Node to add justification to
+        sl: Comma-separated antecedent IDs for SL justification
+        cp: Comma-separated antecedent IDs for CP justification
+        unless: Comma-separated outlist IDs (must be OUT for justification to hold)
+        label: Justification label
+        namespace: Optional namespace prefix (not supported with PostgreSQL)
+        any_mode: If True, expand SL into one justification per antecedent (OR; not supported with PostgreSQL)
+        db_path: Path to RMS database
+
+    Returns: {"node_id", "old_truth_value", "new_truth_value", "changed", "premise_count"}
+    """
     if pg_conninfo:
         if namespace or any_mode:
             raise NotImplementedError("namespace and any_mode are not supported with PostgreSQL")

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1228,6 +1228,8 @@ def export_markdown(visible_to: list[str] | None = None, db_path: str = DEFAULT_
             node.truth_value = ndata.get("truth_value", "OUT")
             node.source = ndata.get("source", "")
             node.source_url = ndata.get("source_url", "")
+            node.source_hash = ndata.get("source_hash", "")
+            node.date = ndata.get("date", "")
             node.metadata = ndata.get("metadata", {})
             for jdata in ndata.get("justifications", []):
                 j = Justification(
@@ -1238,6 +1240,14 @@ def export_markdown(visible_to: list[str] | None = None, db_path: str = DEFAULT_
                 )
                 node.justifications.append(j)
             net.nodes[nid] = node
+        for nid, node in net.nodes.items():
+            for j in node.justifications:
+                for ant_id in j.antecedents:
+                    if ant_id in net.nodes:
+                        net.nodes[ant_id].dependents.add(nid)
+                for out_id in j.outlist:
+                    if out_id in net.nodes:
+                        net.nodes[out_id].dependents.add(nid)
         for ngdata in data.get("nogoods", []):
             net.nogoods.append(Nogood(
                 id=ngdata.get("id", ""),
@@ -1425,6 +1435,8 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
     Returns: formatted string with matched nodes and neighbors
     """
     if pg_conninfo:
+        if depth != 1:
+            raise NotImplementedError("depth is not supported with PostgreSQL")
         return _pg_dispatch(pg_conninfo, project_id, "search",
                             query=query, visible_to=visible_to, format=format)
     with _with_network(db_path) as net:

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -66,11 +66,21 @@ def _with_network(db_path: str, write: bool = False):
     return _Ctx()
 
 
-def init_db(db_path: str = DEFAULT_DB, force: bool = False) -> dict:
+def _pg_dispatch(pg_conninfo, project_id, method_name, **kwargs):
+    """Dispatch a call to the PostgreSQL backend."""
+    from .pg import PgApi
+    with PgApi(pg_conninfo, project_id) as pg:
+        return getattr(pg, method_name)(**kwargs)
+
+
+def init_db(db_path: str = DEFAULT_DB, force: bool = False,
+            pg_conninfo=None, project_id=None) -> dict:
     """Initialize a new RMS database.
 
     Returns: {"db_path": str, "created": bool}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "init_db")
     p = Path(db_path)
     if p.exists() and not force:
         raise FileExistsError(f"Database already exists: {db_path}")
@@ -145,6 +155,7 @@ def add_node(
     any_mode: bool = False,
     access_tags: list[str] | None = None,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Add a node to the network.
 
@@ -163,6 +174,13 @@ def add_node(
 
     Returns: {"node_id": str, "truth_value": str, "type": str, "premise_count": int}
     """
+    if pg_conninfo:
+        if namespace or any_mode:
+            raise NotImplementedError("namespace and any_mode are not supported with PostgreSQL")
+        return _pg_dispatch(pg_conninfo, project_id, "add_node",
+                            node_id=node_id, text=text, sl=sl, cp=cp, unless=unless,
+                            label=label, source=source, source_url=source_url,
+                            access_tags=access_tags)
     outlist = [o.strip() for o in unless.split(",") if o.strip()] if unless else []
     justifications = []
     if sl:
@@ -244,21 +262,14 @@ def add_justification(
     namespace: str | None = None,
     any_mode: bool = False,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
-    """Add a new justification to an existing node.
-
-    Args:
-        node_id: Node to add justification to
-        sl: Comma-separated antecedent IDs for SL justification
-        cp: Comma-separated antecedent IDs for CP justification
-        unless: Comma-separated outlist IDs (must be OUT for justification to hold)
-        label: Justification label
-        namespace: Optional namespace prefix
-        any_mode: If True, expand SL into one justification per antecedent (OR)
-        db_path: Path to RMS database
-
-    Returns: {"node_id", "old_truth_value", "new_truth_value", "changed", "premise_count"}
-    """
+    """Add a new justification to an existing node."""
+    if pg_conninfo:
+        if namespace or any_mode:
+            raise NotImplementedError("namespace and any_mode are not supported with PostgreSQL")
+        return _pg_dispatch(pg_conninfo, project_id, "add_justification",
+                            node_id=node_id, sl=sl, cp=cp, unless=unless, label=label)
     outlist = [o.strip() for o in unless.split(",") if o.strip()] if unless else []
 
     if sl:
@@ -295,7 +306,8 @@ def add_justification(
         return result
 
 
-def retract_node(node_id: str, reason: str = "", db_path: str = DEFAULT_DB) -> dict:
+def retract_node(node_id: str, reason: str = "", db_path: str = DEFAULT_DB,
+                 pg_conninfo=None, project_id=None) -> dict:
     """Retract a node and cascade.
 
     Args:
@@ -305,6 +317,9 @@ def retract_node(node_id: str, reason: str = "", db_path: str = DEFAULT_DB) -> d
 
     Returns: {"changed", "went_out", "went_in", "restoration_hints"}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "retract_node",
+                            node_id=node_id, reason=reason)
     with _with_network(db_path, write=True) as net:
         before = {nid: n.truth_value for nid, n in net.nodes.items()}
         changed = net.retract(node_id, reason=reason)
@@ -330,7 +345,8 @@ def retract_node(node_id: str, reason: str = "", db_path: str = DEFAULT_DB) -> d
         return {"changed": changed, "went_out": went_out, "went_in": went_in, "restoration_hints": hints}
 
 
-def what_if_retract(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+def what_if_retract(node_id: str, db_path: str = DEFAULT_DB,
+                   pg_conninfo=None, project_id=None) -> dict:
     """Simulate retracting a node without mutating the database.
 
     Loads the network read-only, performs the retraction in memory,
@@ -340,6 +356,10 @@ def what_if_retract(node_id: str, db_path: str = DEFAULT_DB) -> dict:
 
     Returns: {"node_id": str, "retracted": list[dict], "restored": list[dict], ...}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "what_if_retract",
+                            node_id=node_id)
+
     with _with_network(db_path, write=False) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
@@ -390,7 +410,8 @@ def what_if_retract(node_id: str, db_path: str = DEFAULT_DB) -> dict:
         }
 
 
-def what_if_assert(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+def what_if_assert(node_id: str, db_path: str = DEFAULT_DB,
+                  pg_conninfo=None, project_id=None) -> dict:
     """Simulate asserting (restoring) a node without mutating the database.
 
     Shows what would change if a currently-OUT node were asserted back to IN.
@@ -399,6 +420,10 @@ def what_if_assert(node_id: str, db_path: str = DEFAULT_DB) -> dict:
 
     Returns: {"node_id": str, "retracted": list[dict], "restored": list[dict], ...}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "what_if_assert",
+                            node_id=node_id)
+
     with _with_network(db_path, write=False) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
@@ -467,11 +492,16 @@ def _cascade_depth(net, target_id: str, retracted_id: str) -> int:
     return 0
 
 
-def assert_node(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+def assert_node(node_id: str, db_path: str = DEFAULT_DB,
+                pg_conninfo=None, project_id=None) -> dict:
     """Assert a node and cascade restoration.
 
     Returns: {"changed": list[str], "went_out": list[str], "went_in": list[str]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "assert_node",
+                            node_id=node_id)
+
     with _with_network(db_path, write=True) as net:
         before = {nid: n.truth_value for nid, n in net.nodes.items()}
         changed = net.assert_node(node_id)
@@ -486,11 +516,16 @@ def propagate(db_path: str = DEFAULT_DB) -> dict:
     return {"changed": changed}
 
 
-def get_status(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
+def get_status(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+               pg_conninfo=None, project_id=None) -> dict:
     """Get all nodes with truth values.
 
     Returns: {"nodes": list[dict], "in_count": int, "total": int}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "get_status",
+                            visible_to=visible_to)
+
     with _with_network(db_path) as net:
         nodes = []
         for nid, node in sorted(net.nodes.items()):
@@ -506,12 +541,17 @@ def get_status(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -
         return {"nodes": nodes, "in_count": in_count, "total": len(nodes)}
 
 
-def show_node(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
+def show_node(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+              pg_conninfo=None, project_id=None) -> dict:
     """Get full details for a node.
 
     Returns: dict with id, text, truth_value, source, justifications, dependents
     Raises PermissionError if node's access_tags are not a subset of visible_to.
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "show_node",
+                            node_id=node_id, visible_to=visible_to)
+
     with _with_network(db_path) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
@@ -536,12 +576,17 @@ def show_node(node_id: str, visible_to: list[str] | None = None, db_path: str = 
         }
 
 
-def explain_node(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
+def explain_node(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+                 pg_conninfo=None, project_id=None) -> dict:
     """Explain why a node is IN or OUT.
 
     Returns: {"steps": list[dict]}
     Raises PermissionError if node's access_tags are not a subset of visible_to.
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "explain_node",
+                            node_id=node_id, visible_to=visible_to)
+
     with _with_network(db_path) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
@@ -553,13 +598,18 @@ def explain_node(node_id: str, visible_to: list[str] | None = None, db_path: str
         return {"steps": steps}
 
 
-def trace_assumptions(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
+def trace_assumptions(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+                      pg_conninfo=None, project_id=None) -> dict:
     """Trace backward to find all premises a node rests on.
 
     Returns: {"node_id": str, "premises": list[str]}
     Raises PermissionError if node's access_tags are not a subset of visible_to.
     Filters returned premises by visible_to.
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "trace_assumptions",
+                            node_id=node_id, visible_to=visible_to)
+
     with _with_network(db_path) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
@@ -590,29 +640,42 @@ def trace_access_tags(node_id: str, visible_to: list[str] | None = None, db_path
         return {"node_id": node_id, "access_tags": tags}
 
 
-def find_culprits(node_ids: list[str], db_path: str = DEFAULT_DB) -> dict:
+def find_culprits(node_ids: list[str], db_path: str = DEFAULT_DB,
+                  pg_conninfo=None, project_id=None) -> dict:
     """Find premises that could be retracted to resolve a contradiction.
 
     Returns: {"culprits": list[dict]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "find_culprits",
+                            node_ids=node_ids)
     with _with_network(db_path) as net:
         culprits = net.find_culprits(node_ids)
         return {"culprits": culprits}
 
 
-def convert_to_premise(node_id: str, db_path: str = DEFAULT_DB) -> dict:
+def convert_to_premise(node_id: str, db_path: str = DEFAULT_DB,
+                       pg_conninfo=None, project_id=None) -> dict:
     """Strip justifications from a node, making it a premise (IN by default).
 
     Returns: {"node_id": str, "old_justifications": int, "truth_value": str, "changed": list[str]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "convert_to_premise",
+                            node_id=node_id)
+
     with _with_network(db_path, write=True) as net:
         return net.convert_to_premise(node_id)
 
 
 def remove_justification(
-    node_id: str, index: int, db_path: str = DEFAULT_DB
+    node_id: str, index: int, db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Remove a single justification by index and propagate."""
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "remove_justification",
+                            node_id=node_id, index=index)
     with _with_network(db_path, write=True) as net:
         return net.remove_justification(node_id, index)
 
@@ -647,11 +710,16 @@ def update_node(
     source: str | None = None,
     source_url: str | None = None,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Update a node's text, source, or source_url in place.
 
     Returns: {"node_id": str, "updated_fields": list[str]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "update_node",
+                            node_id=node_id, text=text, source=source,
+                            source_url=source_url)
     with _with_network(db_path, write=True) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
@@ -674,11 +742,16 @@ def challenge(
     reason: str,
     challenge_id: str | None = None,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Challenge a node — creates a challenge node and the target goes OUT.
 
     Returns: {"challenge_id": str, "target_id": str, "changed": list[str]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "challenge",
+                            target_id=target_id, reason=reason,
+                            challenge_id=challenge_id)
     with _with_network(db_path, write=True) as net:
         return net.challenge(target_id, reason, challenge_id=challenge_id)
 
@@ -689,20 +762,30 @@ def defend(
     reason: str,
     defense_id: str | None = None,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Defend a node against a challenge — neutralises the challenge, target restored.
 
     Returns: {"defense_id": str, "challenge_id": str, "target_id": str, "changed": list[str]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "defend",
+                            target_id=target_id, challenge_id=challenge_id,
+                            reason=reason, defense_id=defense_id)
     with _with_network(db_path, write=True) as net:
         return net.defend(target_id, challenge_id, reason, defense_id=defense_id)
 
 
-def add_nogood(node_ids: list[str], db_path: str = DEFAULT_DB) -> dict:
+def add_nogood(node_ids: list[str], db_path: str = DEFAULT_DB,
+               pg_conninfo=None, project_id=None) -> dict:
     """Record a contradiction and use backtracking to resolve.
 
     Returns: {"nogood_id": str, "nodes": list[str], "changed": list[str], "backtracked_to": str | None}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "add_nogood",
+                            node_ids=node_ids)
+
     with _with_network(db_path, write=True) as net:
         # Find culprits before retraction for reporting
         all_in = all(
@@ -728,11 +811,16 @@ def get_belief_set(db_path: str = DEFAULT_DB) -> list[str]:
         return net.get_belief_set()
 
 
-def get_log(last: int | None = None, db_path: str = DEFAULT_DB) -> dict:
+def get_log(last: int | None = None, db_path: str = DEFAULT_DB,
+            pg_conninfo=None, project_id=None) -> dict:
     """Get propagation history.
 
     Returns: {"entries": list[dict]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "get_log",
+                            last=last)
+
     with _with_network(db_path) as net:
         entries = net.log
         if last:
@@ -740,11 +828,16 @@ def get_log(last: int | None = None, db_path: str = DEFAULT_DB) -> dict:
         return {"entries": entries}
 
 
-def export_network(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
+def export_network(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+                   pg_conninfo=None, project_id=None) -> dict:
     """Export the entire network as a dict.
 
     Returns: {"nodes": dict, "nogoods": list}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "export_network",
+                            visible_to=visible_to)
+
     with _with_network(db_path) as net:
         return {
             "nodes": {
@@ -1116,12 +1209,43 @@ def list_repos(db_path: str = DEFAULT_DB) -> dict:
         return {"repos": dict(net.repos)}
 
 
-def export_markdown(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> str:
+def export_markdown(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+                    pg_conninfo=None, project_id=None) -> str:
     """Export the network as beliefs.md-compatible markdown.
 
     Returns: the markdown string
     """
     from .export_markdown import export_markdown as _export
+
+    if pg_conninfo:
+        data = export_network(visible_to=visible_to, pg_conninfo=pg_conninfo,
+                              project_id=project_id)
+        from . import Node, Justification, Nogood
+        from .network import Network
+        net = Network()
+        for nid, ndata in data.get("nodes", {}).items():
+            node = Node(nid, ndata.get("text", ""))
+            node.truth_value = ndata.get("truth_value", "OUT")
+            node.source = ndata.get("source", "")
+            node.source_url = ndata.get("source_url", "")
+            node.metadata = ndata.get("metadata", {})
+            for jdata in ndata.get("justifications", []):
+                j = Justification(
+                    type=jdata.get("type", "SL"),
+                    antecedents=jdata.get("antecedents", []),
+                    outlist=jdata.get("outlist", []),
+                    label=jdata.get("label", ""),
+                )
+                node.justifications.append(j)
+            net.nodes[nid] = node
+        for ngdata in data.get("nogoods", []):
+            net.nogoods.append(Nogood(
+                id=ngdata.get("id", ""),
+                nodes=ngdata.get("nodes", []),
+                discovered=ngdata.get("discovered", ""),
+                resolution=ngdata.get("resolution", ""),
+            ))
+        return _export(net)
 
     with _with_network(db_path) as net:
         if visible_to is not None:
@@ -1200,11 +1324,15 @@ def hash_sources(
         return {"hashed": results, "count": len(results)}
 
 
-def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> str:
+def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+            pg_conninfo=None, project_id=None) -> str:
     """Generate a token-budgeted belief state summary.
 
     Returns: the compact summary string
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "compact",
+                            budget=budget, truncate=truncate, visible_to=visible_to)
     from .compact import compact as _compact
 
     with _with_network(db_path) as net:
@@ -1277,7 +1405,8 @@ def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
 
 
 def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
-           format: str = "markdown", depth: int = 1) -> str:
+           format: str = "markdown", depth: int = 1,
+           pg_conninfo=None, project_id=None) -> str:
     """Search nodes using full-text search with neighbor expansion.
 
     Uses SQLite FTS5 for ranked all-terms matching. Returns matched nodes
@@ -1295,6 +1424,9 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
 
     Returns: formatted string with matched nodes and neighbors
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "search",
+                            query=query, visible_to=visible_to, format=format)
     with _with_network(db_path) as net:
         matched_ids = _fts_search(query, db_path)
 
@@ -1542,11 +1674,33 @@ def list_nodes(
     never_reviewed: bool = False,
     by_impact: bool = False,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """List nodes with optional filters.
 
     Returns: {"nodes": list[dict], "count": int}
     """
+    if pg_conninfo:
+        unsupported = []
+        if challenged:
+            unsupported.append("challenged")
+        if min_depth is not None:
+            unsupported.append("min_depth")
+        if max_depth is not None:
+            unsupported.append("max_depth")
+        if not_reviewed_since is not None:
+            unsupported.append("not_reviewed_since")
+        if never_reviewed:
+            unsupported.append("never_reviewed")
+        if by_impact:
+            unsupported.append("by_impact")
+        if unsupported:
+            raise NotImplementedError(
+                f"{', '.join(unsupported)} not supported with PostgreSQL")
+        return _pg_dispatch(pg_conninfo, project_id, "list_nodes",
+                            status=status, premises_only=premises_only,
+                            has_dependents=has_dependents, namespace=namespace,
+                            visible_to=visible_to)
     from datetime import datetime, timedelta
 
     with _with_network(db_path) as net:

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -6,6 +6,7 @@ and formats the result dict for terminal output.
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -16,7 +17,7 @@ from . import api
 
 def cmd_init(args):
     try:
-        result = api.init_db(db_path=args.db, force=args.force)
+        result = api.init_db(force=args.force, **_backend_kwargs(args))
         print(f"Initialized RMS database: {result['db_path']}")
     except FileExistsError as e:
         print(f"{e}", file=sys.stderr)
@@ -48,7 +49,7 @@ def cmd_add(args):
             namespace=getattr(args, "namespace", None),
             any_mode=getattr(args, "any", False),
             access_tags=access_tags,
-            db_path=args.db,
+            **_backend_kwargs(args),
         )
         print(f"Added {result['node_id']} [{result['truth_value']}] ({result['type']})")
         _warn_multi_premise(result.get("premise_count", 0), getattr(args, "any", False))
@@ -67,7 +68,7 @@ def cmd_add_justification(args):
             label=args.label or "",
             namespace=getattr(args, "namespace", None),
             any_mode=getattr(args, "any", False),
-            db_path=args.db,
+            **_backend_kwargs(args),
         )
         print(f"Added justification to {result['node_id']}")
         print(f"  Truth value: {result['old_truth_value']} → {result['new_truth_value']}")
@@ -84,7 +85,7 @@ def cmd_remove_justification(args):
         result = api.remove_justification(
             node_id=args.node_id,
             index=args.index,
-            db_path=args.db,
+            **_backend_kwargs(args),
         )
         removed = result["removed"]
         ants = ", ".join(removed["antecedents"])
@@ -127,7 +128,7 @@ def _print_restoration_hints(hints):
 
 def cmd_retract(args):
     try:
-        result = api.retract_node(args.node_id, reason=args.reason or "", db_path=args.db)
+        result = api.retract_node(args.node_id, reason=args.reason or "", **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -143,7 +144,7 @@ def cmd_retract(args):
 
 def cmd_assert(args):
     try:
-        result = api.assert_node(args.node_id, db_path=args.db)
+        result = api.assert_node(args.node_id, **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -201,12 +202,12 @@ def cmd_what_if(args):
     action = args.action
     try:
         if action == "retract":
-            result = api.what_if_retract(args.node_id, db_path=args.db)
+            result = api.what_if_retract(args.node_id, **_backend_kwargs(args))
             if result.get("already_out"):
                 print(f"{args.node_id} is already OUT — nothing to simulate.")
                 return
         else:
-            result = api.what_if_assert(args.node_id, db_path=args.db)
+            result = api.what_if_assert(args.node_id, **_backend_kwargs(args))
             if result.get("already_in"):
                 print(f"{args.node_id} is already IN — nothing to simulate.")
                 return
@@ -218,7 +219,7 @@ def cmd_what_if(args):
 
 
 def cmd_status(args):
-    result = api.get_status(visible_to=_parse_visible_to(args), db_path=args.db)
+    result = api.get_status(visible_to=_parse_visible_to(args), **_backend_kwargs(args))
 
     if not result["nodes"]:
         print("No nodes in the network.")
@@ -236,7 +237,7 @@ def cmd_status(args):
 def cmd_show(args):
     visible_to = _parse_visible_to(args)
     try:
-        node = api.show_node(args.node_id, visible_to=visible_to, db_path=args.db)
+        node = api.show_node(args.node_id, visible_to=visible_to, **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -272,7 +273,7 @@ def cmd_show(args):
 
 def cmd_explain(args):
     try:
-        result = api.explain_node(args.node_id, visible_to=_parse_visible_to(args), db_path=args.db)
+        result = api.explain_node(args.node_id, visible_to=_parse_visible_to(args), **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -301,7 +302,7 @@ def cmd_explain(args):
 
 def cmd_convert_to_premise(args):
     try:
-        result = api.convert_to_premise(args.node_id, db_path=args.db)
+        result = api.convert_to_premise(args.node_id, **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -312,6 +313,7 @@ def cmd_convert_to_premise(args):
 
 
 def cmd_summarize(args):
+    _require_sqlite(args, "summarize")
     over = [n.strip() for n in args.over.split(",")]
     try:
         result = api.summarize(
@@ -327,6 +329,7 @@ def cmd_summarize(args):
 
 
 def cmd_supersede(args):
+    _require_sqlite(args, "supersede")
     try:
         result = api.supersede(args.old_id, args.new_id, db_path=args.db)
     except KeyError as e:
@@ -348,7 +351,7 @@ def cmd_update(args):
             args.node_id, text=args.text,
             source=args.source,
             source_url=args.source_url,
-            db_path=args.db,
+            **_backend_kwargs(args),
         )
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -363,7 +366,7 @@ def cmd_challenge(args):
         result = api.challenge(
             args.target_id, args.reason,
             challenge_id=args.id,
-            db_path=args.db,
+            **_backend_kwargs(args),
         )
     except (KeyError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -379,7 +382,7 @@ def cmd_defend(args):
         result = api.defend(
             args.target_id, args.challenge_id, args.reason,
             defense_id=args.id,
-            db_path=args.db,
+            **_backend_kwargs(args),
         )
     except (KeyError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -392,7 +395,7 @@ def cmd_defend(args):
 
 def cmd_nogood(args):
     try:
-        result = api.add_nogood(args.node_ids, db_path=args.db)
+        result = api.add_nogood(args.node_ids, **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -405,6 +408,7 @@ def cmd_nogood(args):
 
 
 def cmd_trace_access_tags(args):
+    _require_sqlite(args, "trace-access-tags")
     try:
         result = api.trace_access_tags(args.node_id, visible_to=_parse_visible_to(args), db_path=args.db)
     except KeyError as e:
@@ -423,7 +427,7 @@ def cmd_trace_access_tags(args):
 
 def cmd_trace(args):
     try:
-        result = api.trace_assumptions(args.node_id, visible_to=_parse_visible_to(args), db_path=args.db)
+        result = api.trace_assumptions(args.node_id, visible_to=_parse_visible_to(args), **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -437,13 +441,14 @@ def cmd_trace(args):
 
     print(f"{args.node_id} rests on {len(result['premises'])} premise(s):")
     for pid in result["premises"]:
-        node = api.show_node(pid, db_path=args.db)
+        node = api.show_node(pid, **_backend_kwargs(args))
         marker = "+" if node["truth_value"] == "IN" else "-"
         deps = f"  ({len(node['dependents'])} dependents)" if node["dependents"] else ""
         print(f"  [{marker}] {pid}: {node['text'][:80]}{deps}")
 
 
 def cmd_propagate(args):
+    _require_sqlite(args, "propagate")
     result = api.propagate(db_path=args.db)
     changed = result["changed"]
     if changed:
@@ -453,7 +458,7 @@ def cmd_propagate(args):
 
 
 def cmd_log(args):
-    result = api.get_log(last=args.last, db_path=args.db)
+    result = api.get_log(last=args.last, **_backend_kwargs(args))
 
     if not result["entries"]:
         print("No propagation events.")
@@ -464,11 +469,13 @@ def cmd_log(args):
 
 
 def cmd_add_repo(args):
+    _require_sqlite(args, "add-repo")
     result = api.add_repo(args.name, args.path, db_path=args.db)
     print(f"Added repo {result['name']}: {result['path']}")
 
 
 def cmd_repos(args):
+    _require_sqlite(args, "repos")
     result = api.list_repos(db_path=args.db)
     if not result["repos"]:
         print("No repos registered.")
@@ -479,6 +486,7 @@ def cmd_repos(args):
 
 
 def cmd_import_agent(args):
+    _require_sqlite(args, "import-agent")
     try:
         result = api.import_agent(
             agent_name=args.agent_name,
@@ -509,6 +517,7 @@ def cmd_import_agent(args):
 
 
 def cmd_sync_agent(args):
+    _require_sqlite(args, "sync-agent")
     try:
         result = api.sync_agent(
             agent_name=args.agent_name,
@@ -541,6 +550,7 @@ def cmd_sync_agent(args):
 
 
 def cmd_import_beliefs(args):
+    _require_sqlite(args, "import-beliefs")
     try:
         result = api.import_beliefs(
             beliefs_file=args.beliefs_file,
@@ -559,6 +569,7 @@ def cmd_import_beliefs(args):
 
 
 def cmd_import_json(args):
+    _require_sqlite(args, "import-json")
     try:
         result = api.import_json(args.json_file, db_path=args.db)
     except FileNotFoundError as e:
@@ -571,7 +582,7 @@ def cmd_import_json(args):
 
 
 def cmd_export(args):
-    data = api.export_network(visible_to=_parse_visible_to(args), db_path=args.db)
+    data = api.export_network(visible_to=_parse_visible_to(args), **_backend_kwargs(args))
     output = json.dumps(data, indent=2)
     if args.output:
         Path(args.output).write_text(output)
@@ -581,7 +592,7 @@ def cmd_export(args):
 
 
 def cmd_export_markdown(args):
-    md = api.export_markdown(visible_to=_parse_visible_to(args), db_path=args.db)
+    md = api.export_markdown(visible_to=_parse_visible_to(args), **_backend_kwargs(args))
     if args.output:
         Path(args.output).write_text(md)
         print(f"Written to {args.output}")
@@ -590,6 +601,7 @@ def cmd_export_markdown(args):
 
 
 def cmd_hash_sources(args):
+    _require_sqlite(args, "hash-sources")
     result = api.hash_sources(force=args.force, db_path=args.db)
 
     if not result["hashed"]:
@@ -613,6 +625,7 @@ def cmd_hash_sources(args):
 
 
 def cmd_check_stale(args):
+    _require_sqlite(args, "check-stale")
     result = api.check_stale(upgrade_hashes=args.upgrade_hashes, db_path=args.db)
 
     if result.get("upgraded"):
@@ -650,7 +663,7 @@ def cmd_compact(args):
         budget=args.budget,
         truncate=not args.no_truncate,
         visible_to=_parse_visible_to(args),
-        db_path=args.db,
+        **_backend_kwargs(args),
     )
     print(summary)
 
@@ -662,18 +675,38 @@ def _parse_visible_to(args):
     return None
 
 
+def _backend_kwargs(args):
+    pg = getattr(args, "pg", None) or os.environ.get("REASONS_PG_CONNINFO")
+    pid = getattr(args, "project_id", None) or os.environ.get("REASONS_PROJECT_ID")
+    if pg:
+        if not pid:
+            print("Error: --project-id is required with --pg", file=sys.stderr)
+            sys.exit(1)
+        return {"pg_conninfo": pg, "project_id": pid}
+    return {"db_path": args.db}
+
+
+def _require_sqlite(args, command_name):
+    pg = getattr(args, "pg", None) or os.environ.get("REASONS_PG_CONNINFO")
+    if pg:
+        print(f"Error: {command_name} is not supported with --pg", file=sys.stderr)
+        sys.exit(1)
+
+
 def cmd_search(args):
     fmt = getattr(args, "format", "markdown")
-    result = api.search(args.query, visible_to=_parse_visible_to(args), db_path=args.db, format=fmt)
+    result = api.search(args.query, visible_to=_parse_visible_to(args), format=fmt, **_backend_kwargs(args))
     print(result)
 
 
 def cmd_lookup(args):
+    _require_sqlite(args, "lookup")
     result = api.lookup(args.query, visible_to=_parse_visible_to(args), db_path=args.db)
     print(result)
 
 
 def cmd_ask(args):
+    _require_sqlite(args, "ask")
     from .ask import ask
     result = ask(
         question=args.question,
@@ -691,6 +724,7 @@ def cmd_ask(args):
 
 
 def cmd_deduplicate(args):
+    _require_sqlite(args, "deduplicate")
     if args.accept:
         accept_path = Path(args.accept)
         if not accept_path.exists():
@@ -916,6 +950,7 @@ def _write_derive_report(report_state, status):
 
 
 def cmd_derive(args):
+    _require_sqlite(args, "derive")
     from datetime import datetime
 
     if args.cluster and args.sample:
@@ -998,6 +1033,7 @@ def cmd_derive(args):
 
 
 def cmd_accept(args):
+    _require_sqlite(args, "accept")
     from .derive import parse_proposals, validate_proposals, apply_proposals
 
     proposals_path = Path(args.file)
@@ -1051,7 +1087,7 @@ def cmd_list(args):
         not_reviewed_since=args.not_reviewed_since,
         never_reviewed=args.never_reviewed,
         by_impact=args.by_impact,
-        db_path=args.db,
+        **_backend_kwargs(args),
     )
 
     if args.never_reviewed and args.not_reviewed_since is not None:
@@ -1081,7 +1117,7 @@ def cmd_list(args):
 def cmd_list_gated(args):
     result = api.list_gated(
         visible_to=_parse_visible_to(args),
-        db_path=args.db,
+        **_backend_kwargs(args),
     )
 
     if not result["blockers"]:
@@ -1098,6 +1134,7 @@ def cmd_list_gated(args):
 
 
 def cmd_list_negative(args):
+    _require_sqlite(args, "list-negative")
     result = api.list_negative(
         visible_to=_parse_visible_to(args),
         model=getattr(args, "model", None) or "claude",
@@ -1116,6 +1153,7 @@ def cmd_list_negative(args):
 
 
 def cmd_review_beliefs(args):
+    _require_sqlite(args, "review-beliefs")
     import json
     from datetime import datetime
 
@@ -1239,6 +1277,7 @@ def cmd_review_beliefs(args):
 
 
 def cmd_contradictions(args):
+    _require_sqlite(args, "detect-contradictions")
     model = getattr(args, "model", None) or "claude"
     auto_apply = args.auto_apply and not args.dry_run
     result = api.detect_contradictions(
@@ -1290,6 +1329,7 @@ def cmd_contradictions(args):
 
 
 def cmd_namespaces(args):
+    _require_sqlite(args, "namespaces")
     result = api.list_namespaces(db_path=args.db)
     if not result["namespaces"]:
         print("No namespaces found. Use --namespace/-n with 'add' or 'import-agent' to create one.")
@@ -1307,6 +1347,10 @@ def main():
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {_pkg_version('ftl-reasons')}")
     parser.add_argument("--db", default=api.DEFAULT_DB, help="Path to database (default: reasons.db)")
+    parser.add_argument("--pg", default=None, metavar="CONNINFO",
+                        help="PostgreSQL connection string (or set REASONS_PG_CONNINFO)")
+    parser.add_argument("--project-id", default=None,
+                        help="Project ID for PostgreSQL (or set REASONS_PROJECT_ID)")
     sub = parser.add_subparsers(dest="command")
 
     # init

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -18,7 +18,10 @@ from . import api
 def cmd_init(args):
     try:
         result = api.init_db(force=args.force, **_backend_kwargs(args))
-        print(f"Initialized RMS database: {result['db_path']}")
+        if "db_path" in result:
+            print(f"Initialized RMS database: {result['db_path']}")
+        else:
+            print(f"Initialized PostgreSQL project: {result['project_id']}")
     except FileExistsError as e:
         print(f"{e}", file=sys.stderr)
         print("Use --force to reinitialize.", file=sys.stderr)

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -814,6 +814,235 @@ class PgApi:
         gated_count = sum(len(b["gated"]) for b in blockers.values())
         return {"blockers": blockers, "gated_count": gated_count, "blocker_count": len(blockers)}
 
+    def export_network(self, visible_to=None):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, text, truth_value, source, source_url, source_hash, "
+                "date, metadata FROM rms_nodes WHERE project_id = %s ORDER BY id",
+                (pid,),
+            )
+            nodes = {}
+            for row in cur.fetchall():
+                nid, text, tv, source, source_url, source_hash, date, meta = row
+                if isinstance(meta, str):
+                    meta = json.loads(meta)
+                if visible_to is not None and not self._is_visible(meta, visible_to):
+                    continue
+                nodes[nid] = {
+                    "text": text,
+                    "truth_value": tv,
+                    "justifications": [],
+                    "source": source or "",
+                    "source_url": source_url or "",
+                    "source_hash": source_hash or "",
+                    "date": date or "",
+                    "metadata": {k: v for k, v in meta.items() if not k.startswith("_")},
+                }
+
+            if nodes:
+                cur.execute(
+                    "SELECT node_id, type, antecedents, outlist, label "
+                    "FROM rms_justifications WHERE project_id = %s "
+                    "AND node_id = ANY(%s) ORDER BY id",
+                    (pid, list(nodes.keys())),
+                )
+                for row in cur.fetchall():
+                    nid, jtype, ants, outs, label = row
+                    if isinstance(ants, str):
+                        ants = json.loads(ants)
+                    if isinstance(outs, str):
+                        outs = json.loads(outs)
+                    if nid in nodes:
+                        nodes[nid]["justifications"].append({
+                            "type": jtype,
+                            "antecedents": ants,
+                            "outlist": outs,
+                            "label": label or "",
+                        })
+
+            cur.execute(
+                "SELECT id, nodes, discovered, resolution FROM rms_nogoods "
+                "WHERE project_id = %s ORDER BY id",
+                (pid,),
+            )
+            nogoods = []
+            for row in cur.fetchall():
+                ng_id, ng_nodes, discovered, resolution = row
+                if isinstance(ng_nodes, str):
+                    ng_nodes = json.loads(ng_nodes)
+                if visible_to is not None:
+                    if not all(n in nodes for n in ng_nodes):
+                        continue
+                nogoods.append({
+                    "id": ng_id,
+                    "nodes": ng_nodes,
+                    "discovered": discovered or "",
+                    "resolution": resolution or "",
+                })
+
+        return {"nodes": nodes, "nogoods": nogoods, "repos": {}}
+
+    def remove_justification(self, node_id, index):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{node_id}' not found")
+            old_value = row[0]
+
+            cur.execute(
+                "SELECT id, type, antecedents, outlist, label "
+                "FROM rms_justifications WHERE node_id = %s AND project_id = %s "
+                "ORDER BY id",
+                (node_id, pid),
+            )
+            justs = cur.fetchall()
+
+            if not justs:
+                raise ValueError(f"Node '{node_id}' is a premise (no justifications)")
+
+            if index < 0 or index >= len(justs):
+                raise IndexError(
+                    f"Justification index {index} out of range "
+                    f"(node has {len(justs)})"
+                )
+
+            if len(justs) == 1:
+                raise ValueError(
+                    f"Node '{node_id}' has only one justification; "
+                    f"use 'convert-to-premise' or 'retract' instead"
+                )
+
+            target = justs[index]
+            j_id, jtype, ants, outs, label = target
+            if isinstance(ants, str):
+                ants = json.loads(ants)
+            if isinstance(outs, str):
+                outs = json.loads(outs)
+
+            cur.execute(
+                "DELETE FROM rms_justifications WHERE id = %s",
+                (j_id,),
+            )
+
+            new_value = self._compute_truth(cur, node_id)
+            changed = []
+            if old_value != new_value:
+                cur.execute(
+                    "UPDATE rms_nodes SET truth_value = %s "
+                    "WHERE id = %s AND project_id = %s",
+                    (new_value, node_id, pid),
+                )
+                changed.append(node_id)
+                went_out, went_in = self._propagate(cur, node_id)
+                changed.extend(went_out)
+                changed.extend(went_in)
+
+            self._log(cur, "remove-justification", node_id, new_value)
+
+        self.conn.commit()
+        return {
+            "node_id": node_id,
+            "old_truth_value": old_value,
+            "new_truth_value": new_value,
+            "removed": {"type": jtype, "antecedents": ants, "outlist": outs, "label": label or ""},
+            "remaining": len(justs) - 1,
+            "changed": changed,
+        }
+
+    def update_node(self, node_id, text=None, source=None, source_url=None):
+        pid = self.project_id
+        updates = []
+        params = []
+        updated_fields = []
+
+        if text is not None:
+            updates.append("text = %s")
+            params.append(text)
+            updated_fields.append("text")
+        if source is not None:
+            updates.append("source = %s")
+            params.append(source)
+            updated_fields.append("source")
+        if source_url is not None:
+            updates.append("source_url = %s")
+            params.append(source_url)
+            updated_fields.append("source_url")
+
+        if not updates:
+            return {"node_id": node_id, "updated_fields": []}
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            if not cur.fetchone():
+                raise KeyError(f"Node '{node_id}' not found")
+
+            params.extend([node_id, pid])
+            cur.execute(
+                f"UPDATE rms_nodes SET {', '.join(updates)} "
+                f"WHERE id = %s AND project_id = %s",
+                params,
+            )
+
+        self.conn.commit()
+        return {"node_id": node_id, "updated_fields": updated_fields}
+
+    def convert_to_premise(self, node_id):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT truth_value FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{node_id}' not found")
+            old_value = row[0]
+
+            cur.execute(
+                "SELECT COUNT(*) FROM rms_justifications "
+                "WHERE node_id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            old_count = cur.fetchone()[0]
+
+            cur.execute(
+                "DELETE FROM rms_justifications "
+                "WHERE node_id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+
+            changed = []
+            if old_value != "IN":
+                cur.execute(
+                    "UPDATE rms_nodes SET truth_value = 'IN' "
+                    "WHERE id = %s AND project_id = %s",
+                    (node_id, pid),
+                )
+                changed.append(node_id)
+                self._log(cur, "convert-to-premise", node_id, "IN")
+                went_out, went_in = self._propagate(cur, node_id)
+                changed.extend(went_out)
+                changed.extend(went_in)
+            else:
+                self._log(cur, "convert-to-premise", node_id, "IN (unchanged)")
+
+        self.conn.commit()
+        return {
+            "node_id": node_id,
+            "old_justifications": old_count,
+            "truth_value": "IN",
+            "changed": changed,
+        }
+
     def get_log(self, last=None):
         pid = self.project_id
         with self.conn.cursor() as cur:

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -870,3 +870,194 @@ class TestCompact:
         result = pg_api.compact(budget=5000)
         assert "[summary]" in result
         assert "hidden by summaries" in result
+
+
+class TestExportNetwork:
+
+    def test_export_empty(self, pg_api):
+        result = pg_api.export_network()
+        assert result["nodes"] == {}
+        assert result["nogoods"] == []
+
+    def test_export_premises(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        result = pg_api.export_network()
+        assert "a" in result["nodes"]
+        assert "b" in result["nodes"]
+        assert result["nodes"]["a"]["text"] == "Alpha"
+        assert result["nodes"]["a"]["truth_value"] == "IN"
+        assert result["nodes"]["a"]["justifications"] == []
+
+    def test_export_with_justifications(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        result = pg_api.export_network()
+        justs = result["nodes"]["b"]["justifications"]
+        assert len(justs) == 1
+        assert justs[0]["type"] == "SL"
+        assert justs[0]["antecedents"] == ["a"]
+
+    def test_export_with_outlist(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("blocker", "Blocker")
+        pg_api.retract_node("blocker")
+        pg_api.add_node("c", "Gated", sl="a", unless="blocker")
+        result = pg_api.export_network()
+        justs = result["nodes"]["c"]["justifications"]
+        assert justs[0]["outlist"] == ["blocker"]
+
+    def test_export_with_nogoods(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.add_nogood(["a", "b"])
+        result = pg_api.export_network()
+        assert len(result["nogoods"]) == 1
+        assert set(result["nogoods"][0]["nodes"]) == {"a", "b"}
+
+    def test_export_source_fields(self, pg_api):
+        pg_api.add_node("a", "Alpha", source="test.py", source_url="https://example.com")
+        result = pg_api.export_network()
+        assert result["nodes"]["a"]["source"] == "test.py"
+        assert result["nodes"]["a"]["source_url"] == "https://example.com"
+
+    def test_export_filters_private_metadata(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.retract_node("a", reason="test")
+        result = pg_api.export_network()
+        assert "_retracted" not in result["nodes"]["a"]["metadata"]
+
+    def test_export_visible_to(self, pg_api):
+        pg_api.add_node("a", "Alpha", access_tags=["billing"])
+        pg_api.add_node("b", "Beta", access_tags=["ops"])
+        result = pg_api.export_network(visible_to=["billing"])
+        assert "a" in result["nodes"]
+        assert "b" not in result["nodes"]
+
+
+class TestRemoveJustification:
+
+    def test_remove_one_of_two(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.add_node("c", "Gamma", sl="a")
+        pg_api.add_justification("c", sl="b")
+        result = pg_api.remove_justification("c", 0)
+        assert result["remaining"] == 1
+        assert result["removed"]["antecedents"] == ["a"]
+
+    def test_remove_last_raises(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("c", "Gamma", sl="a")
+        with pytest.raises(ValueError, match="only one justification"):
+            pg_api.remove_justification("c", 0)
+
+    def test_remove_premise_raises(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        with pytest.raises(ValueError, match="premise"):
+            pg_api.remove_justification("a", 0)
+
+    def test_remove_invalid_index(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.add_node("c", "Gamma", sl="a")
+        pg_api.add_justification("c", sl="b")
+        with pytest.raises(IndexError):
+            pg_api.remove_justification("c", 5)
+
+    def test_remove_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.remove_justification("nonexistent", 0)
+
+    def test_remove_causes_truth_change(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.retract_node("b")
+        pg_api.add_node("c", "Gamma", sl="a")
+        pg_api.add_justification("c", sl="b")
+        # c is IN via first justification (a is IN)
+        result = pg_api.remove_justification("c", 0)
+        # Now only justification is sl=b, but b is OUT → c goes OUT
+        assert result["old_truth_value"] == "IN"
+        assert result["new_truth_value"] == "OUT"
+
+    def test_remove_propagates(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.add_node("c", "Gamma", sl="a")
+        pg_api.add_justification("c", sl="b")
+        pg_api.add_node("d", "Delta", sl="c")
+        pg_api.retract_node("b")
+        # Remove first justification (sl=a), leaving only sl=b (b is OUT)
+        result = pg_api.remove_justification("c", 0)
+        assert result["new_truth_value"] == "OUT"
+        assert "d" in result["changed"]
+
+
+class TestUpdateNode:
+
+    def test_update_text(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.update_node("a", text="Alpha updated")
+        assert result["updated_fields"] == ["text"]
+        node = pg_api.show_node("a")
+        assert node["text"] == "Alpha updated"
+
+    def test_update_source(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.update_node("a", source="test.py", source_url="https://example.com")
+        assert "source" in result["updated_fields"]
+        assert "source_url" in result["updated_fields"]
+        node = pg_api.show_node("a")
+        assert node["source"] == "test.py"
+        assert node["source_url"] == "https://example.com"
+
+    def test_update_nothing(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.update_node("a")
+        assert result["updated_fields"] == []
+
+    def test_update_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.update_node("nonexistent", text="test")
+
+
+class TestConvertToPremise:
+
+    def test_convert_derived_to_premise(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        result = pg_api.convert_to_premise("b")
+        assert result["old_justifications"] == 1
+        assert result["truth_value"] == "IN"
+        node = pg_api.show_node("b")
+        assert node["justifications"] == []
+
+    def test_convert_out_to_in(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.retract_node("a")
+        assert pg_api.show_node("b")["truth_value"] == "OUT"
+        result = pg_api.convert_to_premise("b")
+        assert result["truth_value"] == "IN"
+        assert "b" in result["changed"]
+
+    def test_convert_propagates(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma", sl="b")
+        pg_api.retract_node("a")
+        assert pg_api.show_node("c")["truth_value"] == "OUT"
+        result = pg_api.convert_to_premise("b")
+        assert "c" in result["changed"]
+        assert pg_api.show_node("c")["truth_value"] == "IN"
+
+    def test_convert_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.convert_to_premise("nonexistent")
+
+    def test_convert_premise_noop(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.convert_to_premise("a")
+        assert result["old_justifications"] == 0
+        assert result["truth_value"] == "IN"

--- a/tests/test_pg_dispatch.py
+++ b/tests/test_pg_dispatch.py
@@ -1,0 +1,84 @@
+"""Tests for the PostgreSQL dispatch layer in api.py and cli.py."""
+
+import argparse
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from reasons_lib.api import _pg_dispatch
+from reasons_lib.cli import _backend_kwargs, _require_sqlite
+
+
+class TestPgDispatch:
+
+    def test_dispatch_calls_pgapi_method(self):
+        mock_pg = MagicMock()
+        mock_pg.get_status.return_value = {"total": 5}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = _pg_dispatch("postgresql://...", "proj-1", "get_status")
+        assert result == {"total": 5}
+
+    def test_dispatch_passes_kwargs(self):
+        mock_pg = MagicMock()
+        mock_pg.show_node.return_value = {"id": "a", "text": "Alpha"}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = _pg_dispatch("postgresql://...", "proj-1", "show_node", node_id="a")
+        mock_pg.show_node.assert_called_once_with(node_id="a")
+
+
+class TestBackendKwargs:
+
+    def test_sqlite_default(self):
+        args = argparse.Namespace(db="reasons.db", pg=None, project_id=None)
+        result = _backend_kwargs(args)
+        assert result == {"db_path": "reasons.db"}
+
+    def test_pg_with_project_id(self):
+        args = argparse.Namespace(db="reasons.db", pg="postgresql://localhost/test",
+                                  project_id="abc-123")
+        result = _backend_kwargs(args)
+        assert result == {"pg_conninfo": "postgresql://localhost/test",
+                          "project_id": "abc-123"}
+
+    def test_pg_missing_project_id_exits(self):
+        args = argparse.Namespace(db="reasons.db", pg="postgresql://localhost/test",
+                                  project_id=None)
+        with pytest.raises(SystemExit):
+            _backend_kwargs(args)
+
+    def test_env_var_fallback(self):
+        args = argparse.Namespace(db="reasons.db", pg=None, project_id=None)
+        with patch.dict("os.environ", {"REASONS_PG_CONNINFO": "postgresql://env",
+                                        "REASONS_PROJECT_ID": "env-proj"}):
+            result = _backend_kwargs(args)
+        assert result == {"pg_conninfo": "postgresql://env", "project_id": "env-proj"}
+
+    def test_cli_overrides_env(self):
+        args = argparse.Namespace(db="reasons.db", pg="postgresql://cli",
+                                  project_id="cli-proj")
+        with patch.dict("os.environ", {"REASONS_PG_CONNINFO": "postgresql://env",
+                                        "REASONS_PROJECT_ID": "env-proj"}):
+            result = _backend_kwargs(args)
+        assert result == {"pg_conninfo": "postgresql://cli", "project_id": "cli-proj"}
+
+
+class TestRequireSqlite:
+
+    def test_no_pg_passes(self):
+        args = argparse.Namespace(pg=None)
+        _require_sqlite(args, "hash-sources")
+
+    def test_pg_set_exits(self):
+        args = argparse.Namespace(pg="postgresql://localhost/test")
+        with pytest.raises(SystemExit):
+            _require_sqlite(args, "hash-sources")
+
+    def test_env_pg_exits(self):
+        args = argparse.Namespace(pg=None)
+        with patch.dict("os.environ", {"REASONS_PG_CONNINFO": "postgresql://env"}):
+            with pytest.raises(SystemExit):
+                _require_sqlite(args, "hash-sources")

--- a/tests/test_pg_dispatch.py
+++ b/tests/test_pg_dispatch.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from reasons_lib.api import _pg_dispatch
+from reasons_lib.api import _pg_dispatch, export_markdown
 from reasons_lib.cli import _backend_kwargs, _require_sqlite
 
 
@@ -82,3 +82,109 @@ class TestRequireSqlite:
         with patch.dict("os.environ", {"REASONS_PG_CONNINFO": "postgresql://env"}):
             with pytest.raises(SystemExit):
                 _require_sqlite(args, "hash-sources")
+
+
+class TestExportMarkdownPgPath:
+
+    EXPORT_DATA = {
+        "nodes": {
+            "premise-a": {
+                "text": "Alpha premise",
+                "truth_value": "IN",
+                "justifications": [],
+                "source": "test.py",
+                "source_url": "https://example.com",
+                "source_hash": "abc123",
+                "date": "2026-01-01",
+                "metadata": {"domain": "test"},
+            },
+            "derived-b": {
+                "text": "Beta derived from alpha",
+                "truth_value": "IN",
+                "justifications": [
+                    {"type": "SL", "antecedents": ["premise-a"], "outlist": [], "label": ""}
+                ],
+                "source": "",
+                "source_url": "",
+                "source_hash": "",
+                "date": "",
+                "metadata": {},
+            },
+            "gated-c": {
+                "text": "Gamma gated on blocker",
+                "truth_value": "OUT",
+                "justifications": [
+                    {"type": "SL", "antecedents": ["premise-a"],
+                     "outlist": ["blocker"], "label": "gated"}
+                ],
+                "source": "",
+                "source_url": "",
+                "source_hash": "",
+                "date": "",
+                "metadata": {},
+            },
+            "blocker": {
+                "text": "Blocker node",
+                "truth_value": "IN",
+                "justifications": [],
+                "source": "",
+                "source_url": "",
+                "source_hash": "",
+                "date": "",
+                "metadata": {},
+            },
+        },
+        "nogoods": [
+            {"id": "nogood-001", "nodes": ["premise-a", "blocker"],
+             "discovered": "2026-01-01", "resolution": ""},
+        ],
+        "repos": {},
+    }
+
+    def test_produces_markdown(self):
+        with patch("reasons_lib.api.export_network", return_value=self.EXPORT_DATA):
+            md = export_markdown(pg_conninfo="postgresql://...", project_id="test")
+        assert isinstance(md, str)
+        assert len(md) > 0
+
+    def test_contains_node_ids(self):
+        with patch("reasons_lib.api.export_network", return_value=self.EXPORT_DATA):
+            md = export_markdown(pg_conninfo="postgresql://...", project_id="test")
+        assert "premise-a" in md
+        assert "derived-b" in md
+        assert "gated-c" in md
+
+    def test_contains_node_text(self):
+        with patch("reasons_lib.api.export_network", return_value=self.EXPORT_DATA):
+            md = export_markdown(pg_conninfo="postgresql://...", project_id="test")
+        assert "Alpha premise" in md
+        assert "Beta derived from alpha" in md
+
+    def test_contains_justification_refs(self):
+        with patch("reasons_lib.api.export_network", return_value=self.EXPORT_DATA):
+            md = export_markdown(pg_conninfo="postgresql://...", project_id="test")
+        assert "premise-a" in md
+
+    def test_contains_source_info(self):
+        with patch("reasons_lib.api.export_network", return_value=self.EXPORT_DATA):
+            md = export_markdown(pg_conninfo="postgresql://...", project_id="test")
+        assert "test.py" in md
+
+    def test_contains_nogoods(self):
+        with patch("reasons_lib.api.export_network", return_value=self.EXPORT_DATA):
+            md = export_markdown(pg_conninfo="postgresql://...", project_id="test")
+        assert "nogood" in md.lower()
+
+    def test_dependents_reconstructed(self):
+        with patch("reasons_lib.api.export_network", return_value=self.EXPORT_DATA):
+            md = export_markdown(pg_conninfo="postgresql://...", project_id="test")
+        # premise-a is an antecedent of derived-b and gated-c,
+        # so it should show dependents in the markdown
+        assert "derived-b" in md
+        assert "gated-c" in md
+
+    def test_empty_network(self):
+        empty = {"nodes": {}, "nogoods": [], "repos": {}}
+        with patch("reasons_lib.api.export_network", return_value=empty):
+            md = export_markdown(pg_conninfo="postgresql://...", project_id="test")
+        assert isinstance(md, str)


### PR DESCRIPTION
## Summary

- Add `_pg_dispatch` helper and `pg_conninfo`/`project_id` params to all api.py functions that have PgApi equivalents (~25 functions)
- Add 4 missing PgApi methods: `export_network`, `remove_justification`, `update_node`, `convert_to_premise`
- Add `--pg` and `--project-id` global CLI args with `REASONS_PG_CONNINFO`/`REASONS_PROJECT_ID` env var fallbacks
- Add `_backend_kwargs(args)` helper to dispatch CLI commands to the correct backend
- Add `_require_sqlite` guards to SQLite-only commands (hash-sources, check-stale, propagate, lookup, etc.)
- 34 new tests (10 dispatch/mock tests + 24 PG integration tests)

## Test plan

- [x] All 847 existing tests pass (10 new dispatch tests included)
- [x] 131 PG tests skipped without DATABASE_URL (expected)
- [ ] PG integration tests pass with DATABASE_URL set
- [ ] Manual smoke test: `reasons --pg postgresql://... --project-id UUID status`
- [ ] SQLite-only guard: `reasons --pg ... hash-sources` errors correctly

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)