### PR TITLE
Add PgApi namespace support

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -91,7 +91,8 @@ def init_db(db_path: str = DEFAULT_DB, force: bool = False,
     return {"db_path": str(p), "created": True}
 
 
-def ensure_namespace(namespace: str, db_path: str = DEFAULT_DB) -> dict:
+def ensure_namespace(namespace: str, db_path: str = DEFAULT_DB,
+                     pg_conninfo=None, project_id=None) -> dict:
     """Ensure a namespace premise node exists (namespace:active).
 
     Creates the premise if it doesn't exist. This is the node that all
@@ -100,6 +101,9 @@ def ensure_namespace(namespace: str, db_path: str = DEFAULT_DB) -> dict:
 
     Returns: {"namespace": str, "active_node": str, "created": bool}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "ensure_namespace",
+                            namespace=namespace)
     active_id = f"{namespace}:active"
     with _with_network(db_path, write=True) as net:
         created = False
@@ -113,7 +117,8 @@ def ensure_namespace(namespace: str, db_path: str = DEFAULT_DB) -> dict:
         return {"namespace": namespace, "active_node": active_id, "created": created}
 
 
-def list_namespaces(db_path: str = DEFAULT_DB) -> dict:
+def list_namespaces(db_path: str = DEFAULT_DB,
+                    pg_conninfo=None, project_id=None) -> dict:
     """List all namespaces (agents) in the database.
 
     Detects namespaces by looking for nodes with ':active' suffix
@@ -121,6 +126,8 @@ def list_namespaces(db_path: str = DEFAULT_DB) -> dict:
 
     Returns: {"namespaces": list[dict]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "list_namespaces")
     with _with_network(db_path) as net:
         namespaces = []
         for nid, node in sorted(net.nodes.items()):
@@ -175,12 +182,12 @@ def add_node(
     Returns: {"node_id": str, "truth_value": str, "type": str, "premise_count": int}
     """
     if pg_conninfo:
-        if namespace or any_mode:
-            raise NotImplementedError("namespace and any_mode are not supported with PostgreSQL")
+        if any_mode:
+            raise NotImplementedError("any_mode is not supported with PostgreSQL")
         return _pg_dispatch(pg_conninfo, project_id, "add_node",
                             node_id=node_id, text=text, sl=sl, cp=cp, unless=unless,
                             label=label, source=source, source_url=source_url,
-                            access_tags=access_tags)
+                            access_tags=access_tags, namespace=namespace)
     outlist = [o.strip() for o in unless.split(",") if o.strip()] if unless else []
     justifications = []
     if sl:
@@ -272,17 +279,18 @@ def add_justification(
         cp: Comma-separated antecedent IDs for CP justification
         unless: Comma-separated outlist IDs (must be OUT for justification to hold)
         label: Justification label
-        namespace: Optional namespace prefix (not supported with PostgreSQL)
+        namespace: Optional namespace prefix
         any_mode: If True, expand SL into one justification per antecedent (OR; not supported with PostgreSQL)
         db_path: Path to RMS database
 
     Returns: {"node_id", "old_truth_value", "new_truth_value", "changed", "premise_count"}
     """
     if pg_conninfo:
-        if namespace or any_mode:
-            raise NotImplementedError("namespace and any_mode are not supported with PostgreSQL")
+        if any_mode:
+            raise NotImplementedError("any_mode is not supported with PostgreSQL")
         return _pg_dispatch(pg_conninfo, project_id, "add_justification",
-                            node_id=node_id, sl=sl, cp=cp, unless=unless, label=label)
+                            node_id=node_id, sl=sl, cp=cp, unless=unless,
+                            label=label, namespace=namespace)
     outlist = [o.strip() for o in unless.split(",") if o.strip()] if unless else []
 
     if sl:

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1389,8 +1389,7 @@ def cmd_contradictions(args):
 
 
 def cmd_namespaces(args):
-    _require_sqlite(args, "namespaces")
-    result = api.list_namespaces(db_path=args.db)
+    result = api.list_namespaces(**_backend_kwargs(args))
     if not result["namespaces"]:
         print("No namespaces found. Use --namespace/-n with 'add' or 'import-agent' to create one.")
         return

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -136,12 +136,18 @@ class PgApi:
     # ── Core mutations ──────────────────────────────────────────
 
     def add_node(self, node_id, text, sl="", cp="", unless="", label="",
-                 source="", source_url="", access_tags=None):
+                 source="", source_url="", access_tags=None,
+                 namespace=None):
         pid = self.project_id
         now = datetime.now().isoformat(timespec="seconds")
         metadata = {}
         if access_tags:
             metadata["access_tags"] = sorted(access_tags)
+
+        if namespace:
+            if ":" not in node_id:
+                node_id = f"{namespace}:{node_id}"
+            self.ensure_namespace(namespace)
 
         with self.conn.cursor() as cur:
             cur.execute(
@@ -158,6 +164,29 @@ class PgApi:
             )
 
             justifications = self._parse_justifications(sl, cp, unless, label)
+
+            if namespace:
+                active_id = f"{namespace}:active"
+                for j in justifications:
+                    j["antecedents"] = [
+                        f"{namespace}:{a}" if ":" not in a else a
+                        for a in j["antecedents"]
+                    ]
+                    j["outlist"] = [
+                        f"{namespace}:{o}" if ":" not in o else o
+                        for o in j["outlist"]
+                    ]
+                if not justifications:
+                    justifications.append({
+                        "type": "SL",
+                        "antecedents": [active_id],
+                        "outlist": [],
+                        "label": "",
+                    })
+                else:
+                    for j in justifications:
+                        if active_id not in j["antecedents"]:
+                            j["antecedents"].append(active_id)
 
             if justifications:
                 self._validate_refs(cur, justifications)
@@ -204,8 +233,12 @@ class PgApi:
             "premise_count": premise_count,
         }
 
-    def add_justification(self, node_id, sl="", cp="", unless="", label=""):
+    def add_justification(self, node_id, sl="", cp="", unless="", label="",
+                          namespace=None):
         pid = self.project_id
+
+        if namespace and ":" not in node_id:
+            node_id = f"{namespace}:{node_id}"
 
         with self.conn.cursor() as cur:
             cur.execute(
@@ -220,6 +253,17 @@ class PgApi:
             justifications = self._parse_justifications(sl, cp, unless, label)
             if not justifications:
                 raise ValueError("No justification specified (use --sl or --cp)")
+
+            if namespace:
+                for j in justifications:
+                    j["antecedents"] = [
+                        f"{namespace}:{a}" if ":" not in a else a
+                        for a in j["antecedents"]
+                    ]
+                    j["outlist"] = [
+                        f"{namespace}:{o}" if ":" not in o else o
+                        for o in j["outlist"]
+                    ]
 
             self._validate_refs(cur, justifications)
 
@@ -1625,6 +1669,71 @@ class PgApi:
                 cur, node_id, all_tags, visited)
 
         return {"node_id": node_id, "access_tags": sorted(all_tags)}
+
+    def ensure_namespace(self, namespace):
+        """Ensure a namespace premise node exists (namespace:active)."""
+        pid = self.project_id
+        active_id = f"{namespace}:active"
+        now = datetime.now().isoformat(timespec="seconds")
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM rms_nodes "
+                "WHERE id = %s AND project_id = %s",
+                (active_id, pid),
+            )
+            if cur.fetchone():
+                return {"namespace": namespace,
+                        "active_node": active_id, "created": False}
+
+            metadata = {"agent": namespace, "role": "agent_premise"}
+            cur.execute(
+                "INSERT INTO rms_nodes "
+                "(id, project_id, text, source, date, metadata, truth_value) "
+                "VALUES (%s, %s, %s, '', %s, %s, 'IN')",
+                (active_id, pid,
+                 f"Agent '{namespace}' beliefs are trusted",
+                 now, json.dumps(metadata)),
+            )
+            self._log(cur, "add", active_id, "IN")
+
+        self.conn.commit()
+        return {"namespace": namespace,
+                "active_node": active_id, "created": True}
+
+    def list_namespaces(self):
+        """List all namespaces with belief counts."""
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, truth_value FROM rms_nodes "
+                "WHERE project_id = %s AND id LIKE '%%:active' "
+                "AND metadata->>'role' = 'agent_premise' "
+                "ORDER BY id",
+                (pid,),
+            )
+            ns_rows = cur.fetchall()
+
+            namespaces = []
+            for active_id, tv in ns_rows:
+                ns = active_id[:-len(":active")]
+                cur.execute(
+                    "SELECT COUNT(*), "
+                    "COUNT(*) FILTER (WHERE truth_value = 'IN') "
+                    "FROM rms_nodes "
+                    "WHERE project_id = %s AND id LIKE %s AND id != %s",
+                    (pid, f"{ns}:%", active_id),
+                )
+                total, in_count = cur.fetchone()
+                namespaces.append({
+                    "namespace": ns,
+                    "active_node": active_id,
+                    "active": tv == "IN",
+                    "total_beliefs": total,
+                    "in_beliefs": in_count,
+                })
+
+        return {"namespaces": namespaces}
 
     # ── Internal: propagation ───────────────────────────────────
 

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -1231,3 +1231,110 @@ class TestTraceAccessTags:
         pg_api.add_node("a", "A", access_tags=["finance"])
         with pytest.raises(PermissionError):
             pg_api.trace_access_tags("a", visible_to=["hr"])
+
+
+class TestEnsureNamespace:
+
+    def test_creates_active_node(self, pg_api):
+        result = pg_api.ensure_namespace("agent1")
+        assert result["namespace"] == "agent1"
+        assert result["active_node"] == "agent1:active"
+        assert result["created"] is True
+        node = pg_api.show_node("agent1:active")
+        assert node["truth_value"] == "IN"
+        meta = node["metadata"]
+        assert meta["agent"] == "agent1"
+        assert meta["role"] == "agent_premise"
+
+    def test_idempotent(self, pg_api):
+        pg_api.ensure_namespace("agent1")
+        result = pg_api.ensure_namespace("agent1")
+        assert result["created"] is False
+        assert result["active_node"] == "agent1:active"
+
+    def test_multiple_namespaces(self, pg_api):
+        pg_api.ensure_namespace("alice")
+        pg_api.ensure_namespace("bob")
+        n1 = pg_api.show_node("alice:active")
+        n2 = pg_api.show_node("bob:active")
+        assert n1["truth_value"] == "IN"
+        assert n2["truth_value"] == "IN"
+
+
+class TestListNamespaces:
+
+    def test_empty(self, pg_api):
+        result = pg_api.list_namespaces()
+        assert result["namespaces"] == []
+
+    def test_with_counts(self, pg_api):
+        pg_api.add_node("a", "A", namespace="ns1")
+        pg_api.add_node("b", "B", namespace="ns1")
+        pg_api.add_node("c", "C", namespace="ns2")
+        result = pg_api.list_namespaces()
+        ns_map = {ns["namespace"]: ns for ns in result["namespaces"]}
+        assert "ns1" in ns_map
+        assert "ns2" in ns_map
+        assert ns_map["ns1"]["total_beliefs"] == 2
+        assert ns_map["ns1"]["in_beliefs"] == 2
+        assert ns_map["ns1"]["active"] is True
+        assert ns_map["ns2"]["total_beliefs"] == 1
+
+    def test_inactive_namespace(self, pg_api):
+        pg_api.add_node("a", "A", namespace="ns1")
+        pg_api.retract_node("ns1:active")
+        result = pg_api.list_namespaces()
+        ns = result["namespaces"][0]
+        assert ns["active"] is False
+        assert ns["in_beliefs"] == 0
+
+
+class TestNamespaceAddNode:
+
+    def test_prefixes_node_id(self, pg_api):
+        result = pg_api.add_node("belief1", "A belief", namespace="agent1")
+        assert result["node_id"] == "agent1:belief1"
+
+    def test_auto_creates_premise(self, pg_api):
+        pg_api.add_node("belief1", "A belief", namespace="agent1")
+        node = pg_api.show_node("agent1:active")
+        assert node["truth_value"] == "IN"
+        assert node["metadata"]["role"] == "agent_premise"
+
+    def test_cascade_on_retract(self, pg_api):
+        pg_api.add_node("belief1", "A belief", namespace="agent1")
+        assert pg_api.show_node("agent1:belief1")["truth_value"] == "IN"
+        pg_api.retract_node("agent1:active")
+        assert pg_api.show_node("agent1:belief1")["truth_value"] == "OUT"
+
+    def test_no_double_prefix(self, pg_api):
+        result = pg_api.add_node("agent1:belief1", "Already prefixed", namespace="agent1")
+        assert result["node_id"] == "agent1:belief1"
+
+    def test_resolves_antecedent_ids(self, pg_api):
+        pg_api.add_node("premise", "P", namespace="agent1")
+        result = pg_api.add_node("derived", "D", sl="premise", namespace="agent1")
+        assert result["node_id"] == "agent1:derived"
+        assert result["truth_value"] == "IN"
+        info = pg_api.explain_node("agent1:derived")
+        antecedents = info["steps"][0].get("antecedents", [])
+        assert "agent1:premise" in antecedents
+        assert "agent1:active" in antecedents
+
+
+class TestNamespaceAddJustification:
+
+    def test_prefixes_ids(self, pg_api):
+        pg_api.add_node("a", "A", namespace="ns1")
+        pg_api.add_node("b", "B", namespace="ns1")
+        result = pg_api.add_justification("b", sl="a", namespace="ns1")
+        assert result["node_id"] == "ns1:b"
+
+    def test_works_with_namespaced_nodes(self, pg_api):
+        pg_api.add_node("a", "A", namespace="ns1")
+        pg_api.add_node("b", "B", namespace="ns1")
+        pg_api.retract_node("ns1:b")
+        assert pg_api.show_node("ns1:b")["truth_value"] == "OUT"
+        pg_api.assert_node("ns1:b")
+        result = pg_api.add_justification("b", sl="a", namespace="ns1")
+        assert result["new_truth_value"] == "IN"


### PR DESCRIPTION
## Summary
- Implements `ensure_namespace()` and `list_namespaces()` on PgApi (PostgreSQL backend)
- Adds `namespace` parameter to `add_node()` and `add_justification()` — prefixes node IDs, auto-creates `ns:active` premise, injects namespace dependency into justifications
- Wires dispatch in `api.py`, removes `_require_sqlite` guard from `cmd_namespaces` in `cli.py`
- 13 new PG integration tests across 4 test classes

Closes #65

## Test plan
- [x] `TestEnsureNamespace` — creates active node, idempotent, multiple namespaces
- [x] `TestListNamespaces` — empty, with counts, inactive namespace
- [x] `TestNamespaceAddNode` — prefixes ID, auto-creates premise, cascade on retract, no double-prefix, resolves antecedent IDs
- [x] `TestNamespaceAddJustification` — prefixes IDs, works with namespaced nodes
- [x] Full test suite: 1050 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)