### PR TITLE
Add reasons export-card command for HuggingFace EEM cards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.10"
 dependencies = []
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-cov"]
+test = ["pytest", "pytest-cov", "pyyaml"]
 pg = ["psycopg[binary]>=3.1"]
 test-pg = ["psycopg[binary]>=3.1", "pytest", "pytest-cov"]
 cluster = ["sentence-transformers>=2.2", "scikit-learn>=1.2"]

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1461,7 +1461,6 @@ def export_card(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
                 discovered=ngdata.get("discovered", ""),
                 resolution=ngdata.get("resolution", ""),
             ))
-        repos = data.get("repos", {})
         meta = data.get("meta")
         if meta:
             net.meta = dict(meta)

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1410,6 +1410,77 @@ def export_markdown(visible_to: list[str] | None = None, db_path: str = DEFAULT_
         return _export(net, repos=net.repos)
 
 
+def export_card(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+                pg_conninfo=None, project_id=None,
+                domain=None, license="mit", base_network=None,
+                source_repos=None) -> str:
+    """Export the network as a HuggingFace EEM card (README.md).
+
+    Returns: the markdown string
+    """
+    from .export_card import export_card as _export_card
+
+    card_kwargs = dict(domain=domain, license=license,
+                       base_network=base_network, source_repos=source_repos)
+
+    if pg_conninfo:
+        data = export_network(visible_to=visible_to, pg_conninfo=pg_conninfo,
+                              project_id=project_id)
+        from . import Node, Justification, Nogood
+        from .network import Network
+        net = Network()
+        for nid, ndata in data.get("nodes", {}).items():
+            node = Node(nid, ndata.get("text", ""))
+            node.truth_value = ndata.get("truth_value", "OUT")
+            node.source = ndata.get("source", "")
+            node.source_url = ndata.get("source_url", "")
+            node.source_hash = ndata.get("source_hash", "")
+            node.date = ndata.get("date", "")
+            node.metadata = ndata.get("metadata", {})
+            for jdata in ndata.get("justifications", []):
+                j = Justification(
+                    type=jdata.get("type", "SL"),
+                    antecedents=jdata.get("antecedents", []),
+                    outlist=jdata.get("outlist", []),
+                    label=jdata.get("label", ""),
+                )
+                node.justifications.append(j)
+            net.nodes[nid] = node
+        for nid, node in net.nodes.items():
+            for j in node.justifications:
+                for ant_id in j.antecedents:
+                    if ant_id in net.nodes:
+                        net.nodes[ant_id].dependents.add(nid)
+                for out_id in j.outlist:
+                    if out_id in net.nodes:
+                        net.nodes[out_id].dependents.add(nid)
+        for ngdata in data.get("nogoods", []):
+            net.nogoods.append(Nogood(
+                id=ngdata.get("id", ""),
+                nodes=ngdata.get("nodes", []),
+                discovered=ngdata.get("discovered", ""),
+                resolution=ngdata.get("resolution", ""),
+            ))
+        repos = data.get("repos", {})
+        meta = data.get("meta")
+        if meta:
+            net.meta = dict(meta)
+        return _export_card(net, repos=repos, **card_kwargs)
+
+    with _with_network(db_path) as net:
+        if visible_to is not None:
+            from .network import Network
+            filtered = Network()
+            for nid, node in net.nodes.items():
+                if _is_visible(node, visible_to):
+                    filtered.nodes[nid] = node
+            filtered.nogoods = [ng for ng in net.nogoods if all(n in filtered.nodes for n in ng.nodes)]
+            filtered.repos = net.repos
+            filtered.meta = net.meta
+            return _export_card(filtered, repos=filtered.repos, **card_kwargs)
+        return _export_card(net, repos=net.repos, **card_kwargs)
+
+
 def check_stale(
     repos: dict[str, str] | None = None,
     upgrade_hashes: bool = False,

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1465,7 +1465,7 @@ def export_card(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
         meta = data.get("meta")
         if meta:
             net.meta = dict(meta)
-        return _export_card(net, repos=repos, **card_kwargs)
+        return _export_card(net, **card_kwargs)
 
     with _with_network(db_path) as net:
         if visible_to is not None:
@@ -1477,8 +1477,8 @@ def export_card(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
             filtered.nogoods = [ng for ng in net.nogoods if all(n in filtered.nodes for n in ng.nodes)]
             filtered.repos = net.repos
             filtered.meta = net.meta
-            return _export_card(filtered, repos=filtered.repos, **card_kwargs)
-        return _export_card(net, repos=net.repos, **card_kwargs)
+            return _export_card(filtered, **card_kwargs)
+        return _export_card(net, **card_kwargs)
 
 
 def check_stale(

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -598,6 +598,22 @@ def cmd_export_markdown(args):
         print(f"Written to {args.output}")
 
 
+def cmd_export_card(args):
+    md = api.export_card(
+        visible_to=_parse_visible_to(args),
+        domain=args.domain,
+        license=args.license,
+        base_network=args.base_network,
+        source_repos=args.source_repos,
+        **_backend_kwargs(args),
+    )
+    if args.output == "-":
+        print(md)
+    else:
+        Path(args.output).write_text(md)
+        print(f"Written to {args.output}")
+
+
 def cmd_hash_sources(args):
     result = api.hash_sources(force=args.force, **_backend_kwargs(args))
 
@@ -1647,6 +1663,16 @@ def main():
                    help="Output file (default: beliefs.md). Use --output=- for stdout")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only export nodes whose access_tags are a subset of these tags")
 
+    # export-card
+    p = sub.add_parser("export-card", help="Export network as HuggingFace EEM card (README.md)")
+    p.add_argument("-o", "--output", default="README.md", nargs="?", const="README.md",
+                   help="Output file (default: README.md). Use --output=- for stdout")
+    p.add_argument("--domain", nargs="*", help="Domain tags (e.g. kubernetes devops)")
+    p.add_argument("--license", default="mit", help="License identifier (default: mit)")
+    p.add_argument("--base-network", help="Parent EEM this was derived from")
+    p.add_argument("--source-repos", nargs="*", help="Source repository identifiers")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only export nodes whose access_tags are a subset of these tags")
+
     # hash-sources
     p = sub.add_parser("hash-sources", help="Backfill source hashes for nodes without them")
     p.add_argument("--force", action="store_true", help="Re-hash all nodes, even those with existing hashes")
@@ -1832,6 +1858,7 @@ def main():
         "import-json": cmd_import_json,
         "export": cmd_export,
         "export-markdown": cmd_export_markdown,
+        "export-card": cmd_export_card,
         "hash-sources": cmd_hash_sources,
         "check-stale": cmd_check_stale,
         "compact": cmd_compact,

--- a/reasons_lib/export_card.py
+++ b/reasons_lib/export_card.py
@@ -24,7 +24,6 @@ def _node_depth(nid, nodes, memo=None):
 
 def export_card(
     network: Network,
-    repos: dict[str, str] | None = None,
     domain: list[str] | None = None,
     license: str = "mit",
     base_network: str | None = None,
@@ -34,7 +33,6 @@ def export_card(
 
     Args:
         network: The network to export
-        repos: Optional repo name -> path mapping
         domain: Domain tags for the card frontmatter
         license: License identifier (default: mit)
         base_network: Parent EEM this was derived from

--- a/reasons_lib/export_card.py
+++ b/reasons_lib/export_card.py
@@ -1,0 +1,162 @@
+"""Export a reasons network as a HuggingFace-compatible EEM card (README.md)."""
+
+from .metadata import build_meta
+from .network import Network
+
+
+def _node_depth(nid, nodes, memo=None):
+    if memo is None:
+        memo = {}
+    if nid in memo:
+        return memo[nid]
+    node = nodes.get(nid)
+    if not node or not node.justifications:
+        memo[nid] = 0
+        return 0
+    memo[nid] = 0
+    max_d = 0
+    for j in node.justifications:
+        for a in j.antecedents:
+            max_d = max(max_d, _node_depth(a, nodes, memo))
+    memo[nid] = max_d + 1
+    return max_d + 1
+
+
+def export_card(
+    network: Network,
+    repos: dict[str, str] | None = None,
+    domain: list[str] | None = None,
+    license: str = "mit",
+    base_network: str | None = None,
+    source_repos: list[str] | None = None,
+) -> str:
+    """Generate a HuggingFace EEM card from the network.
+
+    Args:
+        network: The network to export
+        repos: Optional repo name -> path mapping
+        domain: Domain tags for the card frontmatter
+        license: License identifier (default: mit)
+        base_network: Parent EEM this was derived from
+        source_repos: Source repository identifiers
+    """
+    meta = build_meta(
+        project_name=network.meta.get("project_name", ""),
+        node_count=len(network.nodes),
+        created_at=network.meta.get("created_at", ""),
+    )
+
+    project_name = meta["project_name"] or "eem"
+    total = len(network.nodes)
+    in_count = sum(1 for n in network.nodes.values() if n.truth_value == "IN")
+    out_count = total - in_count
+    premises = sum(1 for n in network.nodes.values() if not n.justifications)
+    derived = total - premises
+    nogood_count = len(network.nogoods)
+
+    memo = {}
+    max_depth = max((_node_depth(nid, network.nodes, memo) for nid in network.nodes), default=0)
+
+    retraction_pct = f"{out_count / total * 100:.0f}%" if total > 0 else "0%"
+
+    # --- YAML frontmatter ---
+    lines = [
+        "---",
+        f'schema_version: "{meta["schema_version"]}"',
+        "type: eem",
+        f'project_name: "{project_name}"',
+    ]
+
+    if domain:
+        lines.append("domain:")
+        for d in domain:
+            lines.append(f"  - {d}")
+    else:
+        lines.append("domain: []")
+
+    lines.append(f"license: {license}")
+
+    if base_network:
+        lines.append(f'base_network: "{base_network}"')
+    else:
+        lines.append("base_network: null")
+
+    if source_repos:
+        lines.append("source_repos:")
+        for sr in source_repos:
+            lines.append(f"  - {sr}")
+    else:
+        lines.append("source_repos: []")
+
+    lines.extend([
+        f"beliefs_total: {total}",
+        f"beliefs_in: {in_count}",
+        f"beliefs_out: {out_count}",
+        f"premises: {premises}",
+        f"derived: {derived}",
+        f"nogoods: {nogood_count}",
+        f"generator: {meta['generator']}",
+        "---",
+        "",
+    ])
+
+    # --- Markdown body ---
+    title = project_name.replace("-", " ").replace("_", " ").title()
+    lines.extend([
+        f"# {title}",
+        "",
+        "## Stats",
+        "",
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| Total beliefs | {total} |",
+        f"| Status | {in_count} IN / {out_count} OUT |",
+        f"| Premises (observations) | {premises} |",
+        f"| Derived (justified conclusions) | {derived} |",
+        f"| Nogoods (contradictions) | {nogood_count} |",
+        f"| Retraction rate | {retraction_pct} |",
+        f"| Max derivation depth | {max_depth} |",
+        "",
+        "## How to Use",
+        "",
+        "### Import into a reasons database",
+        "",
+        "```bash",
+        "reasons init",
+        "reasons import-json network.json",
+        "```",
+        "",
+        "### Query beliefs",
+        "",
+        "```bash",
+        'reasons search "your query"',
+        "reasons explain <node-id>",
+        "reasons show <node-id>",
+        "```",
+        "",
+        "## Files",
+        "",
+        "| File | Description |",
+        "|------|-------------|",
+        "| `network.json` | Full belief network (machine-readable, portable) |",
+        "| `reasons.db` | SQLite database (gitignored, regenerate with `reasons import-json network.json`) |",
+        "| `README.md` | This EEM card |",
+        "",
+        "## Quality",
+        "",
+        f"- {in_count} beliefs IN, {out_count} OUT",
+        f"- {premises} premises grounded in direct observations",
+        f"- {derived} derived beliefs justified via SL justifications",
+        f"- {nogood_count} nogoods detected",
+        "",
+        "## Limitations",
+        "",
+        "- Auto-generated card — review and customize for your use case",
+        "",
+        "## License",
+        "",
+        license,
+        "",
+    ])
+
+    return "\n".join(lines)

--- a/tests/test_export_card.py
+++ b/tests/test_export_card.py
@@ -1,0 +1,239 @@
+"""Tests for export_card — HuggingFace EEM card generation."""
+
+import yaml
+
+from reasons_lib import Justification
+from reasons_lib.metadata import SCHEMA_VERSION
+from reasons_lib.network import Network
+from reasons_lib.export_card import export_card
+
+
+def _parse_frontmatter(text):
+    """Extract YAML frontmatter from card text."""
+    parts = text.split("---", 2)
+    assert len(parts) >= 3, "Missing YAML frontmatter delimiters"
+    return yaml.safe_load(parts[1])
+
+
+def _make_network(nodes=None, project_name="test-project", nogoods=None):
+    net = Network()
+    net.meta = {"project_name": project_name}
+    if nodes:
+        for nid, data in nodes.items():
+            from reasons_lib import Node
+            node = Node(nid, data.get("text", f"Text for {nid}"))
+            node.truth_value = data.get("truth_value", "IN")
+            for jdata in data.get("justifications", []):
+                j = Justification(
+                    type=jdata.get("type", "SL"),
+                    antecedents=jdata.get("antecedents", []),
+                    outlist=jdata.get("outlist", []),
+                )
+                node.justifications.append(j)
+            net.nodes[nid] = node
+    if nogoods:
+        from reasons_lib import Nogood
+        for ng in nogoods:
+            net.nogoods.append(Nogood(**ng))
+    return net
+
+
+class TestFrontmatter:
+
+    def test_schema_version(self):
+        net = _make_network()
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["schema_version"] == SCHEMA_VERSION
+
+    def test_type_is_eem(self):
+        net = _make_network()
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["type"] == "eem"
+
+    def test_project_name(self):
+        net = _make_network(project_name="my-expert")
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["project_name"] == "my-expert"
+
+    def test_domain_tags(self):
+        net = _make_network()
+        card = export_card(net, domain=["kubernetes", "devops"])
+        fm = _parse_frontmatter(card)
+        assert fm["domain"] == ["kubernetes", "devops"]
+
+    def test_no_domain_defaults_to_empty(self):
+        net = _make_network()
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["domain"] == []
+
+    def test_license(self):
+        net = _make_network()
+        card = export_card(net, license="apache-2.0")
+        fm = _parse_frontmatter(card)
+        assert fm["license"] == "apache-2.0"
+
+    def test_default_license(self):
+        net = _make_network()
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["license"] == "mit"
+
+    def test_base_network(self):
+        net = _make_network()
+        card = export_card(net, base_network="user/parent-eem")
+        fm = _parse_frontmatter(card)
+        assert fm["base_network"] == "user/parent-eem"
+
+    def test_no_base_network(self):
+        net = _make_network()
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["base_network"] is None
+
+    def test_source_repos(self):
+        net = _make_network()
+        card = export_card(net, source_repos=["user/repo1", "user/repo2"])
+        fm = _parse_frontmatter(card)
+        assert fm["source_repos"] == ["user/repo1", "user/repo2"]
+
+    def test_generator(self):
+        net = _make_network()
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert "ftl-reasons/" in fm["generator"]
+
+
+class TestBeliefCounts:
+
+    def test_all_in(self):
+        net = _make_network(nodes={
+            "a": {"text": "A"},
+            "b": {"text": "B"},
+        })
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["beliefs_total"] == 2
+        assert fm["beliefs_in"] == 2
+        assert fm["beliefs_out"] == 0
+
+    def test_mixed_in_out(self):
+        net = _make_network(nodes={
+            "a": {"text": "A", "truth_value": "IN"},
+            "b": {"text": "B", "truth_value": "OUT"},
+            "c": {"text": "C", "truth_value": "IN"},
+        })
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["beliefs_total"] == 3
+        assert fm["beliefs_in"] == 2
+        assert fm["beliefs_out"] == 1
+
+    def test_premises_and_derived(self):
+        net = _make_network(nodes={
+            "premise-a": {"text": "A"},
+            "premise-b": {"text": "B"},
+            "derived-c": {
+                "text": "C",
+                "justifications": [{"antecedents": ["premise-a", "premise-b"]}],
+            },
+        })
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["premises"] == 2
+        assert fm["derived"] == 1
+
+    def test_nogoods_count(self):
+        net = _make_network(
+            nodes={"a": {"text": "A"}, "b": {"text": "B"}},
+            nogoods=[{"id": "ng1", "nodes": ["a", "b"], "discovered": "", "resolution": ""}],
+        )
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["nogoods"] == 1
+
+
+class TestEmptyNetwork:
+
+    def test_empty_produces_valid_card(self):
+        net = _make_network()
+        card = export_card(net)
+        fm = _parse_frontmatter(card)
+        assert fm["beliefs_total"] == 0
+        assert fm["beliefs_in"] == 0
+        assert fm["premises"] == 0
+        assert fm["derived"] == 0
+        assert fm["nogoods"] == 0
+
+    def test_empty_has_title(self):
+        net = _make_network(project_name="my-project")
+        card = export_card(net)
+        assert "# My Project" in card
+
+
+class TestMaxDepth:
+
+    def test_premises_only_depth_zero(self):
+        net = _make_network(nodes={"a": {"text": "A"}, "b": {"text": "B"}})
+        card = export_card(net)
+        assert "| Max derivation depth | 0 |" in card
+
+    def test_single_level_derivation(self):
+        net = _make_network(nodes={
+            "a": {"text": "A"},
+            "d": {"text": "D", "justifications": [{"antecedents": ["a"]}]},
+        })
+        card = export_card(net)
+        assert "| Max derivation depth | 1 |" in card
+
+    def test_multi_level_derivation(self):
+        net = _make_network(nodes={
+            "a": {"text": "A"},
+            "b": {"text": "B", "justifications": [{"antecedents": ["a"]}]},
+            "c": {"text": "C", "justifications": [{"antecedents": ["b"]}]},
+        })
+        card = export_card(net)
+        assert "| Max derivation depth | 2 |" in card
+
+
+class TestMarkdownBody:
+
+    def test_stats_table(self):
+        net = _make_network(nodes={"x": {"text": "X"}})
+        card = export_card(net)
+        assert "| Total beliefs | 1 |" in card
+        assert "| Premises (observations) | 1 |" in card
+
+    def test_retraction_rate(self):
+        net = _make_network(nodes={
+            "a": {"text": "A", "truth_value": "IN"},
+            "b": {"text": "B", "truth_value": "OUT"},
+        })
+        card = export_card(net)
+        assert "| Retraction rate | 50% |" in card
+
+    def test_how_to_use_section(self):
+        net = _make_network()
+        card = export_card(net)
+        assert "## How to Use" in card
+        assert "reasons import-json network.json" in card
+
+    def test_quality_section(self):
+        net = _make_network(nodes={"a": {"text": "A"}})
+        card = export_card(net)
+        assert "## Quality" in card
+        assert "1 beliefs IN, 0 OUT" in card
+
+    def test_license_section(self):
+        net = _make_network()
+        card = export_card(net, license="apache-2.0")
+        assert "## License" in card
+        assert "apache-2.0" in card
+
+    def test_title_from_project_name(self):
+        net = _make_network(project_name="k8s-ops-expert")
+        card = export_card(net)
+        assert "# K8S Ops Expert" in card


### PR DESCRIPTION
## Summary

- Adds `reasons export-card` command that auto-generates a HuggingFace-compatible EEM card (README.md) from the belief network
- YAML frontmatter includes schema_version, type, domain tags, license, belief counts, and generator
- Markdown body includes stats table, how-to-use instructions, file listing, quality summary, and license
- Supports `--domain`, `--license`, `--base-network`, `--source-repos`, and `--visible-to` flags
- Follows existing `export-markdown` pattern for CLI, API, and PG codepaths

Closes #148

## Test plan

- [x] 26 new tests in `tests/test_export_card.py` covering frontmatter fields, belief counts, empty networks, derivation depth, stats table, and markdown body sections
- [x] Full test suite passes (1022 passed, 166 skipped)
- [ ] Smoke test: `reasons export-card --domain kubernetes --source-repos benthomasson/ftl-reasons -o -`

🤖 Generated with [Claude Code](https://claude.com/claude-code)