### PR TITLE
PgApi: Add repo management and list_negative

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1297,21 +1297,28 @@ def derive_apply(proposals: list[dict], db_path: str = DEFAULT_DB) -> dict:
     return {"added": added, "failed": failed}
 
 
-def add_repo(name: str, path: str, db_path: str = DEFAULT_DB) -> dict:
+def add_repo(name: str, path: str, db_path: str = DEFAULT_DB,
+             pg_conninfo=None, project_id=None) -> dict:
     """Add a repo to the network.
 
     Returns: {"name": str, "path": str}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "add_repo",
+                            name=name, path=path)
     with _with_network(db_path, write=True) as net:
         net.repos[name] = path
         return {"name": name, "path": path}
 
 
-def list_repos(db_path: str = DEFAULT_DB) -> dict:
+def list_repos(db_path: str = DEFAULT_DB,
+               pg_conninfo=None, project_id=None) -> dict:
     """List all repos.
 
     Returns: {"repos": dict[str, str]}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "list_repos")
     with _with_network(db_path) as net:
         return {"repos": dict(net.repos)}
 
@@ -1970,6 +1977,7 @@ def list_negative(
     visible_to: list[str] | None = None,
     model: str = "claude",
     db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Find IN beliefs that describe problems, defects, or risks.
 
@@ -1978,6 +1986,9 @@ def list_negative(
     Returns: {"negative": [{"id": str, "text": str}, ...],
               "count": int, "candidates": int, "total": int}
     """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "list_negative",
+                            visible_to=visible_to, model=model)
     from . import ask
 
     with _with_network(db_path) as net:

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1369,7 +1369,8 @@ def export_markdown(visible_to: list[str] | None = None, db_path: str = DEFAULT_
                 discovered=ngdata.get("discovered", ""),
                 resolution=ngdata.get("resolution", ""),
             ))
-        return _export(net)
+        repos = data.get("repos", {})
+        return _export(net, repos=repos)
 
     with _with_network(db_path) as net:
         if visible_to is not None:

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -469,14 +469,12 @@ def cmd_log(args):
 
 
 def cmd_add_repo(args):
-    _require_sqlite(args, "add-repo")
-    result = api.add_repo(args.name, args.path, db_path=args.db)
+    result = api.add_repo(args.name, args.path, **_backend_kwargs(args))
     print(f"Added repo {result['name']}: {result['path']}")
 
 
 def cmd_repos(args):
-    _require_sqlite(args, "repos")
-    result = api.list_repos(db_path=args.db)
+    result = api.list_repos(**_backend_kwargs(args))
     if not result["repos"]:
         print("No repos registered.")
         return
@@ -1200,11 +1198,10 @@ def cmd_list_gated(args):
 
 
 def cmd_list_negative(args):
-    _require_sqlite(args, "list-negative")
     result = api.list_negative(
         visible_to=_parse_visible_to(args),
         model=getattr(args, "model", None) or "claude",
-        db_path=args.db,
+        **_backend_kwargs(args),
     )
 
     if not result["negative"]:

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -753,6 +753,8 @@ class PgApi:
         repo_paths = None
         if repos:
             repo_paths = {k: Path(v) for k, v in repos.items()}
+        else:
+            repo_paths = self._load_repos()
 
         with self.conn.cursor() as cur:
             if force:
@@ -808,6 +810,8 @@ class PgApi:
         repo_paths = None
         if repos:
             repo_paths = {k: Path(v) for k, v in repos.items()}
+        else:
+            repo_paths = self._load_repos()
 
         with self.conn.cursor() as cur:
             cur.execute(
@@ -960,6 +964,118 @@ class PgApi:
             parts.append("")
 
         return "\n".join(parts)
+
+    def add_repo(self, name, path):
+        """Register a repo name/path for source tracking."""
+        pid = self.project_id
+        key = f"repo:{name}"
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO rms_network_meta (key, project_id, value) "
+                "VALUES (%s, %s, %s) "
+                "ON CONFLICT (key, project_id) DO UPDATE SET value = EXCLUDED.value",
+                (key, pid, path),
+            )
+        self.conn.commit()
+        return {"name": name, "path": path}
+
+    def list_repos(self):
+        """List all registered repos."""
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT key, value FROM rms_network_meta "
+                "WHERE project_id = %s AND key LIKE 'repo:%%'",
+                (pid,),
+            )
+            rows = cur.fetchall()
+        repos = {key[5:]: value for key, value in rows}
+        return {"repos": repos}
+
+    def _load_repos(self):
+        """Load stored repos as a Path dict for source resolution."""
+        from pathlib import Path
+        result = self.list_repos()
+        if result["repos"]:
+            return {k: Path(v) for k, v in result["repos"].items()}
+        return None
+
+    def list_negative(self, visible_to=None, model="claude"):
+        """Find IN beliefs describing problems/defects/risks."""
+        import sys
+        from .api import NEGATIVE_TERMS, NEGATIVE_CLASSIFY_PROMPT, NEGATIVE_BATCH_SIZE
+        from .llm import invoke_model
+
+        pid = self.project_id
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id, text, metadata FROM rms_nodes "
+                "WHERE project_id = %s AND truth_value = 'IN' "
+                "ORDER BY id",
+                (pid,),
+            )
+            rows = cur.fetchall()
+
+        in_nodes = []
+        for nid, text, meta in rows:
+            if isinstance(meta, str):
+                meta = json.loads(meta) if meta else {}
+            if visible_to is not None and not self._is_visible(meta, visible_to):
+                continue
+            in_nodes.append((nid, text))
+
+        total = len(in_nodes)
+        empty = {"negative": [], "count": 0, "candidates": 0, "total": total}
+
+        if not in_nodes:
+            return empty
+
+        candidates = []
+        for nid, text in in_nodes:
+            text_lower = text.lower()
+            if any(term in text_lower for term in NEGATIVE_TERMS):
+                candidates.append((nid, text))
+
+        if not candidates:
+            return empty
+
+        negative_ids = set()
+        total_batches = (len(candidates) + NEGATIVE_BATCH_SIZE - 1) // NEGATIVE_BATCH_SIZE
+        for i in range(0, len(candidates), NEGATIVE_BATCH_SIZE):
+            batch = candidates[i:i + NEGATIVE_BATCH_SIZE]
+            lines = [f"- [{nid}] `{text}`" for nid, text in batch]
+            prompt = NEGATIVE_CLASSIFY_PROMPT.format(candidates="\n".join(lines))
+
+            batch_num = i // NEGATIVE_BATCH_SIZE + 1
+            print(f"  Classifying batch {batch_num}/{total_batches} "
+                  f"({len(batch)} candidates)...", file=sys.stderr)
+
+            response = invoke_model(prompt, model=model)
+
+            for match in re.finditer(r"\[.*?\]", response, re.DOTALL):
+                try:
+                    ids = json.loads(match.group())
+                    if isinstance(ids, list):
+                        negative_ids.update(ids)
+                        break
+                except json.JSONDecodeError:
+                    continue
+
+        candidate_map = {nid: text for nid, text in candidates}
+        negative = [
+            {"id": nid, "text": candidate_map[nid]}
+            for nid in negative_ids
+            if nid in candidate_map
+        ]
+        negative.sort(key=lambda x: x["id"])
+
+        return {
+            "negative": negative,
+            "count": len(negative),
+            "candidates": len(candidates),
+            "total": total,
+        }
 
     def list_nodes(self, status=None, premises_only=False, has_dependents=False,
                    namespace=None, visible_to=None):
@@ -1163,7 +1279,8 @@ class PgApi:
                     "resolution": resolution or "",
                 })
 
-        return {"nodes": nodes, "nogoods": nogoods, "repos": {}}
+        repos = self.list_repos()["repos"]
+        return {"nodes": nodes, "nogoods": nogoods, "repos": repos}
 
     def remove_justification(self, node_id, index):
         pid = self.project_id

--- a/tests/test_pg_dispatch.py
+++ b/tests/test_pg_dispatch.py
@@ -10,6 +10,7 @@ from reasons_lib.api import (
     _pg_dispatch, export_markdown,
     import_json, import_beliefs, import_agent, sync_agent,
     hash_sources, check_stale, lookup,
+    add_repo, list_repos, list_negative,
 )
 from reasons_lib.cli import _backend_kwargs, _require_sqlite
 
@@ -459,3 +460,102 @@ class TestMaintenanceCliNoLongerBlocked:
             MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
             result = lookup("test", pg_conninfo="postgresql://...", project_id="test")
         assert "No beliefs" in result
+
+
+class TestAddRepoDispatch:
+
+    def test_dispatches_to_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.add_repo.return_value = {"name": "myrepo", "path": "/tmp/repo"}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = add_repo("myrepo", "/tmp/repo",
+                              pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.add_repo.assert_called_once_with(name="myrepo", path="/tmp/repo")
+        assert result == {"name": "myrepo", "path": "/tmp/repo"}
+
+
+class TestListReposDispatch:
+
+    def test_dispatches_to_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.list_repos.return_value = {"repos": {"myrepo": "/tmp/repo"}}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = list_repos(pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.list_repos.assert_called_once_with()
+        assert result["repos"] == {"myrepo": "/tmp/repo"}
+
+    def test_empty_repos(self):
+        mock_pg = MagicMock()
+        mock_pg.list_repos.return_value = {"repos": {}}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = list_repos(pg_conninfo="postgresql://...", project_id="test")
+        assert result["repos"] == {}
+
+
+class TestListNegativeDispatch:
+
+    def test_dispatches_to_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.list_negative.return_value = {
+            "negative": [{"id": "a", "text": "A bug"}],
+            "count": 1, "candidates": 3, "total": 10,
+        }
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = list_negative(pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.list_negative.assert_called_once_with(visible_to=None, model="claude")
+        assert result["count"] == 1
+
+    def test_passes_visible_to_and_model(self):
+        mock_pg = MagicMock()
+        mock_pg.list_negative.return_value = {
+            "negative": [], "count": 0, "candidates": 0, "total": 5,
+        }
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = list_negative(visible_to=["admin"], model="gemini",
+                                   pg_conninfo="postgresql://...", project_id="test")
+        mock_pg.list_negative.assert_called_once_with(
+            visible_to=["admin"], model="gemini")
+        assert result["total"] == 5
+
+
+class TestRepoAndNegativeCliNoLongerBlocked:
+
+    def test_add_repo_accepts_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.add_repo.return_value = {"name": "r", "path": "/p"}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = add_repo("r", "/p",
+                              pg_conninfo="postgresql://...", project_id="test")
+        assert result["name"] == "r"
+
+    def test_list_repos_accepts_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.list_repos.return_value = {"repos": {}}
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = list_repos(pg_conninfo="postgresql://...", project_id="test")
+        assert result["repos"] == {}
+
+    def test_list_negative_accepts_pg(self):
+        mock_pg = MagicMock()
+        mock_pg.list_negative.return_value = {
+            "negative": [], "count": 0, "candidates": 0, "total": 0,
+        }
+        with patch("reasons_lib.pg.PgApi") as MockPgApi:
+            MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
+            MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
+            result = list_negative(pg_conninfo="postgresql://...", project_id="test")
+        assert result["count"] == 0


### PR DESCRIPTION
## Summary

Closes #70. Adds `add_repo`, `list_repos`, and `list_negative` to PgApi:

- **add_repo/list_repos**: Repos stored in `rms_network_meta` with `repo:<name>` keys. `export_network` now returns stored repos instead of `{}`. `hash_sources` and `check_stale` fall back to stored repos when `repos=None`.
- **list_negative**: Same keyword pre-filter + LLM classification pipeline as SQLite path. Queries IN nodes, applies `_is_visible` filter, batches candidates through `invoke_model()`.

Also removes `_require_sqlite` guards from `add-repo`, `repos`, and `list-negative` CLI commands.

## Test plan

- [x] All 43 `test_pg_dispatch.py` tests pass (8 new)
- [x] Full suite: 929 passed, 166 skipped
- [ ] Manual test with real PG database

🤖 Generated with [Claude Code](https://claude.com/claude-code)