### PR TITLE
Add cluster-list command for semantic belief clustering

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2133,6 +2133,7 @@ def _rewrite_dependents(net, old_id: str, new_id: str):
 def list_clusters(
     status: str = "IN",
     n_clusters: int | None = None,
+    seed: int | None = None,
     embedding_model: str | None = None,
     visible_to: list[str] | None = None,
     db_path: str = DEFAULT_DB,
@@ -2155,6 +2156,7 @@ def list_clusters(
     return _list_clusters(
         beliefs,
         n_clusters=n_clusters,
+        seed=seed,
         model_name=embedding_model or DEFAULT_MODEL,
     )
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2130,6 +2130,35 @@ def _rewrite_dependents(net, old_id: str, new_id: str):
         old_node.dependents.discard(dep_id)
 
 
+def list_clusters(
+    status: str = "IN",
+    n_clusters: int | None = None,
+    embedding_model: str | None = None,
+    visible_to: list[str] | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Cluster beliefs by semantic similarity and return full assignments."""
+    from .cluster import list_clusters as _list_clusters, DEFAULT_MODEL
+
+    with _with_network(db_path) as net:
+        beliefs = {}
+        for nid, n in sorted(net.nodes.items()):
+            if status and n.truth_value != status:
+                continue
+            if visible_to is not None and not _is_visible(n, visible_to):
+                continue
+            beliefs[nid] = n.text
+
+    if not beliefs:
+        return {"clusters": [], "n_clusters": 0, "embedding_model": embedding_model or DEFAULT_MODEL}
+
+    return _list_clusters(
+        beliefs,
+        n_clusters=n_clusters,
+        model_name=embedding_model or DEFAULT_MODEL,
+    )
+
+
 def deduplicate(
     threshold: float = 0.5,
     auto: bool = False,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -731,6 +731,7 @@ def cmd_cluster_list(args):
     result = api.list_clusters(
         status=args.status,
         n_clusters=args.n_clusters,
+        seed=args.seed,
         embedding_model=args.embedding_model,
         visible_to=_parse_visible_to(args),
         db_path=args.db,
@@ -1672,6 +1673,8 @@ def main():
                    help="Filter by truth value (default: IN)")
     p.add_argument("--n-clusters", type=int, default=None,
                    help="Override automatic cluster count")
+    p.add_argument("--seed", type=int, default=None,
+                   help="Random seed for reproducible clustering")
     p.add_argument("--embedding-model", default=None,
                    help="Sentence-transformers model (default: all-MiniLM-L6-v2)")
     p.add_argument("--visible-to", metavar="TAG,TAG",

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -763,7 +763,8 @@ def cmd_cluster_list(args):
         for b in cluster["beliefs"]:
             marker = "+" if args.status == "IN" else "-"
             print(f"  [{marker}] {b['id']}")
-            print(f"      {b['text'][:100]}")
+            text = b['text'][:100] + "..." if len(b['text']) > 100 else b['text']
+            print(f"      {text}")
 
     print(f"\n{result['n_clusters']} cluster(s), {total} beliefs")
     print(f"Model: {result['embedding_model']}")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -740,7 +740,7 @@ def cmd_cluster_list(args):
         print("No beliefs to cluster.")
         return
 
-    fmt = getattr(args, "format", "text")
+    fmt = args.format
 
     if fmt == "json":
         print(json.dumps(result, indent=2))

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -726,6 +726,48 @@ def cmd_ask(args):
     print(result)
 
 
+def cmd_cluster_list(args):
+    _require_sqlite(args, "cluster-list")
+    result = api.list_clusters(
+        status=args.status,
+        n_clusters=args.n_clusters,
+        embedding_model=args.embedding_model,
+        visible_to=_parse_visible_to(args),
+        db_path=args.db,
+    )
+
+    if not result["clusters"]:
+        print("No beliefs to cluster.")
+        return
+
+    fmt = getattr(args, "format", "text")
+
+    if fmt == "json":
+        print(json.dumps(result, indent=2))
+        return
+
+    if fmt == "markdown":
+        for i, cluster in enumerate(result["clusters"], 1):
+            size = len(cluster["beliefs"])
+            print(f"\n## Cluster {i} ({size} belief{'s' if size != 1 else ''})\n")
+            for b in cluster["beliefs"]:
+                print(f"- **{b['id']}**: {b['text']}")
+        return
+
+    total = 0
+    for i, cluster in enumerate(result["clusters"], 1):
+        size = len(cluster["beliefs"])
+        total += size
+        print(f"\nCluster {i} ({size} belief{'s' if size != 1 else ''}):")
+        for b in cluster["beliefs"]:
+            marker = "+" if args.status == "IN" else "-"
+            print(f"  [{marker}] {b['id']}")
+            print(f"      {b['text'][:100]}")
+
+    print(f"\n{result['n_clusters']} cluster(s), {total} beliefs")
+    print(f"Model: {result['embedding_model']}")
+
+
 def cmd_deduplicate(args):
     _require_sqlite(args, "deduplicate")
     if args.accept:
@@ -1624,6 +1666,19 @@ def main():
     p.add_argument("--accept", metavar="FILE",
                    help="Apply a reviewed dedup plan file")
 
+    # cluster-list
+    p = sub.add_parser("cluster-list", help="List semantic similarity clusters")
+    p.add_argument("--status", choices=["IN", "OUT"], default="IN",
+                   help="Filter by truth value (default: IN)")
+    p.add_argument("--n-clusters", type=int, default=None,
+                   help="Override automatic cluster count")
+    p.add_argument("--embedding-model", default=None,
+                   help="Sentence-transformers model (default: all-MiniLM-L6-v2)")
+    p.add_argument("--visible-to", metavar="TAG,TAG",
+                   help="Only show nodes whose access_tags are a subset of these tags")
+    p.add_argument("--format", choices=["text", "json", "markdown"], default="text",
+                   help="Output format (default: text)")
+
     # namespaces
     p = sub.add_parser("list-gated", help="List OUT nodes blocked by IN outlist nodes")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
@@ -1740,6 +1795,7 @@ def main():
         "lookup": cmd_lookup,
         "ask": cmd_ask,
         "deduplicate": cmd_deduplicate,
+        "cluster-list": cmd_cluster_list,
         "list": cmd_list,
         "list-gated": cmd_list_gated,
         "list-negative": cmd_list_negative,

--- a/reasons_lib/cluster.py
+++ b/reasons_lib/cluster.py
@@ -81,7 +81,7 @@ def _auto_k(n_beliefs, n_clusters=None, max_k=20):
     if n_clusters is not None:
         k = max(n_clusters, 1)
     else:
-        k = len(range(n_beliefs)) // 5
+        k = n_beliefs // 5
         k = min(k, max_k)
         k = max(k, 2)
     return min(k, n_beliefs)

--- a/reasons_lib/cluster.py
+++ b/reasons_lib/cluster.py
@@ -141,3 +141,62 @@ def cluster_beliefs(beliefs, budget, seed=None, n_clusters=None,
         "cluster_sizes": cluster_sizes,
         "embedding_model": cache.model_name,
     }
+
+
+def list_clusters(beliefs, n_clusters=None, cache=None, model_name=DEFAULT_MODEL):
+    """Cluster beliefs and return full cluster assignments.
+
+    Args:
+        beliefs: {node_id: text} dict
+        n_clusters: override automatic cluster count
+        cache: optional ClusterCache for embedding reuse
+        model_name: sentence-transformers model name
+
+    Returns:
+        {"clusters": [{"id": int, "beliefs": [{"id": str, "text": str}]}],
+         "n_clusters": int, "embedding_model": str}
+    """
+    _require_cluster_deps()
+
+    if len(beliefs) <= 3:
+        return {
+            "clusters": [{"id": 0, "beliefs": [
+                {"id": nid, "text": text} for nid, text in sorted(beliefs.items())
+            ]}],
+            "n_clusters": 1,
+            "embedding_model": model_name,
+        }
+
+    if cache is None:
+        cache = ClusterCache(model_name)
+
+    ids, embeddings = cache.embed(beliefs)
+
+    if n_clusters is None:
+        k = len(beliefs) // 5
+        k = min(k, 20)
+        k = max(k, 2)
+    else:
+        k = max(n_clusters, 1)
+
+    k = min(k, len(beliefs))
+
+    km = KMeans(n_clusters=k, random_state=42, n_init=10)
+    labels = km.fit_predict(embeddings)
+
+    groups = {}
+    for i, nid in enumerate(ids):
+        groups.setdefault(int(labels[i]), []).append(
+            {"id": nid, "text": beliefs[nid]}
+        )
+
+    clusters = [
+        {"id": label, "beliefs": members}
+        for label, members in sorted(groups.items(), key=lambda x: -len(x[1]))
+    ]
+
+    return {
+        "clusters": clusters,
+        "n_clusters": k,
+        "embedding_model": cache.model_name,
+    }

--- a/reasons_lib/cluster.py
+++ b/reasons_lib/cluster.py
@@ -76,6 +76,17 @@ class ClusterCache:
         return ids, np.array(embeddings)
 
 
+def _auto_k(n_beliefs, n_clusters=None, max_k=20):
+    """Compute cluster count from belief count or explicit override."""
+    if n_clusters is not None:
+        k = max(n_clusters, 1)
+    else:
+        k = len(range(n_beliefs)) // 5
+        k = min(k, max_k)
+        k = max(k, 2)
+    return min(k, n_beliefs)
+
+
 def cluster_beliefs(beliefs, budget, seed=None, n_clusters=None,
                     cache=None, model_name=DEFAULT_MODEL):
     """Cluster beliefs and sample across cluster boundaries.
@@ -106,14 +117,7 @@ def cluster_beliefs(beliefs, budget, seed=None, n_clusters=None,
 
     ids, embeddings = cache.embed(beliefs)
 
-    if n_clusters is None:
-        k = len(beliefs) // 5
-        k = min(k, budget // 3, 20)
-        k = max(k, 2)
-    else:
-        k = max(n_clusters, 1)
-
-    k = min(k, len(beliefs))
+    k = _auto_k(len(beliefs), n_clusters, max_k=min(budget // 3, 20))
 
     km = KMeans(n_clusters=k, random_state=seed, n_init=10)
     labels = km.fit_predict(embeddings)
@@ -143,12 +147,14 @@ def cluster_beliefs(beliefs, budget, seed=None, n_clusters=None,
     }
 
 
-def list_clusters(beliefs, n_clusters=None, cache=None, model_name=DEFAULT_MODEL):
+def list_clusters(beliefs, n_clusters=None, seed=None, cache=None,
+                  model_name=DEFAULT_MODEL):
     """Cluster beliefs and return full cluster assignments.
 
     Args:
         beliefs: {node_id: text} dict
         n_clusters: override automatic cluster count
+        seed: random seed for KMeans
         cache: optional ClusterCache for embedding reuse
         model_name: sentence-transformers model name
 
@@ -172,16 +178,9 @@ def list_clusters(beliefs, n_clusters=None, cache=None, model_name=DEFAULT_MODEL
 
     ids, embeddings = cache.embed(beliefs)
 
-    if n_clusters is None:
-        k = len(beliefs) // 5
-        k = min(k, 20)
-        k = max(k, 2)
-    else:
-        k = max(n_clusters, 1)
+    k = _auto_k(len(beliefs), n_clusters)
 
-    k = min(k, len(beliefs))
-
-    km = KMeans(n_clusters=k, random_state=42, n_init=10)
+    km = KMeans(n_clusters=k, random_state=seed, n_init=10)
     labels = km.fit_predict(embeddings)
 
     groups = {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 """Tests for the functional Python API."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 """Tests for the functional Python API."""
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -577,3 +577,52 @@ class TestUpdateNode:
         node = api.show_node("a", db_path=db_path)
         assert node["text"] == "Updated while OUT"
         assert node["truth_value"] == "OUT"
+
+
+class TestListClusters:
+
+    @pytest.fixture
+    def db_with_beliefs(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        for i in range(10):
+            api.add_node(f"in-{i}", f"Active belief {i}", db_path=db)
+        for i in range(5):
+            api.add_node(f"out-{i}", f"Retracted belief {i}", db_path=db)
+            api.retract_node(f"out-{i}", db_path=db)
+        return db
+
+    def test_filters_by_status(self, db_with_beliefs):
+        mock_result = {"clusters": [{"id": 0, "beliefs": []}], "n_clusters": 1, "embedding_model": "test"}
+        with patch("reasons_lib.cluster.list_clusters", return_value=mock_result) as mock_lc:
+            api.list_clusters(status="IN", db_path=db_with_beliefs)
+            beliefs_arg = mock_lc.call_args[0][0]
+            assert all(k.startswith("in-") for k in beliefs_arg)
+            assert len(beliefs_arg) == 10
+
+    def test_filters_out_status(self, db_with_beliefs):
+        mock_result = {"clusters": [{"id": 0, "beliefs": []}], "n_clusters": 1, "embedding_model": "test"}
+        with patch("reasons_lib.cluster.list_clusters", return_value=mock_result) as mock_lc:
+            api.list_clusters(status="OUT", db_path=db_with_beliefs)
+            beliefs_arg = mock_lc.call_args[0][0]
+            assert all(k.startswith("out-") for k in beliefs_arg)
+            assert len(beliefs_arg) == 5
+
+    def test_empty_network(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        api.init_db(db_path=db)
+        result = api.list_clusters(db_path=db)
+        assert result["clusters"] == []
+        assert result["n_clusters"] == 0
+
+    def test_passes_seed(self, db_with_beliefs):
+        mock_result = {"clusters": [], "n_clusters": 0, "embedding_model": "test"}
+        with patch("reasons_lib.cluster.list_clusters", return_value=mock_result) as mock_lc:
+            api.list_clusters(seed=42, db_path=db_with_beliefs)
+            assert mock_lc.call_args[1]["seed"] == 42
+
+    def test_passes_n_clusters(self, db_with_beliefs):
+        mock_result = {"clusters": [], "n_clusters": 0, "embedding_model": "test"}
+        with patch("reasons_lib.cluster.list_clusters", return_value=mock_result) as mock_lc:
+            api.list_clusters(n_clusters=3, db_path=db_with_beliefs)
+            assert mock_lc.call_args[1]["n_clusters"] == 3

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -9,7 +9,7 @@ import pytest
 try:
     from reasons_lib.cluster import (
         cluster_beliefs, list_clusters, ClusterCache, _require_cluster_deps,
-        HAS_CLUSTER_DEPS,
+        _auto_k, HAS_CLUSTER_DEPS,
     )
 except ImportError:
     HAS_CLUSTER_DEPS = False
@@ -135,3 +135,30 @@ def test_list_clusters_small_set():
     assert len(result["clusters"]) == 1
     all_ids = {b["id"] for b in result["clusters"][0]["beliefs"]}
     assert all_ids == {"a", "b"}
+
+
+@skip_no_cluster
+def test_list_clusters_reproducible_with_seed():
+    beliefs = {f"b-{i}": f"Belief about topic {i}" for i in range(30)}
+    r1 = list_clusters(beliefs, seed=42)
+    r2 = list_clusters(beliefs, seed=42)
+    ids1 = [b["id"] for c in r1["clusters"] for b in c["beliefs"]]
+    ids2 = [b["id"] for c in r2["clusters"] for b in c["beliefs"]]
+    assert ids1 == ids2
+
+
+def test_auto_k_defaults():
+    assert _auto_k(100) == 20
+    assert _auto_k(50) == 10
+    assert _auto_k(10) == 2
+    assert _auto_k(5) == 2
+
+
+def test_auto_k_with_override():
+    assert _auto_k(100, n_clusters=5) == 5
+    assert _auto_k(3, n_clusters=10) == 3
+
+
+def test_auto_k_with_max_k():
+    assert _auto_k(100, max_k=8) == 8
+    assert _auto_k(100, max_k=30) == 20

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -8,7 +8,8 @@ import pytest
 
 try:
     from reasons_lib.cluster import (
-        cluster_beliefs, ClusterCache, _require_cluster_deps, HAS_CLUSTER_DEPS,
+        cluster_beliefs, list_clusters, ClusterCache, _require_cluster_deps,
+        HAS_CLUSTER_DEPS,
     )
 except ImportError:
     HAS_CLUSTER_DEPS = False
@@ -106,3 +107,31 @@ def test_cluster_n_clusters_override():
     beliefs = {f"b-{i}": f"Belief about topic {i}" for i in range(50)}
     _, stats = cluster_beliefs(beliefs, budget=20, seed=42, n_clusters=5)
     assert stats["n_clusters"] == 5
+
+
+@skip_no_cluster
+def test_list_clusters_returns_all_beliefs():
+    beliefs = {f"b-{i}": f"Belief about topic {i} with some text" for i in range(30)}
+    result = list_clusters(beliefs)
+    all_ids = {b["id"] for c in result["clusters"] for b in c["beliefs"]}
+    assert all_ids == set(beliefs.keys())
+    assert result["n_clusters"] >= 2
+    assert "embedding_model" in result
+
+
+@skip_no_cluster
+def test_list_clusters_n_clusters_override():
+    beliefs = {f"b-{i}": f"Belief about topic {i}" for i in range(50)}
+    result = list_clusters(beliefs, n_clusters=5)
+    assert result["n_clusters"] == 5
+    assert len(result["clusters"]) == 5
+
+
+@skip_no_cluster
+def test_list_clusters_small_set():
+    beliefs = {"a": "Alpha belief", "b": "Beta belief"}
+    result = list_clusters(beliefs)
+    assert result["n_clusters"] == 1
+    assert len(result["clusters"]) == 1
+    all_ids = {b["id"] for b in result["clusters"][0]["beliefs"]}
+    assert all_ids == {"a", "b"}


### PR DESCRIPTION
## Summary

- Adds `cluster-list` command that groups beliefs by semantic similarity using sentence-transformers + KMeans
- Supports `--format text|json|markdown` for doc generation pipelines
- Adds `list_clusters()` to `cluster.py` (reuses existing embed/KMeans flow) and `api.py`
- 3 new tests in `test_cluster.py`, full suite passes (858 passed, 131 skipped)

## Test plan

- [x] `uv run pytest tests/test_cluster.py -v` — all 12 tests pass (3 new)
- [x] `uv run pytest tests/ -x -q` — 858 passed, 131 skipped
- [x] Smoke tested against ftl-reasons-expert reasons.db (575 IN beliefs → 20 clusters)
- [x] Verified `--format json` produces valid parseable JSON
- [x] Verified `--format markdown` produces doc-ready output with headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)