### PR TITLE
Add --prompt-file option to derive command

### DIFF
--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -823,7 +823,7 @@ def cmd_deduplicate(args):
 
 
 def _derive_one_round(args, round_num=None, report_state=None,
-                      cluster_cache=None):
+                      cluster_cache=None, prompt_template=None):
     """Run a single derive round. Returns number of beliefs added (0 = saturated).
 
     Used by cmd_derive for both single-round and --exhaust mode.
@@ -860,6 +860,7 @@ def _derive_one_round(args, round_num=None, report_state=None,
         premises_only=args.premises, has_dependents=args.has_dependents,
         cluster=args.cluster, cluster_cache=cluster_cache,
         embedding_model=args.embedding_model, n_clusters=args.n_clusters,
+        prompt_template=prompt_template,
     )
 
     print(f"{prefix}Network: {stats['total_in']} IN beliefs, "
@@ -999,6 +1000,15 @@ def cmd_derive(args):
     _require_sqlite(args, "derive")
     from datetime import datetime
 
+    prompt_template = None
+    if args.prompt_file:
+        prompt_path = Path(args.prompt_file)
+        if not prompt_path.exists():
+            print(f"Error: prompt file not found: {prompt_path}",
+                  file=sys.stderr)
+            sys.exit(1)
+        prompt_template = prompt_path.read_text()
+
     if args.cluster and args.sample:
         print("Error: --cluster and --sample are mutually exclusive.",
               file=sys.stderr)
@@ -1054,7 +1064,8 @@ def cmd_derive(args):
             print(f"{'=' * 40}", file=sys.stderr)
             added = _derive_one_round(args, round_num=round_num,
                                       report_state=report_state,
-                                      cluster_cache=cluster_cache)
+                                      cluster_cache=cluster_cache,
+                                      prompt_template=prompt_template)
             if added < 0:
                 print(f"\nExhaust stopped: error in round {round_num}.",
                       file=sys.stderr)
@@ -1069,7 +1080,8 @@ def cmd_derive(args):
                   f"Total added: {total_added}.", file=sys.stderr)
     else:
         added = _derive_one_round(args, report_state=report_state,
-                                  cluster_cache=cluster_cache)
+                                  cluster_cache=cluster_cache,
+                                  prompt_template=prompt_template)
         if added < 0:
             sys.exit(1)
 
@@ -1582,6 +1594,8 @@ def main():
                         "(default: all-MiniLM-L6-v2)")
     p.add_argument("--n-clusters", type=int, default=None,
                    help="Override automatic cluster count for --cluster")
+    p.add_argument("--prompt-file", default=None,
+                   help="Custom prompt template file (overrides built-in DERIVE_PROMPT)")
 
     # accept
     p = sub.add_parser("accept", help="Accept proposals from a derive proposals file")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1051,6 +1051,7 @@ def cmd_derive(args):
                 "cluster": args.cluster,
                 "embedding_model": args.embedding_model,
                 "n_clusters": args.n_clusters,
+                "prompt_file": args.prompt_file,
             },
             "rounds": [],
         }

--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -401,7 +401,7 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
                  seed=None, min_depth=None, max_depth_filter=None,
                  premises_only=False, has_dependents=False,
                  cluster=False, cluster_cache=None, embedding_model=None,
-                 n_clusters=None):
+                 n_clusters=None, prompt_template=None):
     """Build the full derive prompt from a network's nodes dict.
 
     Args:
@@ -496,7 +496,7 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
     )
     derived_section = _build_derived_section(nodes, derived)
 
-    prompt = DERIVE_PROMPT.format(
+    prompt = (prompt_template or DERIVE_PROMPT).format(
         domain_context=domain_context,
         beliefs_section=beliefs_section,
         derived_section=derived_section,

--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -496,16 +496,32 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
     )
     derived_section = _build_derived_section(nodes, derived)
 
-    prompt = (prompt_template or DERIVE_PROMPT).format(
-        domain_context=domain_context,
-        beliefs_section=beliefs_section,
-        derived_section=derived_section,
-        total_in=len(in_nodes),
-        total_derived=len(derived),
-        max_depth=max_depth,
-        cross_agent_task=cross_agent_task,
-        agents_stats=agents_stats,
-    )
+    template = prompt_template or DERIVE_PROMPT
+    try:
+        prompt = template.format(
+            domain_context=domain_context,
+            beliefs_section=beliefs_section,
+            derived_section=derived_section,
+            total_in=len(in_nodes),
+            total_derived=len(derived),
+            max_depth=max_depth,
+            cross_agent_task=cross_agent_task,
+            agents_stats=agents_stats,
+        )
+    except KeyError as e:
+        raise ValueError(
+            f"Custom prompt template references unknown placeholder: {e}. "
+            f"Available: {{beliefs_section}}, {{derived_section}}, {{total_in}}, "
+            f"{{total_derived}}, {{max_depth}}, {{domain_context}}, "
+            f"{{cross_agent_task}}, {{agents_stats}}"
+        ) from None
+    except ValueError as e:
+        if prompt_template:
+            raise ValueError(
+                f"Custom prompt template has malformed braces: {e}. "
+                f"Use {{{{ and }}}} to include literal braces in the template."
+            ) from None
+        raise
 
     stats = {
         "total_in": len(in_nodes),

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -927,3 +927,18 @@ def test_build_prompt_cluster_with_agents(agent_network):
     assert stats["agents"] == 2
     assert "Agent: agent-a" in prompt
     assert "Agent: agent-b" in prompt
+
+
+def test_build_prompt_custom_template(simple_network):
+    data = api.export_network(db_path=simple_network)
+    template = "Custom prompt with {total_in} beliefs and depth {max_depth}. {beliefs_section}{derived_section}{domain_context}{cross_agent_task}{agents_stats}{total_derived}"
+    prompt, stats = build_prompt(data["nodes"], prompt_template=template)
+    assert prompt.startswith("Custom prompt with")
+    assert str(stats["total_in"]) in prompt
+
+
+def test_build_prompt_default_template_unchanged(simple_network):
+    data = api.export_network(db_path=simple_network)
+    prompt_default, _ = build_prompt(data["nodes"])
+    prompt_none, _ = build_prompt(data["nodes"], prompt_template=None)
+    assert prompt_default == prompt_none

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -942,3 +942,17 @@ def test_build_prompt_default_template_unchanged(simple_network):
     prompt_default, _ = build_prompt(data["nodes"])
     prompt_none, _ = build_prompt(data["nodes"], prompt_template=None)
     assert prompt_default == prompt_none
+
+
+def test_build_prompt_bad_placeholder(simple_network):
+    data = api.export_network(db_path=simple_network)
+    template = "Bad template with {unknown_field}"
+    with pytest.raises(ValueError, match="unknown placeholder"):
+        build_prompt(data["nodes"], prompt_template=template)
+
+
+def test_build_prompt_malformed_braces(simple_network):
+    data = api.export_network(db_path=simple_network)
+    template = "Output as JSON: {unclosed brace"
+    with pytest.raises(ValueError, match="malformed braces"):
+        build_prompt(data["nodes"], prompt_template=template)


### PR DESCRIPTION
## Summary
- Adds `--prompt-file` flag to `reasons derive` that loads a custom prompt template
- Template uses the same placeholders as the built-in `DERIVE_PROMPT`: `{beliefs_section}`, `{derived_section}`, `{total_in}`, `{total_derived}`, `{max_depth}`, `{domain_context}`, `{cross_agent_task}`, `{agents_stats}`
- All other flags (`--exhaust`, `--auto`, `--budget`, `--topic`, etc.) work unchanged

Closes #57

## Test plan
- [x] `test_build_prompt_custom_template` — custom template is used and formatted
- [x] `test_build_prompt_default_template_unchanged` — `None` template matches default
- [x] Full test suite: 887 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)