### PR TITLE
PgApi: Add maintenance operations (hash-sources, check-stale, lookup)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1381,6 +1381,7 @@ def check_stale(
     repos: dict[str, str] | None = None,
     upgrade_hashes: bool = False,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Check all IN nodes for source file staleness.
 
@@ -1390,6 +1391,9 @@ def check_stale(
     Returns: {"stale": list[dict], "checked": int, "stale_count": int,
               "upgraded": int}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "check_stale",
+                            repos=repos, upgrade_hashes=upgrade_hashes)
     from pathlib import Path as P
     from .check_stale import check_stale as _check
 
@@ -1420,11 +1424,15 @@ def hash_sources(
     force: bool = False,
     repos: dict[str, str] | None = None,
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Backfill source hashes for nodes with source paths but no stored hash.
 
     Returns: {"hashed": list[dict], "count": int}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "hash_sources",
+                            force=force, repos=repos)
     from pathlib import Path as P
     from .check_stale import hash_sources as _hash
 
@@ -1464,7 +1472,8 @@ def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | No
         return _compact(net, budget=budget, truncate=truncate)
 
 
-def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB) -> str:
+def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+           pg_conninfo=None, project_id=None) -> str:
     """Simple all-terms search over the full belief block — ID, text, source,
     dependencies, and metadata. Matches the same search corpus and output
     format as lookup_beliefs on a flat beliefs.md file.
@@ -1476,6 +1485,9 @@ def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
 
     Returns: formatted string with matching beliefs (full blocks)
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "lookup",
+                            query=query, visible_to=visible_to)
     with _with_network(db_path) as net:
         query_terms = query.lower().split()
         matches = []

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -597,8 +597,7 @@ def cmd_export_markdown(args):
 
 
 def cmd_hash_sources(args):
-    _require_sqlite(args, "hash-sources")
-    result = api.hash_sources(force=args.force, db_path=args.db)
+    result = api.hash_sources(force=args.force, **_backend_kwargs(args))
 
     if not result["hashed"]:
         print("No nodes to hash (all sources already have hashes, or source files not found).")
@@ -621,8 +620,7 @@ def cmd_hash_sources(args):
 
 
 def cmd_check_stale(args):
-    _require_sqlite(args, "check-stale")
-    result = api.check_stale(upgrade_hashes=args.upgrade_hashes, db_path=args.db)
+    result = api.check_stale(upgrade_hashes=args.upgrade_hashes, **_backend_kwargs(args))
 
     if result.get("upgraded"):
         print(f"Upgraded {result['upgraded']} truncated hash(es) to full length.")
@@ -696,8 +694,7 @@ def cmd_search(args):
 
 
 def cmd_lookup(args):
-    _require_sqlite(args, "lookup")
-    result = api.lookup(args.query, visible_to=_parse_visible_to(args), db_path=args.db)
+    result = api.lookup(args.query, visible_to=_parse_visible_to(args), **_backend_kwargs(args))
     print(result)
 
 

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -780,19 +780,22 @@ class PgApi:
                 continue
             new_hash = hash_file(path)
             was_empty = not source_hash
-            with self.conn.cursor() as cur:
-                cur.execute(
-                    "UPDATE rms_nodes SET source_hash = %s "
-                    "WHERE id = %s AND project_id = %s",
-                    (new_hash, nid, pid),
-                )
-            self.conn.commit()
             results.append({
                 "node_id": nid,
                 "source": source,
                 "hash": new_hash,
                 "was_empty": was_empty,
             })
+
+        if results:
+            with self.conn.cursor() as cur:
+                for item in results:
+                    cur.execute(
+                        "UPDATE rms_nodes SET source_hash = %s "
+                        "WHERE id = %s AND project_id = %s",
+                        (item["hash"], item["node_id"], pid),
+                    )
+            self.conn.commit()
 
         return {"hashed": results, "count": len(results)}
 
@@ -818,6 +821,7 @@ class PgApi:
 
         results = []
         upgraded = 0
+        upgrades_to_commit = []
 
         for nid, source, source_hash, meta in sorted(rows, key=lambda r: r[0]):
             if isinstance(meta, str):
@@ -839,13 +843,7 @@ class PgApi:
             if current_hash != source_hash:
                 if len(source_hash) == 16 and current_hash.startswith(source_hash):
                     if upgrade_hashes:
-                        with self.conn.cursor() as cur:
-                            cur.execute(
-                                "UPDATE rms_nodes SET source_hash = %s "
-                                "WHERE id = %s AND project_id = %s",
-                                (current_hash, nid, pid),
-                            )
-                        self.conn.commit()
+                        upgrades_to_commit.append((current_hash, nid))
                         upgraded += 1
                         continue
                     results.append({
@@ -865,6 +863,16 @@ class PgApi:
                     "source_path": str(path),
                     "reason": "content_changed",
                 })
+
+        if upgrades_to_commit:
+            with self.conn.cursor() as cur:
+                for new_hash, nid in upgrades_to_commit:
+                    cur.execute(
+                        "UPDATE rms_nodes SET source_hash = %s "
+                        "WHERE id = %s AND project_id = %s",
+                        (new_hash, nid, pid),
+                    )
+            self.conn.commit()
 
         return {
             "stale": results,
@@ -888,20 +896,23 @@ class PgApi:
             node_rows = cur.fetchall()
 
             cur.execute(
-                "SELECT node_id, antecedents FROM rms_justifications "
+                "SELECT node_id, antecedents, outlist FROM rms_justifications "
                 "WHERE project_id = %s",
                 (pid,),
             )
             just_rows = cur.fetchall()
 
-        antecedents_by_node = {}
+        refs_by_node = {}
         dependents_by_node = {}
-        for node_id, ants in just_rows:
+        for node_id, ants, outs in just_rows:
             if isinstance(ants, str):
                 ants = json.loads(ants)
-            antecedents_by_node.setdefault(node_id, []).extend(ants)
-            for ant in ants:
-                dependents_by_node.setdefault(ant, []).append(node_id)
+            if isinstance(outs, str):
+                outs = json.loads(outs)
+            all_refs = list(ants) + list(outs or [])
+            refs_by_node.setdefault(node_id, []).extend(all_refs)
+            for ref in all_refs:
+                dependents_by_node.setdefault(ref, []).append(node_id)
 
         matches = []
         for nid, text, tv, source, source_hash, date, meta in node_rows:
@@ -917,8 +928,8 @@ class PgApi:
                 block_parts.append(source_hash)
             if date:
                 block_parts.append(date)
-            for ant in antecedents_by_node.get(nid, []):
-                block_parts.append(ant)
+            for ref in refs_by_node.get(nid, []):
+                block_parts.append(ref)
             for dep in dependents_by_node.get(nid, []):
                 block_parts.append(dep)
             block_lower = " ".join(block_parts).lower()
@@ -928,7 +939,7 @@ class PgApi:
                     "id": nid, "text": text, "truth_value": tv,
                     "source": source, "source_hash": source_hash,
                     "date": date,
-                    "antecedents": antecedents_by_node.get(nid, []),
+                    "depends_on": refs_by_node.get(nid, []),
                 })
 
         if not matches:
@@ -944,8 +955,8 @@ class PgApi:
                 parts.append(f"- Source hash: {m['source_hash']}")
             if m["date"]:
                 parts.append(f"- Date: {m['date']}")
-            if m["antecedents"]:
-                parts.append(f"- Depends on: {', '.join(m['antecedents'])}")
+            if m["depends_on"]:
+                parts.append(f"- Depends on: {', '.join(m['depends_on'])}")
             parts.append("")
 
         return "\n".join(parts)

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -744,6 +744,212 @@ class PgApi:
 
         return self._format_results(matched, neighbors, format)
 
+    def hash_sources(self, force=False, repos=None):
+        """Backfill source hashes for nodes with source paths but no stored hash."""
+        from pathlib import Path
+        from .check_stale import hash_file, resolve_source_path
+
+        pid = self.project_id
+        repo_paths = None
+        if repos:
+            repo_paths = {k: Path(v) for k, v in repos.items()}
+
+        with self.conn.cursor() as cur:
+            if force:
+                cur.execute(
+                    "SELECT id, source, source_hash, metadata FROM rms_nodes "
+                    "WHERE project_id = %s AND source != '' AND source IS NOT NULL",
+                    (pid,),
+                )
+            else:
+                cur.execute(
+                    "SELECT id, source, source_hash, metadata FROM rms_nodes "
+                    "WHERE project_id = %s AND source != '' AND source IS NOT NULL "
+                    "AND (source_hash = '' OR source_hash IS NULL)",
+                    (pid,),
+                )
+            rows = cur.fetchall()
+
+        results = []
+        for nid, source, source_hash, meta in sorted(rows, key=lambda r: r[0]):
+            if isinstance(meta, str):
+                meta = json.loads(meta) if meta else {}
+            agent = meta.get("agent") if meta else None
+            path = resolve_source_path(source, repo_paths, agent=agent)
+            if path is None:
+                continue
+            new_hash = hash_file(path)
+            was_empty = not source_hash
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE rms_nodes SET source_hash = %s "
+                    "WHERE id = %s AND project_id = %s",
+                    (new_hash, nid, pid),
+                )
+            self.conn.commit()
+            results.append({
+                "node_id": nid,
+                "source": source,
+                "hash": new_hash,
+                "was_empty": was_empty,
+            })
+
+        return {"hashed": results, "count": len(results)}
+
+    def check_stale(self, repos=None, upgrade_hashes=False):
+        """Check all IN nodes for source file staleness."""
+        from pathlib import Path
+        from .check_stale import hash_file, resolve_source_path
+
+        pid = self.project_id
+        repo_paths = None
+        if repos:
+            repo_paths = {k: Path(v) for k, v in repos.items()}
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, source, source_hash, metadata FROM rms_nodes "
+                "WHERE project_id = %s AND truth_value = 'IN' "
+                "AND source != '' AND source IS NOT NULL "
+                "AND source_hash != '' AND source_hash IS NOT NULL",
+                (pid,),
+            )
+            rows = cur.fetchall()
+
+        results = []
+        upgraded = 0
+
+        for nid, source, source_hash, meta in sorted(rows, key=lambda r: r[0]):
+            if isinstance(meta, str):
+                meta = json.loads(meta) if meta else {}
+            agent = meta.get("agent") if meta else None
+            path = resolve_source_path(source, repo_paths, agent=agent)
+            if path is None:
+                results.append({
+                    "node_id": nid,
+                    "old_hash": source_hash,
+                    "new_hash": None,
+                    "source": source,
+                    "source_path": None,
+                    "reason": "source_deleted",
+                })
+                continue
+
+            current_hash = hash_file(path)
+            if current_hash != source_hash:
+                if len(source_hash) == 16 and current_hash.startswith(source_hash):
+                    if upgrade_hashes:
+                        with self.conn.cursor() as cur:
+                            cur.execute(
+                                "UPDATE rms_nodes SET source_hash = %s "
+                                "WHERE id = %s AND project_id = %s",
+                                (current_hash, nid, pid),
+                            )
+                        self.conn.commit()
+                        upgraded += 1
+                        continue
+                    results.append({
+                        "node_id": nid,
+                        "old_hash": source_hash,
+                        "new_hash": current_hash,
+                        "source": source,
+                        "source_path": str(path),
+                        "reason": "truncated_hash",
+                    })
+                    continue
+                results.append({
+                    "node_id": nid,
+                    "old_hash": source_hash,
+                    "new_hash": current_hash,
+                    "source": source,
+                    "source_path": str(path),
+                    "reason": "content_changed",
+                })
+
+        return {
+            "stale": results,
+            "checked": len(rows),
+            "stale_count": len(results),
+            "upgraded": upgraded,
+        }
+
+    def lookup(self, query, visible_to=None):
+        """Simple all-terms substring search over full belief blocks."""
+        pid = self.project_id
+        query_terms = query.lower().split()
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT n.id, n.text, n.truth_value, n.source, n.source_hash, "
+                "n.date, n.metadata FROM rms_nodes n "
+                "WHERE n.project_id = %s ORDER BY n.id",
+                (pid,),
+            )
+            node_rows = cur.fetchall()
+
+            cur.execute(
+                "SELECT node_id, antecedents FROM rms_justifications "
+                "WHERE project_id = %s",
+                (pid,),
+            )
+            just_rows = cur.fetchall()
+
+        antecedents_by_node = {}
+        dependents_by_node = {}
+        for node_id, ants in just_rows:
+            if isinstance(ants, str):
+                ants = json.loads(ants)
+            antecedents_by_node.setdefault(node_id, []).extend(ants)
+            for ant in ants:
+                dependents_by_node.setdefault(ant, []).append(node_id)
+
+        matches = []
+        for nid, text, tv, source, source_hash, date, meta in node_rows:
+            if isinstance(meta, str):
+                meta = json.loads(meta) if meta else {}
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                continue
+
+            block_parts = [nid, text]
+            if source:
+                block_parts.append(source)
+            if source_hash:
+                block_parts.append(source_hash)
+            if date:
+                block_parts.append(date)
+            for ant in antecedents_by_node.get(nid, []):
+                block_parts.append(ant)
+            for dep in dependents_by_node.get(nid, []):
+                block_parts.append(dep)
+            block_lower = " ".join(block_parts).lower()
+
+            if all(term in block_lower for term in query_terms):
+                matches.append({
+                    "id": nid, "text": text, "truth_value": tv,
+                    "source": source, "source_hash": source_hash,
+                    "date": date,
+                    "antecedents": antecedents_by_node.get(nid, []),
+                })
+
+        if not matches:
+            return f"No beliefs found matching '{query}'"
+
+        parts = [f"Found {len(matches)} matching belief(s):", ""]
+        for m in matches[:20]:
+            parts.append(f"### {m['id']} [{m['truth_value']}]")
+            parts.append(m["text"])
+            if m["source"]:
+                parts.append(f"- Source: {m['source']}")
+            if m["source_hash"]:
+                parts.append(f"- Source hash: {m['source_hash']}")
+            if m["date"]:
+                parts.append(f"- Date: {m['date']}")
+            if m["antecedents"]:
+                parts.append(f"- Depends on: {', '.join(m['antecedents'])}")
+            parts.append("")
+
+        return "\n".join(parts)
+
     def list_nodes(self, status=None, premises_only=False, has_dependents=False,
                    namespace=None, visible_to=None):
         pid = self.project_id

--- a/tests/test_pg_dispatch.py
+++ b/tests/test_pg_dispatch.py
@@ -39,7 +39,10 @@ class TestBackendKwargs:
 
     def test_sqlite_default(self):
         args = argparse.Namespace(db="reasons.db", pg=None, project_id=None)
-        result = _backend_kwargs(args)
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k not in ("REASONS_PG_CONNINFO", "REASONS_PROJECT_ID")}
+        with patch.dict("os.environ", env, clear=True):
+            result = _backend_kwargs(args)
         assert result == {"db_path": "reasons.db"}
 
     def test_pg_with_project_id(self):
@@ -52,8 +55,11 @@ class TestBackendKwargs:
     def test_pg_missing_project_id_exits(self):
         args = argparse.Namespace(db="reasons.db", pg="postgresql://localhost/test",
                                   project_id=None)
-        with pytest.raises(SystemExit):
-            _backend_kwargs(args)
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k not in ("REASONS_PG_CONNINFO", "REASONS_PROJECT_ID")}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(SystemExit):
+                _backend_kwargs(args)
 
     def test_env_var_fallback(self):
         args = argparse.Namespace(db="reasons.db", pg=None, project_id=None)
@@ -75,7 +81,10 @@ class TestRequireSqlite:
 
     def test_no_pg_passes(self):
         args = argparse.Namespace(pg=None)
-        _require_sqlite(args, "hash-sources")
+        env = {k: v for k, v in __import__("os").environ.items()
+               if k != "REASONS_PG_CONNINFO"}
+        with patch.dict("os.environ", env, clear=True):
+            _require_sqlite(args, "hash-sources")
 
     def test_pg_set_exits(self):
         args = argparse.Namespace(pg="postgresql://localhost/test")

--- a/tests/test_pg_dispatch.py
+++ b/tests/test_pg_dispatch.py
@@ -9,6 +9,7 @@ import pytest
 from reasons_lib.api import (
     _pg_dispatch, export_markdown,
     import_json, import_beliefs, import_agent, sync_agent,
+    hash_sources, check_stale, lookup,
 )
 from reasons_lib.cli import _backend_kwargs, _require_sqlite
 
@@ -341,3 +342,111 @@ class TestImportCliNoLongerBlocked:
             result = import_beliefs(str(f),
                                     pg_conninfo="postgresql://...", project_id="test")
         assert result["claims_imported"] == 0
+
+
+class TestHashSourcesDispatch:
+
+    def test_dispatches_to_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.hash_sources.return_value = {"hashed": [], "count": 0}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = hash_sources(pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.hash_sources.assert_called_once_with(force=False, repos=None)
+        assert result == {"hashed": [], "count": 0}
+
+    def test_passes_force_and_repos(self):
+        mock_pg = MagicMock()
+        mock_pg.hash_sources.return_value = {"hashed": [{"node_id": "a"}], "count": 1}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = hash_sources(force=True, repos={"myrepo": "/tmp/repo"},
+                                  pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.hash_sources.assert_called_once_with(
+            force=True, repos={"myrepo": "/tmp/repo"})
+        assert result["count"] == 1
+
+
+class TestCheckStaleDispatch:
+
+    def test_dispatches_to_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.check_stale.return_value = {
+            "stale": [], "checked": 5, "stale_count": 0, "upgraded": 0,
+        }
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = check_stale(pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.check_stale.assert_called_once_with(repos=None, upgrade_hashes=False)
+        assert result["checked"] == 5
+
+    def test_passes_upgrade_hashes(self):
+        mock_pg = MagicMock()
+        mock_pg.check_stale.return_value = {
+            "stale": [], "checked": 3, "stale_count": 0, "upgraded": 2,
+        }
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = check_stale(upgrade_hashes=True,
+                                 pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.check_stale.assert_called_once_with(repos=None, upgrade_hashes=True)
+        assert result["upgraded"] == 2
+
+
+class TestLookupDispatch:
+
+    def test_dispatches_to_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.lookup.return_value = "Found 1 matching belief(s):\n\n### a [IN]\nAlpha\n"
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = lookup("alpha", pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.lookup.assert_called_once_with(query="alpha", visible_to=None)
+        assert "alpha" in result.lower()
+
+    def test_passes_visible_to(self):
+        mock_pg = MagicMock()
+        mock_pg.lookup.return_value = "No beliefs found matching 'secret'"
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = lookup("secret", visible_to=["admin"],
+                            pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.lookup.assert_called_once_with(query="secret", visible_to=["admin"])
+
+
+class TestMaintenanceCliNoLongerBlocked:
+
+    def test_hash_sources_accepts_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.hash_sources.return_value = {"hashed": [], "count": 0}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = hash_sources(pg_conninfo="postgresql://...", project_id="test")
+        assert result["count"] == 0
+
+    def test_check_stale_accepts_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.check_stale.return_value = {
+            "stale": [], "checked": 0, "stale_count": 0, "upgraded": 0,
+        }
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = check_stale(pg_conninfo="postgresql://...", project_id="test")
+        assert result["stale_count"] == 0
+
+    def test_lookup_accepts_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.lookup.return_value = "No beliefs found matching 'test'"
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = lookup("test", pg_conninfo="postgresql://...", project_id="test")
+        assert "No beliefs" in result


### PR DESCRIPTION
## Summary

Closes #67. Adds `hash_sources`, `check_stale`, and `lookup` methods to PgApi, enabling these commands with `--pg`:

- **hash-sources**: Backfill source hashes for nodes with source paths but no stored hash. Reuses `resolve_source_path()` and `hash_file()` from `check_stale.py`.
- **check-stale**: Check all IN nodes for source file staleness (deleted, changed, truncated hashes). Supports `--upgrade-hashes`.
- **lookup**: Simple all-terms substring search over full belief blocks (id, text, source, hash, date, dependencies).

Also fixes test env var isolation so `test_pg_dispatch.py` passes when `REASONS_PG_CONNINFO` is set in the environment.

## Test plan

- [x] All 35 `test_pg_dispatch.py` tests pass (9 new)
- [x] Full suite: 921 passed, 166 skipped
- [x] Tests pass with `REASONS_PG_CONNINFO` set in environment
- [ ] Manual test with real PG database

🤖 Generated with [Claude Code](https://claude.com/claude-code)