### PR TITLE
Add API-based LLM providers with Langfuse tracing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ pg = ["psycopg[binary]>=3.1"]
 test-pg = ["psycopg[binary]>=3.1", "pytest", "pytest-cov"]
 cluster = ["sentence-transformers>=2.2", "scikit-learn>=1.2"]
 mcp = ["mcp>=1.0"]
+api = ["langchain-anthropic>=0.3"]
+vertex = ["langchain-google-vertexai>=2.0"]
+langfuse = ["langfuse>=2.0"]
+llm = ["langchain-anthropic>=0.3", "langchain-google-vertexai>=2.0", "langfuse>=2.0"]
 
 [project.scripts]
 reasons = "reasons_lib.cli:main"

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1559,7 +1559,7 @@ def main():
     p.add_argument("-o", "--output", default="proposed-derivations.md",
                    help="Output file for proposals (default: proposed-derivations.md)")
     p.add_argument("-m", "--model", default=None,
-                   help="Model to use (default: claude). Use ollama:<model> for local models")
+                   help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
     p.add_argument("--auto", action="store_true",
                    help="Automatically add proposals (no review step)")
     p.add_argument("--dry-run", action="store_true",
@@ -1678,7 +1678,7 @@ def main():
     p.add_argument("--timeout", type=int, default=300,
                    help="LLM timeout in seconds (default: 300)")
     p.add_argument("-m", "--model", default=None,
-                   help="Model to use (default: claude). Use ollama:<model> for local models")
+                   help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
     p.add_argument("--simple", action="store_true",
                    help="Single-pass synthesis with pre-retrieved beliefs (better for smaller models)")
     p.add_argument("--full-sources", default=None, metavar="FTS_DB",
@@ -1727,7 +1727,7 @@ def main():
     p = sub.add_parser("list-negative", help="Find IN beliefs describing problems/defects/risks (LLM-classified)")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
     p.add_argument("-m", "--model", default=None,
-                   help="Model to use (default: claude). Use ollama:<model> for local models")
+                   help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
 
     sub.add_parser("namespaces", help="List all agent namespaces in the database")
 
@@ -1735,7 +1735,7 @@ def main():
     p = sub.add_parser("review-beliefs", help="Review derived beliefs for validity, sufficiency, and necessity")
     p.add_argument("ids", nargs="*", help="Specific belief IDs to review (default: all derived)")
     p.add_argument("-m", "--model", default=None,
-                   help="Model to use (default: claude). Use ollama:<model> for local models")
+                   help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
     p.add_argument("--timeout", type=int, default=300,
                    help="LLM timeout in seconds (default: 300)")
     p.add_argument("--min-depth", type=int, default=None,
@@ -1761,7 +1761,7 @@ def main():
     p = sub.add_parser("contradictions", help="Detect contradictions between IN beliefs")
     p.add_argument("ids", nargs="*", help="Specific belief IDs to check (default: all IN)")
     p.add_argument("-m", "--model", default=None,
-                   help="Model to use (default: claude). Use ollama:<model> for local models")
+                   help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
     p.add_argument("--timeout", type=int, default=300,
                    help="LLM timeout in seconds (default: 300)")
     p.add_argument("--sample", type=int, default=None,

--- a/reasons_lib/llm.py
+++ b/reasons_lib/llm.py
@@ -1,20 +1,59 @@
-"""Shared LLM invocation via CLI subprocesses.
+"""Shared LLM invocation via CLI subprocesses and API providers.
 
 Supports named models (claude, gemini), Claude submodels via
-'claude:<model>' syntax, and ollama models via 'ollama:<model>'
-syntax. All invocations pipe prompts to stdin and read responses
-from stdout.
+'claude:<model>' syntax, ollama models via 'ollama:<model>',
+and API-based providers via 'api:<model>' and 'vertex:<model>'.
+
+CLI-based models pipe prompts to stdin and read responses from stdout.
+API-based models use LangChain adapters with optional Langfuse tracing.
 """
 
 import os
 import shutil
 import subprocess
 
+try:
+    from langchain_anthropic import ChatAnthropic
+    _HAS_LANGCHAIN_ANTHROPIC = True
+except ImportError:
+    ChatAnthropic = None
+    _HAS_LANGCHAIN_ANTHROPIC = False
+
+try:
+    from langchain_google_vertexai.model_garden import ChatAnthropicVertex
+    _HAS_LANGCHAIN_VERTEX = True
+except ImportError:
+    ChatAnthropicVertex = None
+    _HAS_LANGCHAIN_VERTEX = False
+
+try:
+    from langfuse.langchain import CallbackHandler as LangfuseCallbackHandler
+    _HAS_LANGFUSE = True
+except ImportError:
+    LangfuseCallbackHandler = None
+    _HAS_LANGFUSE = False
+
 
 MODEL_COMMANDS = {
     "claude": ["claude", "-p"],
     "gemini": ["gemini", "--skip-trust", "-p", ""],
 }
+
+_langfuse_handler = None
+_langfuse_checked = False
+
+
+def _get_langfuse_handler():
+    global _langfuse_handler, _langfuse_checked
+    if _langfuse_checked:
+        return _langfuse_handler
+    _langfuse_checked = True
+    if not _HAS_LANGFUSE:
+        return None
+    if not os.environ.get("LANGFUSE_PUBLIC_KEY"):
+        return None
+    _langfuse_handler = LangfuseCallbackHandler()
+    return _langfuse_handler
 
 
 def resolve_model_cmd(model: str) -> list[str]:
@@ -24,6 +63,9 @@ def resolve_model_cmd(model: str) -> list[str]:
     via 'claude:<model>' (e.g. 'claude:sonnet'), Gemini submodels
     via 'gemini:<model>' (e.g. 'gemini:gemini-2.5-flash'), and
     ollama models via 'ollama:<model>' syntax (e.g. 'ollama:gemma3:4b').
+
+    API-based models ('api:<model>', 'vertex:<model>') are handled
+    by _invoke_api() and should not reach this function.
     """
     if model in MODEL_COMMANDS:
         return MODEL_COMMANDS[model]
@@ -36,17 +78,72 @@ def resolve_model_cmd(model: str) -> list[str]:
     if model.startswith("ollama:"):
         ollama_model = model.split(":", 1)[1]
         return ["ollama", "run", ollama_model]
-    available = list(MODEL_COMMANDS) + ["claude:<model>", "gemini:<model>", "ollama:<model>"]
+    available = (
+        list(MODEL_COMMANDS)
+        + ["claude:<model>", "gemini:<model>", "ollama:<model>",
+           "api:<model>", "vertex:<model>"]
+    )
     raise ValueError(f"Unknown model: {model}. Available: {available}")
 
 
-def invoke_model(prompt: str, model: str = "claude", timeout: int = 300) -> str:
-    """Invoke an LLM via CLI subprocess. Returns response text.
+def _invoke_api(prompt: str, model: str, timeout: int = 300) -> str:
+    """Invoke an LLM via LangChain API adapter. Returns response text."""
+    prefix, name = model.split(":", 1)
 
-    Raises FileNotFoundError if the model binary is not in PATH.
-    Raises RuntimeError if the model exits non-zero.
+    if prefix == "api":
+        if not _HAS_LANGCHAIN_ANTHROPIC:
+            raise ImportError(
+                "langchain-anthropic is required for api: models. "
+                "Install with: pip install 'ftl-reasons[api]'"
+            )
+        llm = ChatAnthropic(model=name, timeout=float(timeout))
+    elif prefix == "vertex":
+        if not _HAS_LANGCHAIN_VERTEX:
+            raise ImportError(
+                "langchain-google-vertexai is required for vertex: models. "
+                "Install with: pip install 'ftl-reasons[vertex]'"
+            )
+        project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+        if not project:
+            raise RuntimeError(
+                "GOOGLE_CLOUD_PROJECT environment variable is required "
+                "for vertex: models"
+            )
+        location = os.environ.get("GOOGLE_CLOUD_REGION", "us-east5")
+        llm = ChatAnthropicVertex(
+            model_name=name, project=project, location=location,
+            request_timeout=float(timeout),
+        )
+    else:
+        raise ValueError(f"Unknown API prefix: {prefix}")
+
+    config = {}
+    handler = _get_langfuse_handler()
+    if handler:
+        config["callbacks"] = [handler]
+
+    try:
+        response = llm.invoke(prompt, config=config)
+    except Exception as exc:
+        exc_name = type(exc).__name__
+        if "timeout" in exc_name.lower() or "timeout" in str(exc).lower():
+            raise subprocess.TimeoutExpired(model, timeout) from exc
+        raise RuntimeError(f"{model} failed: {exc}") from exc
+
+    return response.content
+
+
+def invoke_model(prompt: str, model: str = "claude", timeout: int = 300) -> str:
+    """Invoke an LLM via CLI subprocess or API. Returns response text.
+
+    Raises FileNotFoundError if the model binary is not in PATH (CLI models).
+    Raises ImportError if API dependencies are not installed (API models).
+    Raises RuntimeError if the model exits non-zero or API call fails.
     Raises subprocess.TimeoutExpired on timeout.
     """
+    if model.startswith("api:") or model.startswith("vertex:"):
+        return _invoke_api(prompt, model, timeout)
+
     cmd = resolve_model_cmd(model)
     binary = cmd[0]
     if not shutil.which(binary):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,10 +1,18 @@
 """Tests for the shared LLM invocation module."""
 
-from unittest.mock import patch
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from reasons_lib.llm import invoke_model, resolve_model_cmd
+import reasons_lib.llm as llm_module
+from reasons_lib.llm import (
+    _get_langfuse_handler,
+    _invoke_api,
+    invoke_model,
+    resolve_model_cmd,
+)
 
 
 class TestResolveModelCmd:
@@ -118,3 +126,199 @@ class TestInvokeModel:
             env = mock_run.call_args[1]["env"]
             assert "CLAUDECODE" not in env
             assert "HOME" in env
+
+
+class TestResolveModelCmdApiModels:
+
+    def test_api_prefix_not_in_resolve(self):
+        with pytest.raises(ValueError, match="Unknown model"):
+            resolve_model_cmd("api:claude-sonnet-4-20250514")
+
+    def test_vertex_prefix_not_in_resolve(self):
+        with pytest.raises(ValueError, match="Unknown model"):
+            resolve_model_cmd("vertex:claude-sonnet-4-20250514")
+
+    def test_error_message_lists_api_models(self):
+        with pytest.raises(ValueError, match="api:<model>"):
+            resolve_model_cmd("gpt-4")
+        with pytest.raises(ValueError, match="vertex:<model>"):
+            resolve_model_cmd("gpt-4")
+
+
+class TestInvokeModelApiDispatch:
+
+    def test_api_prefix_dispatches(self):
+        with patch("reasons_lib.llm._invoke_api", return_value="api response") as mock:
+            result = invoke_model("hello", model="api:claude-sonnet-4-20250514")
+            assert result == "api response"
+            mock.assert_called_once_with("hello", "api:claude-sonnet-4-20250514", 300)
+
+    def test_vertex_prefix_dispatches(self):
+        with patch("reasons_lib.llm._invoke_api", return_value="vertex response") as mock:
+            result = invoke_model("hello", model="vertex:claude-sonnet-4-20250514", timeout=60)
+            assert result == "vertex response"
+            mock.assert_called_once_with("hello", "vertex:claude-sonnet-4-20250514", 60)
+
+    def test_claude_still_uses_subprocess(self):
+        mock_result = type("Result", (), {"returncode": 0, "stdout": "cli response", "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = invoke_model("hello", model="claude")
+            assert result == "cli response"
+
+
+class TestInvokeApi:
+
+    def test_api_invokes_chat_anthropic(self):
+        mock_response = MagicMock()
+        mock_response.content = "test response"
+        mock_model = MagicMock()
+        mock_model.invoke.return_value = mock_response
+
+        with patch.object(llm_module, "_HAS_LANGCHAIN_ANTHROPIC", True), \
+             patch.object(llm_module, "ChatAnthropic", return_value=mock_model) as MockChat, \
+             patch.object(llm_module, "_langfuse_checked", True), \
+             patch.object(llm_module, "_langfuse_handler", None):
+            result = _invoke_api("hello", "api:claude-sonnet-4-20250514", timeout=120)
+
+        assert result == "test response"
+        MockChat.assert_called_once_with(model="claude-sonnet-4-20250514", timeout=120.0)
+        mock_model.invoke.assert_called_once_with("hello", config={})
+
+    def test_vertex_invokes_chat_anthropic_vertex(self):
+        mock_response = MagicMock()
+        mock_response.content = "vertex response"
+        mock_model = MagicMock()
+        mock_model.invoke.return_value = mock_response
+
+        with patch.object(llm_module, "_HAS_LANGCHAIN_VERTEX", True), \
+             patch.object(llm_module, "ChatAnthropicVertex", return_value=mock_model) as MockChat, \
+             patch.object(llm_module, "_langfuse_checked", True), \
+             patch.object(llm_module, "_langfuse_handler", None), \
+             patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "my-proj", "GOOGLE_CLOUD_REGION": "us-west1"}):
+            result = _invoke_api("hello", "vertex:claude-sonnet-4-20250514", timeout=60)
+
+        assert result == "vertex response"
+        MockChat.assert_called_once_with(
+            model_name="claude-sonnet-4-20250514",
+            project="my-proj", location="us-west1",
+            request_timeout=60.0,
+        )
+
+    def test_vertex_default_region(self):
+        mock_response = MagicMock()
+        mock_response.content = "ok"
+        mock_model = MagicMock()
+        mock_model.invoke.return_value = mock_response
+
+        with patch.object(llm_module, "_HAS_LANGCHAIN_VERTEX", True), \
+             patch.object(llm_module, "ChatAnthropicVertex", return_value=mock_model) as MockChat, \
+             patch.object(llm_module, "_langfuse_checked", True), \
+             patch.object(llm_module, "_langfuse_handler", None), \
+             patch.dict("os.environ", {"GOOGLE_CLOUD_PROJECT": "my-proj"}, clear=False):
+            os_env = dict(**os.environ)
+            os_env.pop("GOOGLE_CLOUD_REGION", None)
+            with patch.dict("os.environ", os_env, clear=True):
+                _invoke_api("hello", "vertex:claude-sonnet-4-20250514")
+
+        assert MockChat.call_args[1]["location"] == "us-east5"
+
+    def test_api_missing_dep_raises(self):
+        with patch.object(llm_module, "_HAS_LANGCHAIN_ANTHROPIC", False):
+            with pytest.raises(ImportError, match="langchain-anthropic"):
+                _invoke_api("hello", "api:claude-sonnet-4-20250514")
+
+    def test_vertex_missing_dep_raises(self):
+        with patch.object(llm_module, "_HAS_LANGCHAIN_VERTEX", False):
+            with pytest.raises(ImportError, match="langchain-google-vertexai"):
+                _invoke_api("hello", "vertex:claude-sonnet-4-20250514")
+
+    def test_vertex_missing_project_raises(self):
+        with patch.object(llm_module, "_HAS_LANGCHAIN_VERTEX", True), \
+             patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(RuntimeError, match="GOOGLE_CLOUD_PROJECT"):
+                _invoke_api("hello", "vertex:claude-sonnet-4-20250514")
+
+    def test_timeout_reraises_as_timeout_expired(self):
+        mock_model = MagicMock()
+        mock_model.invoke.side_effect = Exception("Request timed out timeout")
+
+        with patch.object(llm_module, "_HAS_LANGCHAIN_ANTHROPIC", True), \
+             patch.object(llm_module, "ChatAnthropic", return_value=mock_model), \
+             patch.object(llm_module, "_langfuse_checked", True), \
+             patch.object(llm_module, "_langfuse_handler", None):
+            with pytest.raises(subprocess.TimeoutExpired):
+                _invoke_api("hello", "api:claude-sonnet-4-20250514", timeout=30)
+
+    def test_api_error_reraises_as_runtime_error(self):
+        mock_model = MagicMock()
+        mock_model.invoke.side_effect = Exception("Authentication failed")
+
+        with patch.object(llm_module, "_HAS_LANGCHAIN_ANTHROPIC", True), \
+             patch.object(llm_module, "ChatAnthropic", return_value=mock_model), \
+             patch.object(llm_module, "_langfuse_checked", True), \
+             patch.object(llm_module, "_langfuse_handler", None):
+            with pytest.raises(RuntimeError, match="api:claude-sonnet-4-20250514 failed"):
+                _invoke_api("hello", "api:claude-sonnet-4-20250514")
+
+    def test_unknown_prefix_raises(self):
+        with pytest.raises(ValueError, match="Unknown API prefix"):
+            _invoke_api("hello", "openai:gpt-4")
+
+
+class TestLangfuseHandler:
+
+    def setup_method(self):
+        llm_module._langfuse_handler = None
+        llm_module._langfuse_checked = False
+
+    def teardown_method(self):
+        llm_module._langfuse_handler = None
+        llm_module._langfuse_checked = False
+
+    def test_handler_created_when_env_set(self):
+        mock_handler = MagicMock()
+        with patch.object(llm_module, "_HAS_LANGFUSE", True), \
+             patch.object(llm_module, "LangfuseCallbackHandler", return_value=mock_handler), \
+             patch.dict("os.environ", {"LANGFUSE_PUBLIC_KEY": "pk-test"}):
+            result = _get_langfuse_handler()
+            assert result is mock_handler
+
+    def test_handler_none_when_env_missing(self):
+        with patch.object(llm_module, "_HAS_LANGFUSE", True), \
+             patch.dict("os.environ", {}, clear=True):
+            result = _get_langfuse_handler()
+            assert result is None
+
+    def test_handler_none_when_dep_missing(self):
+        with patch.object(llm_module, "_HAS_LANGFUSE", False), \
+             patch.dict("os.environ", {"LANGFUSE_PUBLIC_KEY": "pk-test"}):
+            result = _get_langfuse_handler()
+            assert result is None
+
+    def test_handler_singleton(self):
+        mock_handler = MagicMock()
+        with patch.object(llm_module, "_HAS_LANGFUSE", True), \
+             patch.object(llm_module, "LangfuseCallbackHandler", return_value=mock_handler) as MockCB, \
+             patch.dict("os.environ", {"LANGFUSE_PUBLIC_KEY": "pk-test"}):
+            first = _get_langfuse_handler()
+            second = _get_langfuse_handler()
+            assert first is second
+            MockCB.assert_called_once()
+
+    def test_langfuse_callback_passed_to_invoke(self):
+        mock_handler = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = "traced response"
+        mock_model = MagicMock()
+        mock_model.invoke.return_value = mock_response
+
+        with patch.object(llm_module, "_HAS_LANGCHAIN_ANTHROPIC", True), \
+             patch.object(llm_module, "ChatAnthropic", return_value=mock_model), \
+             patch.object(llm_module, "_langfuse_checked", True), \
+             patch.object(llm_module, "_langfuse_handler", mock_handler):
+            result = _invoke_api("hello", "api:claude-sonnet-4-20250514")
+
+        assert result == "traced response"
+        call_config = mock_model.invoke.call_args[1]["config"]
+        assert call_config["callbacks"] == [mock_handler]


### PR DESCRIPTION
## Summary

- Adds `api:<model>` and `vertex:<model>` prefixes to `invoke_model()` via LangChain adapters (`ChatAnthropic`, `ChatAnthropicVertex`)
- Adds optional Langfuse tracing — automatically enabled when `LANGFUSE_PUBLIC_KEY` is set, zero code changes at call sites
- Existing subprocess providers (`claude`, `gemini`, `ollama:<model>`) unchanged
- All deps are optional: `pip install 'ftl-reasons[api]'`, `'ftl-reasons[vertex]'`, `'ftl-reasons[langfuse]'`, or `'ftl-reasons[llm]'` for all three

## Test plan

- [ ] `uv run pytest tests/test_llm.py -v` — 38 tests covering dispatch, API invocation, missing deps, timeout re-raising, Langfuse handler lifecycle
- [ ] `uv run pytest tests/ -x -q` — full suite (949 passed, 0 regressions)
- [ ] Smoke test with `ANTHROPIC_API_KEY`: `reasons ask "test" -m api:claude-sonnet-4-20250514`
- [ ] Smoke test with Langfuse: set `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY`, verify traces appear

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)