### PR TITLE
Add MCP server support for reasons ask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ test = ["pytest", "pytest-cov"]
 pg = ["psycopg[binary]>=3.1"]
 test-pg = ["psycopg[binary]>=3.1", "pytest", "pytest-cov"]
 cluster = ["sentence-transformers>=2.2", "scikit-learn>=1.2"]
+mcp = ["mcp>=1.0"]
 
 [project.scripts]
 reasons = "reasons_lib.cli:main"

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -23,22 +23,20 @@ You are answering a question using a belief network (a Truth Maintenance System)
 Each belief has an ID, text, truth value (IN = held true, OUT = retracted), and
 may have justifications tracing why it is believed.
 
-You have one tool available:
-
-{{"tool": "search_beliefs", "query": "search terms"}}
+{tools_section}
 
 Rules:
 - If the belief matches below are sufficient to answer the question, write your
-  answer directly. Do NOT call the tool.
-- If you need to search for more beliefs, respond with ONLY a single JSON line
-  (no other text). The system will run the search and give you the results.
+  answer directly. Do NOT call a tool.
+- If you need more information, respond with ONLY a single JSON line
+  (no other text). The system will run the tool and give you the results.
 {cite_rule}
-- ONLY answer based on the beliefs provided. Do NOT use your training data or
-  general knowledge to fill gaps.
+- ONLY answer based on the beliefs and data provided. Do NOT use your training
+  data or general knowledge to fill gaps.
 - If the beliefs are insufficient to answer, respond EXACTLY with:
   "I don't have enough beliefs in the network to answer this question."
   Do NOT attempt a partial or speculative answer.
-
+{mcp_instructions}
 ## Question
 
 {question}
@@ -47,6 +45,12 @@ Rules:
 
 {beliefs_context}
 {tool_history}"""
+
+
+_DEFAULT_TOOLS_SECTION = """\
+You have one tool available:
+
+{{"tool": "search_beliefs", "query": "search terms"}}"""
 
 
 FINAL_ASK_PROMPT = """\
@@ -123,23 +127,29 @@ def extract_tool_call(text):
     return None
 
 
-def build_ask_prompt(question, beliefs_context, tool_history=None, natural=False):
+def build_ask_prompt(question, beliefs_context, tool_history=None, natural=False,
+                     tools_section=None, mcp_instructions=""):
     """Build the full prompt for LLM synthesis."""
     history_section = ""
     if tool_history:
         parts = []
         for entry in tool_history:
             parts.append(
-                f"### Tool call: search_beliefs(\"{entry['query']}\")\n\n"
+                f"### Tool call: {entry['tool_label']}\n\n"
                 f"{entry['result']}"
             )
         history_section = "\n\n## Additional search results\n\n" + "\n\n---\n\n".join(parts)
+
+    if mcp_instructions:
+        mcp_instructions = f"\n## Data Source Instructions\n\n{mcp_instructions}\n"
 
     return ASK_PROMPT.format(
         question=question,
         beliefs_context=beliefs_context,
         tool_history=history_section,
         cite_rule=_CITE_RULE_NATURAL if natural else _CITE_RULE,
+        tools_section=tools_section or _DEFAULT_TOOLS_SECTION,
+        mcp_instructions=mcp_instructions,
     )
 
 
@@ -150,7 +160,7 @@ def build_final_prompt(question, beliefs_context, tool_history=None, natural=Fal
         parts = []
         for entry in tool_history:
             parts.append(
-                f"### Tool call: search_beliefs(\"{entry['query']}\")\n\n"
+                f"### Tool call: {entry['tool_label']}\n\n"
                 f"{entry['result']}"
             )
         history_section = "\n\n## Additional search results\n\n" + "\n\n---\n\n".join(parts)
@@ -331,8 +341,39 @@ def _beliefs_or_no_match(beliefs_context):
     return beliefs_context
 
 
+def _build_tools_section(mcp_servers):
+    """Build the tools section for the prompt, including MCP server tools."""
+    lines = ["You have the following tools available:", "",
+             '{"tool": "search_beliefs", "query": "search terms"}']
+    if mcp_servers:
+        for bridge in mcp_servers:
+            for tool in bridge.list_tools():
+                schema = tool.get("input_schema", {})
+                props = schema.get("properties", {})
+                param_parts = []
+                for pname, pinfo in props.items():
+                    param_parts.append(f'"{pname}": "<{pinfo.get("description", pname)}>"')
+                example = ', '.join(param_parts)
+                lines.append(f'{{"tool": "{tool["name"]}", {example}}}')
+                if tool["description"]:
+                    desc = tool["description"].split("\n")[0]
+                    lines.append(f"  # {desc}")
+    return "\n".join(lines)
+
+
+def _build_mcp_instructions(mcp_servers):
+    """Collect server instructions from all MCP servers."""
+    parts = []
+    for bridge in mcp_servers:
+        instructions = bridge.get_instructions()
+        if instructions:
+            parts.append(instructions)
+    return "\n\n".join(parts)
+
+
 def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None,
-        model="claude", simple=False, sources_db=None, natural=False, dual=False):
+        model="claude", simple=False, sources_db=None, natural=False, dual=False,
+        mcp_servers=None):
     """Answer a question using FTS5 belief search and optional LLM synthesis.
 
     Args:
@@ -346,6 +387,7 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
               calls with simple=True (1 TMS + 1 FTS + 1 merge), or up to
               5 with simple=False (up to 3 TMS tool-loop rounds + 1 FTS
               + 1 merge). Timeout applies per call.
+        mcp_servers: list of connected McpBridge instances for external tools.
 
     Returns the answer text.
     """
@@ -423,16 +465,31 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
             return (beliefs_context or "") + sources_suffix
         return beliefs_context
 
+    tools_section = None
+    mcp_instructions = ""
+    mcp_tool_map = {}
+    max_iters = MAX_ITERATIONS
+
+    if mcp_servers:
+        tools_section = _build_tools_section(mcp_servers)
+        mcp_instructions = _build_mcp_instructions(mcp_servers)
+        for bridge in mcp_servers:
+            for tool in bridge.list_tools():
+                mcp_tool_map[tool["name"]] = bridge
+        max_iters = max(MAX_ITERATIONS, 5)
+
     tool_history = []
 
-    for iteration in range(MAX_ITERATIONS):
+    for iteration in range(max_iters):
         ctx = _full_context()
-        if iteration == MAX_ITERATIONS - 1:
+        if iteration == max_iters - 1:
             prompt = build_final_prompt(question, ctx, tool_history, natural=natural)
         else:
-            prompt = build_ask_prompt(question, ctx, tool_history, natural=natural)
+            prompt = build_ask_prompt(question, ctx, tool_history, natural=natural,
+                                      tools_section=tools_section,
+                                      mcp_instructions=mcp_instructions)
 
-        print(f"Synthesizing (round {iteration + 1}/{MAX_ITERATIONS})...",
+        print(f"Synthesizing (round {iteration + 1}/{max_iters})...",
               file=sys.stderr)
 
         try:
@@ -449,20 +506,37 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
         if tool_call is None:
             return response.strip()
 
-        if tool_call.get("tool") == "search_beliefs":
+        tool_name = tool_call.get("tool")
+
+        if tool_name == "search_beliefs":
             query = tool_call.get("query", "")
             print(f"  Searching: {query}", file=sys.stderr)
             result = api.search(query, db_path=db_path, format="markdown")
             history_result = _strip_belief_metadata(result) if natural and result else result
-            tool_history.append({"query": query, "result": history_result})
+            tool_history.append({
+                "tool_label": f'search_beliefs("{query}")',
+                "result": history_result,
+            })
             if result and result.strip() != "No results found.":
                 beliefs_context = result
                 if natural:
                     beliefs_context = _strip_belief_metadata(beliefs_context)
+        elif tool_name in mcp_tool_map:
+            bridge = mcp_tool_map[tool_name]
+            args = {k: v for k, v in tool_call.items() if k != "tool"}
+            print(f"  MCP tool: {tool_name}({json.dumps(args)[:80]})", file=sys.stderr)
+            try:
+                result = bridge.call_tool(tool_name, args)
+            except Exception as e:
+                result = f"Error calling {tool_name}: {e}"
+            tool_history.append({
+                "tool_label": f"{tool_name}(...)",
+                "result": result,
+            })
         else:
             return response.strip()
 
-        if iteration == MAX_ITERATIONS - 1:
+        if iteration == max_iters - 1:
             print(f"Synthesizing (final)...", file=sys.stderr)
             ctx = _full_context()
             prompt = build_final_prompt(question, ctx, tool_history, natural=natural)

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -400,7 +400,8 @@ def ask(question, db_path="reasons.db", timeout=300, no_synth=False, format=None
     if dual and sources_db:
         print("Dual path: running TMS...", file=sys.stderr)
         answer_tms = ask(question, db_path=db_path, timeout=timeout,
-                         model=model, simple=simple, natural=natural)
+                         model=model, simple=simple, natural=natural,
+                         mcp_servers=mcp_servers)
         print("Dual path: running FTS RAG...", file=sys.stderr)
         answer_fts = _fts_rag_answer(question, sources_db, model=model,
                                      timeout=timeout)

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -50,7 +50,7 @@ Rules:
 _DEFAULT_TOOLS_SECTION = """\
 You have one tool available:
 
-{{"tool": "search_beliefs", "query": "search terms"}}"""
+{"tool": "search_beliefs", "query": "search terms"}"""
 
 
 FINAL_ASK_PROMPT = """\

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -354,7 +354,10 @@ def _build_tools_section(mcp_servers):
                 for pname, pinfo in props.items():
                     param_parts.append(f'"{pname}": "<{pinfo.get("description", pname)}>"')
                 example = ', '.join(param_parts)
-                lines.append(f'{{"tool": "{tool["name"]}", {example}}}')
+                if example:
+                    lines.append(f'{{"tool": "{tool["name"]}", {example}}}')
+                else:
+                    lines.append(f'{{"tool": "{tool["name"]}"}}')
                 if tool["description"]:
                     desc = tool["description"].split("\n")[0]
                     lines.append(f"  # {desc}")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -708,19 +708,35 @@ def cmd_lookup(args):
 def cmd_ask(args):
     _require_sqlite(args, "ask")
     from .ask import ask
-    result = ask(
-        question=args.question,
-        db_path=args.db,
-        timeout=args.timeout,
-        no_synth=args.no_synth,
-        format=getattr(args, "format", None),
-        model=args.model or "claude",
-        simple=args.simple,
-        sources_db=args.full_sources,
-        natural=args.natural,
-        dual=args.dual,
-    )
-    print(result)
+
+    mcp_servers = None
+    if args.mcp:
+        from .mcp_client import McpBridge
+        mcp_servers = []
+        for cmd in args.mcp:
+            bridge = McpBridge(cmd)
+            bridge.connect()
+            mcp_servers.append(bridge)
+
+    try:
+        result = ask(
+            question=args.question,
+            db_path=args.db,
+            timeout=args.timeout,
+            no_synth=args.no_synth,
+            format=getattr(args, "format", None),
+            model=args.model or "claude",
+            simple=args.simple,
+            sources_db=args.full_sources,
+            natural=args.natural,
+            dual=args.dual,
+            mcp_servers=mcp_servers,
+        )
+        print(result)
+    finally:
+        if mcp_servers:
+            for bridge in mcp_servers:
+                bridge.close()
 
 
 def cmd_cluster_list(args):
@@ -1683,6 +1699,8 @@ def main():
                    help="Strip belief IDs, status, and justification metadata from context")
     p.add_argument("--dual", action="store_true",
                    help="Run TMS and FTS RAG separately, then merge (requires --full-sources)")
+    p.add_argument("--mcp", action="append", default=None,
+                   help="MCP server command as data source (repeatable, e.g. --mcp snowflake-mcp)")
 
     # deduplicate
     p = sub.add_parser("deduplicate", help="Find and optionally retract duplicate IN beliefs")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -709,16 +709,15 @@ def cmd_ask(args):
     _require_sqlite(args, "ask")
     from .ask import ask
 
-    mcp_servers = None
-    if args.mcp:
-        from .mcp_client import McpBridge
-        mcp_servers = []
-        for cmd in args.mcp:
-            bridge = McpBridge(cmd)
-            bridge.connect()
-            mcp_servers.append(bridge)
-
+    mcp_servers = []
     try:
+        if args.mcp:
+            from .mcp_client import McpBridge
+            for cmd in args.mcp:
+                bridge = McpBridge(cmd)
+                bridge.connect()
+                mcp_servers.append(bridge)
+
         result = ask(
             question=args.question,
             db_path=args.db,
@@ -730,13 +729,12 @@ def cmd_ask(args):
             sources_db=args.full_sources,
             natural=args.natural,
             dual=args.dual,
-            mcp_servers=mcp_servers,
+            mcp_servers=mcp_servers or None,
         )
         print(result)
     finally:
-        if mcp_servers:
-            for bridge in mcp_servers:
-                bridge.close()
+        for bridge in mcp_servers:
+            bridge.close()
 
 
 def cmd_cluster_list(args):

--- a/reasons_lib/mcp_client.py
+++ b/reasons_lib/mcp_client.py
@@ -7,7 +7,7 @@ Requires: pip install 'mcp>=1.0'
 """
 
 import asyncio
-import concurrent.futures
+import shlex
 import threading
 
 try:
@@ -41,6 +41,7 @@ class McpBridge:
         self._loop = None
         self._thread = None
         self._session = None
+        self._shutdown = None
         self._ready = threading.Event()
         self._error = None
 
@@ -50,7 +51,8 @@ class McpBridge:
             target=self._run_loop, daemon=True
         )
         self._thread.start()
-        self._ready.wait(timeout=30)
+        if not self._ready.wait(timeout=30):
+            raise TimeoutError(f"MCP server '{self.command}' did not respond within 30s")
         if self._error:
             raise self._error
 
@@ -59,7 +61,7 @@ class McpBridge:
         self._loop.run_until_complete(self._session_lifecycle())
 
     async def _session_lifecycle(self):
-        parts = self.command.split()
+        parts = shlex.split(self.command)
         server_params = StdioServerParameters(
             command=parts[0], args=parts[1:],
         )
@@ -81,10 +83,9 @@ class McpBridge:
                         }
                         for t in tools_result.tools
                     ]
-                    self._ready.set()
 
-                    # Keep alive until close() is called
                     self._shutdown = asyncio.Event()
+                    self._ready.set()
                     await self._shutdown.wait()
                 except Exception as e:
                     self._error = e

--- a/reasons_lib/mcp_client.py
+++ b/reasons_lib/mcp_client.py
@@ -1,0 +1,130 @@
+"""MCP client bridge for connecting to MCP servers as data source adapters.
+
+Wraps the async MCP SDK with synchronous helpers using a background
+event loop thread, so ask.py can dispatch tool calls to any MCP server.
+
+Requires: pip install 'mcp>=1.0'
+"""
+
+import asyncio
+import concurrent.futures
+import threading
+
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    _mcp_available = True
+except ImportError:
+    _mcp_available = False
+
+
+def _require_mcp():
+    if not _mcp_available:
+        raise ImportError(
+            "mcp is required for MCP server support. "
+            "Install it with: pip install 'mcp>=1.0'"
+        )
+
+
+class McpBridge:
+    """Synchronous bridge to an MCP server over stdio.
+
+    Runs a persistent asyncio event loop in a background thread
+    to keep the MCP session alive across multiple tool calls.
+    """
+
+    def __init__(self, command):
+        _require_mcp()
+        self.command = command
+        self._tools = []
+        self._instructions = ""
+        self._loop = None
+        self._thread = None
+        self._session = None
+        self._ready = threading.Event()
+        self._error = None
+
+    def connect(self):
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(
+            target=self._run_loop, daemon=True
+        )
+        self._thread.start()
+        self._ready.wait(timeout=30)
+        if self._error:
+            raise self._error
+
+    def _run_loop(self):
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._session_lifecycle())
+
+    async def _session_lifecycle(self):
+        parts = self.command.split()
+        server_params = StdioServerParameters(
+            command=parts[0], args=parts[1:],
+        )
+
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                self._session = session
+                try:
+                    result = await session.initialize()
+                    if hasattr(result, "instructions") and result.instructions:
+                        self._instructions = result.instructions
+
+                    tools_result = await session.list_tools()
+                    self._tools = [
+                        {
+                            "name": t.name,
+                            "description": t.description or "",
+                            "input_schema": t.inputSchema,
+                        }
+                        for t in tools_result.tools
+                    ]
+                    self._ready.set()
+
+                    # Keep alive until close() is called
+                    self._shutdown = asyncio.Event()
+                    await self._shutdown.wait()
+                except Exception as e:
+                    self._error = e
+                    self._ready.set()
+
+    def list_tools(self):
+        return self._tools
+
+    def get_instructions(self):
+        return self._instructions
+
+    def call_tool(self, name, arguments):
+        future = asyncio.run_coroutine_threadsafe(
+            self._call_tool_async(name, arguments), self._loop
+        )
+        return future.result(timeout=60)
+
+    async def _call_tool_async(self, name, arguments):
+        result = await self._session.call_tool(name, arguments)
+        parts = []
+        for content in result.content:
+            if hasattr(content, "text"):
+                parts.append(content.text)
+            else:
+                parts.append(str(content))
+        return "\n".join(parts)
+
+    def close(self):
+        if self._loop and self._shutdown:
+            self._loop.call_soon_threadsafe(self._shutdown.set)
+        if self._thread:
+            self._thread.join(timeout=5)
+            self._thread = None
+        if self._loop:
+            self._loop.close()
+            self._loop = None
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, *exc):
+        self.close()

--- a/tests/test_ask.py
+++ b/tests/test_ask.py
@@ -87,8 +87,8 @@ class TestBuildAskPrompt:
 
     def test_with_tool_history(self):
         history = [
-            {"query": "propagation", "result": "Found: propagation-is-bfs"},
-            {"query": "retraction", "result": "Found: retraction-cascades"},
+            {"tool_label": 'search_beliefs("propagation")', "result": "Found: propagation-is-bfs"},
+            {"tool_label": 'search_beliefs("retraction")', "result": "Found: retraction-cascades"},
         ]
         prompt = build_ask_prompt("question", "context", tool_history=history)
         assert "Additional search results" in prompt

--- a/tests/test_ask_mcp.py
+++ b/tests/test_ask_mcp.py
@@ -98,6 +98,8 @@ class TestAskPromptWithMcp:
     def test_default_tools_section(self):
         prompt = build_ask_prompt("question", "context")
         assert "one tool available" in prompt
+        assert '{"tool": "search_beliefs"' in prompt
+        assert '{{' not in prompt
 
     def test_custom_tools_section(self):
         prompt = build_ask_prompt("question", "context",

--- a/tests/test_ask_mcp.py
+++ b/tests/test_ask_mcp.py
@@ -1,0 +1,117 @@
+"""Tests for MCP server integration in ask."""
+
+import json
+
+import pytest
+
+from reasons_lib.ask import (
+    _build_tools_section,
+    _build_mcp_instructions,
+    build_ask_prompt,
+    extract_tool_call,
+)
+
+
+class FakeBridge:
+    """Minimal McpBridge substitute for testing."""
+
+    def __init__(self, tools=None, instructions=""):
+        self._tools = tools or []
+        self._instructions = instructions
+
+    def list_tools(self):
+        return self._tools
+
+    def get_instructions(self):
+        return self._instructions
+
+    def call_tool(self, name, arguments):
+        return json.dumps({"tool": name, "args": arguments, "result": "ok"})
+
+
+class TestBuildToolsSection:
+
+    def test_no_mcp_servers(self):
+        section = _build_tools_section([])
+        assert "search_beliefs" in section
+
+    def test_includes_mcp_tools(self):
+        bridge = FakeBridge(tools=[
+            {
+                "name": "execute_query",
+                "description": "Execute a read-only SQL query",
+                "input_schema": {
+                    "properties": {
+                        "sql": {"description": "A single SELECT statement", "type": "string"}
+                    }
+                },
+            }
+        ])
+        section = _build_tools_section([bridge])
+        assert "search_beliefs" in section
+        assert "execute_query" in section
+        assert "SELECT" in section
+
+    def test_multiple_servers(self):
+        b1 = FakeBridge(tools=[
+            {"name": "tool_a", "description": "Tool A", "input_schema": {"properties": {}}},
+        ])
+        b2 = FakeBridge(tools=[
+            {"name": "tool_b", "description": "Tool B", "input_schema": {"properties": {}}},
+        ])
+        section = _build_tools_section([b1, b2])
+        assert "tool_a" in section
+        assert "tool_b" in section
+
+
+class TestBuildMcpInstructions:
+
+    def test_no_instructions(self):
+        bridge = FakeBridge(instructions="")
+        result = _build_mcp_instructions([bridge])
+        assert result == ""
+
+    def test_collects_instructions(self):
+        b1 = FakeBridge(instructions="Use mart X for sales data")
+        b2 = FakeBridge(instructions="Use API Y for user data")
+        result = _build_mcp_instructions([b1, b2])
+        assert "mart X" in result
+        assert "API Y" in result
+
+
+class TestAskPromptWithMcp:
+
+    def test_default_tools_section(self):
+        prompt = build_ask_prompt("question", "context")
+        assert "one tool available" in prompt
+
+    def test_custom_tools_section(self):
+        prompt = build_ask_prompt("question", "context",
+                                  tools_section="Custom tools here")
+        assert "Custom tools here" in prompt
+        assert "one tool available" not in prompt
+
+    def test_mcp_instructions_injected(self):
+        prompt = build_ask_prompt("question", "context",
+                                  mcp_instructions="Use snowflake for queries")
+        assert "Data Source Instructions" in prompt
+        assert "Use snowflake for queries" in prompt
+
+    def test_no_mcp_instructions(self):
+        prompt = build_ask_prompt("question", "context", mcp_instructions="")
+        assert "Data Source Instructions" not in prompt
+
+
+class TestExtractToolCallMcp:
+
+    def test_mcp_tool_call(self):
+        text = '{"tool": "execute_query", "sql": "SELECT 1"}'
+        result = extract_tool_call(text)
+        assert result["tool"] == "execute_query"
+        assert result["sql"] == "SELECT 1"
+
+    def test_search_beliefs_unchanged(self):
+        text = '{"tool": "search_beliefs", "query": "retraction"}'
+        result = extract_tool_call(text)
+        assert result["tool"] == "search_beliefs"
+        assert result["query"] == "retraction"

--- a/tests/test_ask_mcp.py
+++ b/tests/test_ask_mcp.py
@@ -1,6 +1,10 @@
 """Tests for MCP server integration in ask."""
 
 import json
+import sqlite3
+import sys
+from io import StringIO
+from unittest.mock import patch
 
 import pytest
 
@@ -9,7 +13,9 @@ from reasons_lib.ask import (
     _build_mcp_instructions,
     build_ask_prompt,
     extract_tool_call,
+    ask,
 )
+from reasons_lib.cli import main
 
 
 class FakeBridge:
@@ -123,3 +129,114 @@ class TestExtractToolCallMcp:
         result = extract_tool_call(text)
         assert result["tool"] == "search_beliefs"
         assert result["query"] == "retraction"
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test.db")
+
+
+def run_cli(*args, db_path=None):
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+        except SystemExit:
+            pass
+
+
+class TestAskWithMcpDispatch:
+
+    def test_mcp_tool_dispatched(self, db_path):
+        """ask() dispatches MCP tool calls to the bridge."""
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        bridge = FakeBridge(
+            tools=[{"name": "run_query", "description": "Run SQL",
+                    "input_schema": {"properties": {"sql": {"description": "SQL", "type": "string"}}}}],
+        )
+        calls = []
+        orig_call = bridge.call_tool
+
+        def tracking_call(name, args):
+            calls.append((name, args))
+            return orig_call(name, args)
+
+        bridge.call_tool = tracking_call
+
+        responses = [
+            '{"tool": "run_query", "sql": "SELECT 1"}',
+            "The query returned 1.",
+        ]
+        idx = [0]
+
+        def mock_invoke(prompt, model="claude", timeout=300):
+            r = responses[idx[0]]
+            idx[0] += 1
+            return r
+
+        with patch("reasons_lib.ask.invoke_model", side_effect=mock_invoke):
+            result = ask("run a query", db_path=db_path, mcp_servers=[bridge])
+
+        assert result == "The query returned 1."
+        assert len(calls) == 1
+        assert calls[0] == ("run_query", {"sql": "SELECT 1"})
+
+    def test_mcp_tool_error_handled(self, db_path):
+        """MCP tool errors are captured in tool history, not raised."""
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        bridge = FakeBridge(
+            tools=[{"name": "bad_tool", "description": "Fails",
+                    "input_schema": {"properties": {}}}],
+        )
+        bridge.call_tool = lambda name, args: (_ for _ in ()).throw(
+            RuntimeError("connection lost"))
+
+        responses = [
+            '{"tool": "bad_tool"}',
+            "The tool failed, but alpha is relevant.",
+        ]
+        idx = [0]
+
+        def mock_invoke(prompt, model="claude", timeout=300):
+            r = responses[idx[0]]
+            idx[0] += 1
+            return r
+
+        with patch("reasons_lib.ask.invoke_model", side_effect=mock_invoke):
+            result = ask("alpha", db_path=db_path, mcp_servers=[bridge])
+
+        assert "alpha" in result.lower()
+
+    def test_max_iterations_bumped_with_mcp(self, db_path):
+        """With MCP servers, max iterations increases to 5."""
+        run_cli("init", db_path=db_path)
+        run_cli("add", "a", "Alpha belief", db_path=db_path)
+
+        bridge = FakeBridge(
+            tools=[{"name": "some_tool", "description": "A tool",
+                    "input_schema": {"properties": {}}}],
+        )
+
+        calls = [0]
+
+        def mock_invoke(prompt, model="claude", timeout=300):
+            calls[0] += 1
+            if calls[0] <= 5:
+                return '{"tool": "search_beliefs", "query": "more"}'
+            return "Final answer."
+
+        with patch("reasons_lib.ask.invoke_model", side_effect=mock_invoke):
+            result = ask("alpha", db_path=db_path, mcp_servers=[bridge])
+
+        assert calls[0] == 6
+        assert "Final answer" in result

--- a/tests/test_ask_mcp.py
+++ b/tests/test_ask_mcp.py
@@ -63,6 +63,14 @@ class TestBuildToolsSection:
         assert "tool_a" in section
         assert "tool_b" in section
 
+    def test_no_params_no_trailing_comma(self):
+        bridge = FakeBridge(tools=[
+            {"name": "list_tables", "description": "List tables", "input_schema": {"properties": {}}},
+        ])
+        section = _build_tools_section([bridge])
+        assert '{"tool": "list_tables"}' in section
+        assert '{"tool": "list_tables", }' not in section
+
 
 class TestBuildMcpInstructions:
 


### PR DESCRIPTION
## Summary
- New `--mcp` flag on `reasons ask` connects to MCP servers as data source adapters
- MCP tools are added to the prompt alongside `search_beliefs` — any MCP server becomes a tool source
- Server instructions (e.g., Snowflake data catalog) injected into the prompt automatically
- Tool loop iteration budget bumps from 3 to 5 when MCP servers are attached
- New `reasons_lib/mcp_client.py` module wraps the async MCP SDK with a sync `McpBridge` class using a background event loop thread

Closes #48

## Test plan
- [x] `TestBuildToolsSection` — builds tool definitions from MCP servers (3 tests)
- [x] `TestBuildMcpInstructions` — collects server instructions (2 tests)
- [x] `TestAskPromptWithMcp` — prompt injection of tools and instructions (4 tests)
- [x] `TestExtractToolCallMcp` — tool call parsing for MCP tools (2 tests)
- [x] Existing ask tests updated and passing (78 tests)
- [x] Full test suite: 900 passed, 1 skipped
- [x] Manual: `McpBridge("snowflake-mcp")` connects, lists 5 tools, gets 22K chars of instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)