### PR TITLE
PgApi: Add simple query/conversion methods

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -523,7 +523,10 @@ def assert_node(node_id: str, db_path: str = DEFAULT_DB,
         return {"changed": changed, "went_out": went_out, "went_in": went_in}
 
 
-def propagate(db_path: str = DEFAULT_DB) -> dict:
+def propagate(db_path: str = DEFAULT_DB,
+              pg_conninfo=None, project_id=None) -> dict:
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "propagate")
     with _with_network(db_path, write=True) as net:
         changed = net.recompute_all()
     return {"changed": changed}
@@ -636,12 +639,17 @@ def trace_assumptions(node_id: str, visible_to: list[str] | None = None, db_path
         return {"node_id": node_id, "premises": premises}
 
 
-def trace_access_tags(node_id: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> dict:
+def trace_access_tags(node_id: str, visible_to: list[str] | None = None,
+                      db_path: str = DEFAULT_DB,
+                      pg_conninfo=None, project_id=None) -> dict:
     """Trace backward through dependency chains and return union of all access_tags.
 
     Returns: {"node_id": str, "access_tags": list[str]}
     Raises PermissionError if node's access_tags are not a subset of visible_to.
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "trace_access_tags",
+                            node_id=node_id, visible_to=visible_to)
     with _with_network(db_path) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
@@ -699,20 +707,29 @@ def summarize(
     over: list[str],
     source: str = "",
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Create a summary node that abstracts over a group of nodes.
 
     Returns: {"summary_id": str, "over": list[str], "truth_value": str}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "summarize",
+                            summary_id=summary_id, text=text,
+                            over=over, source=source)
     with _with_network(db_path, write=True) as net:
         return net.summarize(summary_id, text, over, source=source)
 
 
-def supersede(old_id: str, new_id: str, db_path: str = DEFAULT_DB) -> dict:
+def supersede(old_id: str, new_id: str, db_path: str = DEFAULT_DB,
+              pg_conninfo=None, project_id=None) -> dict:
     """Mark old_id as superseded by new_id. Old goes OUT when new is IN.
 
     Returns: {"old_id": str, "new_id": str, "changed": list[str]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "supersede",
+                            old_id=old_id, new_id=new_id)
     with _with_network(db_path, write=True) as net:
         return net.supersede(old_id, new_id)
 
@@ -818,8 +835,11 @@ def add_nogood(node_ids: list[str], db_path: str = DEFAULT_DB,
         }
 
 
-def get_belief_set(db_path: str = DEFAULT_DB) -> list[str]:
+def get_belief_set(db_path: str = DEFAULT_DB,
+                   pg_conninfo=None, project_id=None) -> list[str]:
     """Return all node IDs currently IN."""
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "get_belief_set")
     with _with_network(db_path) as net:
         return net.get_belief_set()
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -316,13 +316,12 @@ def cmd_convert_to_premise(args):
 
 
 def cmd_summarize(args):
-    _require_sqlite(args, "summarize")
     over = [n.strip() for n in args.over.split(",")]
     try:
         result = api.summarize(
             args.summary_id, args.text, over,
             source=args.source or "",
-            db_path=args.db,
+            **_backend_kwargs(args),
         )
     except (KeyError, ValueError) as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -332,9 +331,8 @@ def cmd_summarize(args):
 
 
 def cmd_supersede(args):
-    _require_sqlite(args, "supersede")
     try:
-        result = api.supersede(args.old_id, args.new_id, db_path=args.db)
+        result = api.supersede(args.old_id, args.new_id, **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -411,9 +409,9 @@ def cmd_nogood(args):
 
 
 def cmd_trace_access_tags(args):
-    _require_sqlite(args, "trace-access-tags")
     try:
-        result = api.trace_access_tags(args.node_id, visible_to=_parse_visible_to(args), db_path=args.db)
+        result = api.trace_access_tags(args.node_id, visible_to=_parse_visible_to(args),
+                                        **_backend_kwargs(args))
     except KeyError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
@@ -451,8 +449,7 @@ def cmd_trace(args):
 
 
 def cmd_propagate(args):
-    _require_sqlite(args, "propagate")
-    result = api.propagate(db_path=args.db)
+    result = api.propagate(**_backend_kwargs(args))
     changed = result["changed"]
     if changed:
         print(f"Updated: {', '.join(changed)}")

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1057,7 +1057,7 @@ class PgApi:
     def propagate(self):
         """Recompute truth values for all derived nodes to a fixpoint."""
         pid = self.project_id
-        all_changed = []
+        all_changed = set()
         with self.conn.cursor() as cur:
             cur.execute(
                 "SELECT COUNT(*) FROM rms_nodes WHERE project_id = %s",
@@ -1094,10 +1094,10 @@ class PgApi:
 
                 if not changed_this_pass:
                     break
-                all_changed.extend(changed_this_pass)
+                all_changed.update(changed_this_pass)
 
         self.conn.commit()
-        return {"changed": all_changed}
+        return {"changed": list(all_changed)}
 
     def supersede(self, old_id, new_id):
         """Mark old_id as superseded by new_id using the outlist mechanism."""

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1043,6 +1043,228 @@ class PgApi:
             "changed": changed,
         }
 
+    def get_belief_set(self):
+        """Return all node IDs currently IN."""
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM rms_nodes "
+                "WHERE project_id = %s AND truth_value = 'IN'",
+                (pid,),
+            )
+            return [row[0] for row in cur.fetchall()]
+
+    def propagate(self):
+        """Recompute truth values for all derived nodes to a fixpoint."""
+        pid = self.project_id
+        all_changed = []
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM rms_nodes WHERE project_id = %s",
+                (pid,),
+            )
+            max_iterations = cur.fetchone()[0] + 1
+
+            for _ in range(max_iterations):
+                cur.execute(
+                    "SELECT DISTINCT n.id, n.truth_value, n.metadata "
+                    "FROM rms_nodes n "
+                    "JOIN rms_justifications j "
+                    "  ON j.node_id = n.id AND j.project_id = n.project_id "
+                    "WHERE n.project_id = %s",
+                    (pid,),
+                )
+                rows = cur.fetchall()
+
+                changed_this_pass = []
+                for node_id, old_tv, meta in rows:
+                    if isinstance(meta, str):
+                        meta = json.loads(meta)
+                    if meta.get("_retracted"):
+                        continue
+                    new_tv = self._compute_truth(cur, node_id)
+                    if old_tv != new_tv:
+                        cur.execute(
+                            "UPDATE rms_nodes SET truth_value = %s "
+                            "WHERE id = %s AND project_id = %s",
+                            (new_tv, node_id, pid),
+                        )
+                        self._log(cur, "recompute", node_id, new_tv)
+                        changed_this_pass.append(node_id)
+
+                if not changed_this_pass:
+                    break
+                all_changed.extend(changed_this_pass)
+
+        self.conn.commit()
+        return {"changed": all_changed}
+
+    def supersede(self, old_id, new_id):
+        """Mark old_id as superseded by new_id using the outlist mechanism."""
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT truth_value, metadata FROM rms_nodes "
+                "WHERE id = %s AND project_id = %s",
+                (old_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{old_id}' not found")
+            old_tv, old_meta = row
+            if isinstance(old_meta, str):
+                old_meta = json.loads(old_meta)
+
+            cur.execute(
+                "SELECT metadata FROM rms_nodes "
+                "WHERE id = %s AND project_id = %s",
+                (new_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{new_id}' not found")
+            new_meta = row[0]
+            if isinstance(new_meta, str):
+                new_meta = json.loads(new_meta)
+
+            cur.execute(
+                "SELECT id FROM rms_justifications "
+                "WHERE node_id = %s AND project_id = %s",
+                (old_id, pid),
+            )
+            just_rows = cur.fetchall()
+            if just_rows:
+                cur.execute(
+                    "UPDATE rms_justifications "
+                    "SET outlist = outlist || %s::jsonb "
+                    "WHERE node_id = %s AND project_id = %s",
+                    (json.dumps([new_id]), old_id, pid),
+                )
+            else:
+                cur.execute(
+                    "INSERT INTO rms_justifications "
+                    "(node_id, project_id, type, antecedents, outlist, label) "
+                    "VALUES (%s, %s, 'SL', '[]', %s, '')",
+                    (old_id, pid, json.dumps([new_id])),
+                )
+
+            old_meta["superseded_by"] = new_id
+            cur.execute(
+                "UPDATE rms_nodes SET metadata = %s "
+                "WHERE id = %s AND project_id = %s",
+                (json.dumps(old_meta), old_id, pid),
+            )
+
+            supersedes = new_meta.get("supersedes", [])
+            if old_id not in supersedes:
+                supersedes.append(old_id)
+            new_meta["supersedes"] = supersedes
+            cur.execute(
+                "UPDATE rms_nodes SET metadata = %s "
+                "WHERE id = %s AND project_id = %s",
+                (json.dumps(new_meta), new_id, pid),
+            )
+
+            new_tv = self._compute_truth(cur, old_id)
+            changed = []
+            if old_tv != new_tv:
+                cur.execute(
+                    "UPDATE rms_nodes SET truth_value = %s "
+                    "WHERE id = %s AND project_id = %s",
+                    (new_tv, old_id, pid),
+                )
+                self._log(cur, "supersede", old_id,
+                          f"superseded by {new_id}")
+                changed.append(old_id)
+                went_out, went_in = self._propagate(cur, old_id)
+                changed.extend(went_out)
+                changed.extend(went_in)
+            else:
+                self._log(cur, "supersede", old_id,
+                          f"superseded by {new_id} (unchanged)")
+
+        self.conn.commit()
+        return {"old_id": old_id, "new_id": new_id, "changed": changed}
+
+    def summarize(self, summary_id, text, over, source=""):
+        """Create a summary node that abstracts over a group of nodes."""
+        pid = self.project_id
+        now = datetime.now().isoformat(timespec="seconds")
+
+        with self.conn.cursor() as cur:
+            if over:
+                cur.execute(
+                    "SELECT id FROM rms_nodes "
+                    "WHERE project_id = %s AND id = ANY(%s)",
+                    (pid, list(over)),
+                )
+                found = {row[0] for row in cur.fetchall()}
+                missing = set(over) - found
+                if missing:
+                    raise KeyError(
+                        f"Node(s) not found: {', '.join(sorted(missing))}")
+
+            cur.execute(
+                "SELECT 1 FROM rms_nodes "
+                "WHERE id = %s AND project_id = %s",
+                (summary_id, pid),
+            )
+            if cur.fetchone():
+                raise ValueError(f"Node '{summary_id}' already exists")
+
+            metadata = {"summarizes": list(over)}
+            cur.execute(
+                "INSERT INTO rms_nodes "
+                "(id, project_id, text, source, date, metadata) "
+                "VALUES (%s, %s, %s, %s, %s, %s)",
+                (summary_id, pid, text, source, now, json.dumps(metadata)),
+            )
+
+            justifications = [{"antecedents": list(over), "outlist": []}]
+            cur.execute(
+                "INSERT INTO rms_justifications "
+                "(node_id, project_id, type, antecedents, outlist, label) "
+                "VALUES (%s, %s, 'SL', %s, '[]', 'summarizes')",
+                (summary_id, pid, json.dumps(list(over))),
+            )
+
+            self._inherit_access_tags(cur, summary_id, justifications)
+
+            truth = self._compute_truth(cur, summary_id)
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = %s "
+                "WHERE id = %s AND project_id = %s",
+                (truth, summary_id, pid),
+            )
+            self._log(cur, "add", summary_id, truth)
+
+            for nid in over:
+                cur.execute(
+                    "SELECT metadata FROM rms_nodes "
+                    "WHERE id = %s AND project_id = %s",
+                    (nid, pid),
+                )
+                row = cur.fetchone()
+                meta = row[0] if row else {}
+                if isinstance(meta, str):
+                    meta = json.loads(meta)
+                covered = meta.get("summarized_by", [])
+                if summary_id not in covered:
+                    covered.append(summary_id)
+                meta["summarized_by"] = covered
+                cur.execute(
+                    "UPDATE rms_nodes SET metadata = %s "
+                    "WHERE id = %s AND project_id = %s",
+                    (json.dumps(meta), nid, pid),
+                )
+
+        self.conn.commit()
+        return {
+            "summary_id": summary_id,
+            "over": list(over),
+            "truth_value": truth,
+        }
+
     def get_log(self, last=None):
         pid = self.project_id
         with self.conn.cursor() as cur:
@@ -1374,6 +1596,33 @@ class PgApi:
             self._trace_assumptions_recursive(cur, node_id, premises, visited)
 
         return {"node_id": node_id, "premises": premises}
+
+    def trace_access_tags(self, node_id, visible_to=None):
+        """Trace access_tags union through the dependency chain."""
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT metadata FROM rms_nodes "
+                "WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{node_id}' not found")
+            meta = row[0]
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                raise PermissionError(
+                    f"Node '{node_id}' requires access tags "
+                    f"not in {visible_to}")
+
+            all_tags = set()
+            visited = set()
+            self._trace_access_tags_recursive(
+                cur, node_id, all_tags, visited)
+
+        return {"node_id": node_id, "access_tags": sorted(all_tags)}
 
     # ── Internal: propagation ───────────────────────────────────
 
@@ -1758,6 +2007,37 @@ class PgApi:
                 ants = json.loads(ants)
             for ant_id in ants:
                 self._trace_assumptions_recursive(cur, ant_id, premises, visited)
+
+    def _trace_access_tags_recursive(self, cur, node_id, all_tags, visited):
+        if node_id in visited:
+            return
+        visited.add(node_id)
+        pid = self.project_id
+
+        cur.execute(
+            "SELECT metadata FROM rms_nodes "
+            "WHERE id = %s AND project_id = %s",
+            (node_id, pid),
+        )
+        row = cur.fetchone()
+        if not row:
+            return
+        meta = row[0]
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        all_tags.update(meta.get("access_tags", []))
+
+        cur.execute(
+            "SELECT antecedents FROM rms_justifications "
+            "WHERE node_id = %s AND project_id = %s",
+            (node_id, pid),
+        )
+        for (ants,) in cur.fetchall():
+            if isinstance(ants, str):
+                ants = json.loads(ants)
+            for ant_id in ants:
+                self._trace_access_tags_recursive(
+                    cur, ant_id, all_tags, visited)
 
     def _explain_recursive(self, cur, node_id, visible_to, visited):
         if node_id in visited:

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1128,7 +1128,7 @@ class PgApi:
                 new_meta = json.loads(new_meta)
 
             cur.execute(
-                "SELECT id FROM rms_justifications "
+                "SELECT id, outlist FROM rms_justifications "
                 "WHERE node_id = %s AND project_id = %s",
                 (old_id, pid),
             )
@@ -1137,8 +1137,10 @@ class PgApi:
                 cur.execute(
                     "UPDATE rms_justifications "
                     "SET outlist = outlist || %s::jsonb "
-                    "WHERE node_id = %s AND project_id = %s",
-                    (json.dumps([new_id]), old_id, pid),
+                    "WHERE node_id = %s AND project_id = %s "
+                    "AND NOT outlist @> %s::jsonb",
+                    (json.dumps([new_id]), old_id, pid,
+                     json.dumps([new_id])),
                 )
             else:
                 cur.execute(

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -1061,3 +1061,173 @@ class TestConvertToPremise:
         result = pg_api.convert_to_premise("a")
         assert result["old_justifications"] == 0
         assert result["truth_value"] == "IN"
+
+
+class TestGetBeliefSet:
+
+    def test_empty(self, pg_api):
+        result = pg_api.get_belief_set()
+        assert result == []
+
+    def test_all_in(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        assert set(pg_api.get_belief_set()) == {"a", "b"}
+
+    def test_mixed(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta")
+        pg_api.retract_node("b")
+        result = pg_api.get_belief_set()
+        assert result == ["a"]
+
+
+class TestPropagate:
+
+    def test_no_changes(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        result = pg_api.propagate()
+        assert result["changed"] == []
+
+    def test_fixes_stale_truth(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        with pg_api.conn.cursor() as cur:
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = 'OUT' "
+                "WHERE id = 'b' AND project_id = %s",
+                (pg_api.project_id,),
+            )
+        pg_api.conn.commit()
+        result = pg_api.propagate()
+        assert "b" in result["changed"]
+        assert pg_api.show_node("b")["truth_value"] == "IN"
+
+    def test_cascade(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        pg_api.add_node("b", "Beta", sl="a")
+        pg_api.add_node("c", "Gamma", sl="b")
+        with pg_api.conn.cursor() as cur:
+            cur.execute(
+                "UPDATE rms_nodes SET truth_value = 'OUT' "
+                "WHERE id IN ('b', 'c') AND project_id = %s",
+                (pg_api.project_id,),
+            )
+        pg_api.conn.commit()
+        result = pg_api.propagate()
+        assert set(result["changed"]) >= {"b", "c"}
+
+    def test_empty_network(self, pg_api):
+        result = pg_api.propagate()
+        assert result["changed"] == []
+
+
+class TestSupersede:
+
+    def test_makes_old_out(self, pg_api):
+        pg_api.add_node("old", "Old belief")
+        pg_api.add_node("new", "New belief")
+        result = pg_api.supersede("old", "new")
+        assert result["old_id"] == "old"
+        assert result["new_id"] == "new"
+        assert "old" in result["changed"]
+        assert pg_api.show_node("old")["truth_value"] == "OUT"
+
+    def test_metadata(self, pg_api):
+        pg_api.add_node("old", "Old belief")
+        pg_api.add_node("new", "New belief")
+        pg_api.supersede("old", "new")
+        old = pg_api.show_node("old")
+        new = pg_api.show_node("new")
+        assert old["metadata"]["superseded_by"] == "new"
+        assert "old" in new["metadata"]["supersedes"]
+
+    def test_reversible(self, pg_api):
+        pg_api.add_node("old", "Old")
+        pg_api.add_node("new", "New")
+        pg_api.supersede("old", "new")
+        assert pg_api.show_node("old")["truth_value"] == "OUT"
+        pg_api.retract_node("new")
+        assert pg_api.show_node("old")["truth_value"] == "IN"
+
+    def test_cascade(self, pg_api):
+        pg_api.add_node("old", "Old")
+        pg_api.add_node("dep", "Depends on old", sl="old")
+        pg_api.add_node("new", "New")
+        result = pg_api.supersede("old", "new")
+        assert "dep" in result["changed"]
+        assert pg_api.show_node("dep")["truth_value"] == "OUT"
+
+    def test_not_found(self, pg_api):
+        pg_api.add_node("a", "Alpha")
+        with pytest.raises(KeyError):
+            pg_api.supersede("a", "missing")
+        with pytest.raises(KeyError):
+            pg_api.supersede("missing", "a")
+
+
+class TestSummarize:
+
+    def test_create_summary(self, pg_api):
+        pg_api.add_node("a", "Premise A")
+        pg_api.add_node("b", "Premise B")
+        result = pg_api.summarize("s", "Summary of A and B", over=["a", "b"])
+        assert result["summary_id"] == "s"
+        assert result["truth_value"] == "IN"
+        assert result["over"] == ["a", "b"]
+
+    def test_metadata(self, pg_api):
+        pg_api.add_node("a", "A")
+        pg_api.add_node("b", "B")
+        pg_api.summarize("s", "Summary", over=["a", "b"])
+        summary = pg_api.show_node("s")
+        assert summary["metadata"]["summarizes"] == ["a", "b"]
+        a = pg_api.show_node("a")
+        assert "s" in a["metadata"]["summarized_by"]
+
+    def test_out_when_antecedent_out(self, pg_api):
+        pg_api.add_node("a", "A")
+        pg_api.add_node("b", "B")
+        pg_api.summarize("s", "Summary", over=["a", "b"])
+        pg_api.retract_node("a")
+        assert pg_api.show_node("s")["truth_value"] == "OUT"
+
+    def test_duplicate_raises(self, pg_api):
+        pg_api.add_node("a", "A")
+        pg_api.summarize("s", "Summary", over=["a"])
+        with pytest.raises(ValueError):
+            pg_api.summarize("s", "Dup", over=["a"])
+
+    def test_missing_node_raises(self, pg_api):
+        pg_api.add_node("a", "A")
+        with pytest.raises(KeyError):
+            pg_api.summarize("s", "Summary", over=["a", "missing"])
+
+
+class TestTraceAccessTags:
+
+    def test_premise_returns_own_tags(self, pg_api):
+        pg_api.add_node("a", "A", access_tags=["finance"])
+        result = pg_api.trace_access_tags("a")
+        assert result["access_tags"] == ["finance"]
+
+    def test_no_tags_returns_empty(self, pg_api):
+        pg_api.add_node("a", "A")
+        result = pg_api.trace_access_tags("a")
+        assert result["access_tags"] == []
+
+    def test_chain_collects_all(self, pg_api):
+        pg_api.add_node("a", "A", access_tags=["finance"])
+        pg_api.add_node("b", "B", sl="a", access_tags=["hr"])
+        pg_api.add_node("c", "C", sl="b")
+        result = pg_api.trace_access_tags("c")
+        assert result["access_tags"] == ["finance", "hr"]
+
+    def test_not_found(self, pg_api):
+        with pytest.raises(KeyError):
+            pg_api.trace_access_tags("missing")
+
+    def test_visible_to_denied(self, pg_api):
+        pg_api.add_node("a", "A", access_tags=["finance"])
+        with pytest.raises(PermissionError):
+            pg_api.trace_access_tags("a", visible_to=["hr"])


### PR DESCRIPTION
## Summary

- Add 5 missing PgApi methods: `get_belief_set`, `propagate`, `supersede`, `summarize`, `trace_access_tags`
- Wire dispatch in api.py so these work with `--pg` flag
- Remove `_require_sqlite` guards from 4 CLI commands (summarize, supersede, trace-access-tags, propagate)
- Add 22 new PG integration tests across 5 test classes

## Test plan

- [x] All 885 existing tests pass
- [x] 153 PG tests skipped without DATABASE_URL (expected)
- [ ] PG integration tests pass with DATABASE_URL set

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)