### PR TITLE
Add --semantic mode to deduplicate

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2183,9 +2183,8 @@ def deduplicate(
     Returns: {"clusters": list[dict], "retracted": list[str]}
     """
     if semantic:
-        from .cluster import ClusterCache, DEFAULT_MODEL, _require_cluster_deps
+        from .cluster import ClusterCache, DEFAULT_MODEL
         import numpy as np
-        _require_cluster_deps()
     else:
         from .derive import _tokenize_id, _jaccard
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2192,6 +2192,9 @@ def deduplicate(
         in_nodes = [(nid, n) for nid, n in sorted(net.nodes.items())
                     if n.truth_value == "IN"]
 
+        if not in_nodes:
+            return {"clusters": [], "retracted": []}
+
         if semantic:
             beliefs = {nid: n.text for nid, n in in_nodes}
             cache = ClusterCache(embedding_model or DEFAULT_MODEL)

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2164,30 +2164,46 @@ def list_clusters(
 def deduplicate(
     threshold: float = 0.5,
     auto: bool = False,
+    semantic: bool = False,
+    embedding_model: str | None = None,
     db_path: str = DEFAULT_DB,
 ) -> dict:
-    """Find clusters of IN beliefs with similar IDs (likely duplicates).
+    """Find clusters of IN beliefs with similar IDs or text (likely duplicates).
 
-    Uses Jaccard similarity on ID tokens to detect beliefs that say the
-    same thing under slightly different IDs.
+    Uses Jaccard similarity on ID tokens by default, or embedding cosine
+    similarity when semantic=True.
 
     Args:
-        threshold: Minimum Jaccard similarity to consider a pair (default: 0.5)
+        threshold: Minimum similarity to consider a pair (default: 0.5)
         auto: If True, retract all but the most-connected belief in each cluster
+        semantic: If True, use embedding cosine similarity instead of ID tokens
+        embedding_model: Sentence-transformers model (semantic mode only)
         db_path: Path to database
 
     Returns: {"clusters": list[dict], "retracted": list[str]}
     """
-    from .derive import _tokenize_id, _jaccard
+    if semantic:
+        from .cluster import ClusterCache, DEFAULT_MODEL, _require_cluster_deps
+        import numpy as np
+        _require_cluster_deps()
+    else:
+        from .derive import _tokenize_id, _jaccard
 
     with _with_network(db_path, write=auto) as net:
         in_nodes = [(nid, n) for nid, n in sorted(net.nodes.items())
                     if n.truth_value == "IN"]
 
-        # Build token sets once
-        tokens = {nid: _tokenize_id(nid) for nid, _ in in_nodes}
+        if semantic:
+            beliefs = {nid: n.text for nid, n in in_nodes}
+            cache = ClusterCache(embedding_model or DEFAULT_MODEL)
+            ids, embeddings = cache.embed(beliefs)
+            norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+            norms = np.where(norms == 0, 1, norms)
+            normed = embeddings / norms
+            sim_matrix = normed @ normed.T
+        else:
+            tokens = {nid: _tokenize_id(nid) for nid, _ in in_nodes}
 
-        # Union-find to group similar beliefs
         parent = {nid: nid for nid, _ in in_nodes}
 
         def find(x):
@@ -2201,10 +2217,16 @@ def deduplicate(
             if ra != rb:
                 parent[ra] = rb
 
-        for i, (nid_a, _) in enumerate(in_nodes):
-            for nid_b, _ in in_nodes[i + 1:]:
-                if _jaccard(tokens[nid_a], tokens[nid_b]) >= threshold:
-                    union(nid_a, nid_b)
+        if semantic:
+            for i in range(len(ids)):
+                for j in range(i + 1, len(ids)):
+                    if sim_matrix[i, j] >= threshold:
+                        union(ids[i], ids[j])
+        else:
+            for i, (nid_a, _) in enumerate(in_nodes):
+                for nid_b, _ in in_nodes[i + 1:]:
+                    if _jaccard(tokens[nid_a], tokens[nid_b]) >= threshold:
+                        union(nid_a, nid_b)
 
         # Collect clusters (only groups of 2+)
         from collections import defaultdict

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -797,7 +797,7 @@ def cmd_deduplicate(args):
         threshold=args.threshold,
         auto=args.auto,
         semantic=args.semantic,
-        embedding_model=getattr(args, "embedding_model", None),
+        embedding_model=args.embedding_model,
         db_path=args.db,
     )
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -796,6 +796,8 @@ def cmd_deduplicate(args):
     result = api.deduplicate(
         threshold=args.threshold,
         auto=args.auto,
+        semantic=args.semantic,
+        embedding_model=getattr(args, "embedding_model", None),
         db_path=args.db,
     )
 
@@ -1660,7 +1662,11 @@ def main():
     # deduplicate
     p = sub.add_parser("deduplicate", help="Find and optionally retract duplicate IN beliefs")
     p.add_argument("--threshold", type=float, default=0.5,
-                   help="Jaccard similarity threshold for ID tokens (default: 0.5)")
+                   help="Similarity threshold (Jaccard for ID mode, cosine for --semantic; default: 0.5)")
+    p.add_argument("--semantic", action="store_true",
+                   help="Use embedding similarity instead of ID token similarity")
+    p.add_argument("--embedding-model", default=None,
+                   help="Sentence-transformers model (default: all-MiniLM-L6-v2)")
     p.add_argument("--auto", action="store_true",
                    help="Automatically retract duplicates (keeps one per cluster)")
     p.add_argument("-o", "--output", default="proposed-dedup.md",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -673,9 +673,10 @@ class TestDeduplicateSemantic:
     def test_semantic_auto_retracts(self, db_with_similar):
         result = api.deduplicate(threshold=0.5, semantic=True, auto=True,
                                   db_path=db_with_similar)
-        assert len(result["retracted"]) >= 1
         retracted_set = set(result["retracted"])
-        assert not ({"input-validation-at-boundaries", "boundary-input-checking"} <= retracted_set)
+        similar_pair = {"input-validation-at-boundaries", "boundary-input-checking"}
+        assert len(retracted_set & similar_pair) == 1
+        assert "database-query-performance" not in retracted_set
 
     def test_jaccard_mode_unchanged(self, db_with_similar):
         result = api.deduplicate(threshold=0.5, semantic=False, db_path=db_with_similar)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -678,6 +678,13 @@ class TestDeduplicateSemantic:
         assert len(retracted_set & similar_pair) == 1
         assert "database-query-performance" not in retracted_set
 
+    def test_semantic_empty_network(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        api.init_db(db_path=db)
+        result = api.deduplicate(threshold=0.5, semantic=True, db_path=db)
+        assert result["clusters"] == []
+        assert result["retracted"] == []
+
     def test_jaccard_mode_unchanged(self, db_with_similar):
         result = api.deduplicate(threshold=0.5, semantic=False, db_path=db_with_similar)
         assert result["retracted"] == []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -626,3 +626,57 @@ class TestListClusters:
         with patch("reasons_lib.cluster.list_clusters", return_value=mock_result) as mock_lc:
             api.list_clusters(n_clusters=3, db_path=db_with_beliefs)
             assert mock_lc.call_args[1]["n_clusters"] == 3
+
+
+try:
+    from reasons_lib.cluster import HAS_CLUSTER_DEPS
+except ImportError:
+    HAS_CLUSTER_DEPS = False
+
+skip_no_cluster = pytest.mark.skipif(
+    not HAS_CLUSTER_DEPS,
+    reason="sentence-transformers and scikit-learn not installed"
+)
+
+
+@skip_no_cluster
+class TestDeduplicateSemantic:
+
+    @pytest.fixture
+    def db_with_similar(self, tmp_path):
+        db = str(tmp_path / "sim.db")
+        api.init_db(db_path=db)
+        api.add_node("input-validation-at-boundaries",
+                      "The system validates all inputs at system boundaries",
+                      db_path=db)
+        api.add_node("boundary-input-checking",
+                      "Input validation occurs at system edges and boundaries",
+                      db_path=db)
+        api.add_node("database-query-performance",
+                      "Database queries are optimized for read-heavy workloads",
+                      db_path=db)
+        return db
+
+    def test_semantic_finds_similar_text(self, db_with_similar):
+        result = api.deduplicate(threshold=0.5, semantic=True, db_path=db_with_similar)
+        assert len(result["clusters"]) >= 1
+        cluster_ids = {b["id"] for b in result["clusters"][0]["beliefs"]}
+        assert "input-validation-at-boundaries" in cluster_ids
+        assert "boundary-input-checking" in cluster_ids
+
+    def test_semantic_skips_dissimilar(self, db_with_similar):
+        result = api.deduplicate(threshold=0.8, semantic=True, db_path=db_with_similar)
+        for cluster in result["clusters"]:
+            ids = {b["id"] for b in cluster["beliefs"]}
+            assert not ({"input-validation-at-boundaries", "database-query-performance"} <= ids)
+
+    def test_semantic_auto_retracts(self, db_with_similar):
+        result = api.deduplicate(threshold=0.5, semantic=True, auto=True,
+                                  db_path=db_with_similar)
+        assert len(result["retracted"]) >= 1
+        retracted_set = set(result["retracted"])
+        assert not ({"input-validation-at-boundaries", "boundary-input-checking"} <= retracted_set)
+
+    def test_jaccard_mode_unchanged(self, db_with_similar):
+        result = api.deduplicate(threshold=0.5, semantic=False, db_path=db_with_similar)
+        assert result["retracted"] == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -731,6 +731,36 @@ class TestDeduplicate:
         assert code == 1
 
 
+try:
+    from reasons_lib.cluster import HAS_CLUSTER_DEPS
+except ImportError:
+    HAS_CLUSTER_DEPS = False
+
+
+@pytest.mark.skipif(not HAS_CLUSTER_DEPS,
+                    reason="sentence-transformers and scikit-learn not installed")
+class TestDeduplicateSemantic:
+
+    def test_semantic_finds_similar(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "input-validation-at-boundaries",
+                "The system validates all inputs at system boundaries", db_path=db_path)
+        run_cli("add", "boundary-input-checking",
+                "Input validation occurs at system edges and boundaries", db_path=db_path)
+        out, err, code = run_cli("deduplicate", "--semantic", db_path=db_path)
+        assert code == 0
+        assert "Cluster" in out
+
+    def test_semantic_with_threshold(self, db_path):
+        run_cli("init", db_path=db_path)
+        run_cli("add", "alpha", "Something about alpha", db_path=db_path)
+        run_cli("add", "beta", "Something completely unrelated about beta", db_path=db_path)
+        out, err, code = run_cli("deduplicate", "--semantic", "--threshold", "0.95",
+                                  db_path=db_path)
+        assert code == 0
+        assert "No duplicate" in out
+
+
 class TestCheckStale:
 
     def test_check_stale_all_fresh(self, db_path):


### PR DESCRIPTION
## Summary

- Adds `--semantic` flag to `deduplicate` that uses embedding cosine similarity (via `ClusterCache` from `cluster.py`) instead of Jaccard similarity on ID tokens
- Catches semantically similar beliefs with different names (e.g., "input validation at boundaries" vs "boundary input checking")
- Adds `--embedding-model` flag to override the default sentence-transformers model
- Existing Jaccard mode unchanged — `--semantic` is opt-in

## Test plan

- [x] 4 new tests in `TestDeduplicateSemantic`: finds similar text, skips dissimilar, auto-retracts, Jaccard mode unchanged
- [x] Full suite: 871 passed, 131 skipped
- [x] Manual test against expert repo: 30 semantic clusters (65 beliefs) at threshold 0.85

🤖 Generated with [Claude Code](https://claude.com/claude-code)