### PR TITLE
Add reasons import-hf to import from HuggingFace repos

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1283,6 +1283,48 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB,
         return {"nodes_imported": nodes_imported, "nogoods_imported": nogoods_imported}
 
 
+def import_hf(repo_id: str, init: bool = False, token: str | None = None,
+              db_path: str = DEFAULT_DB,
+              pg_conninfo=None, project_id=None) -> dict:
+    """Download network.json from a HuggingFace repo and import it.
+
+    Args:
+        repo_id: HuggingFace repo ID (user/repo) or full URL
+        init: Initialize reasons.db before import if it doesn't exist
+        token: Optional HuggingFace auth token
+
+    Returns: {"nodes_imported": int, "nogoods_imported": int, "repo_id": str}
+    """
+    import json as json_mod
+    import tempfile
+
+    from .hf import download_network, _parse_repo_id
+
+    parsed_id = _parse_repo_id(repo_id)
+    json_str = download_network(repo_id, token=token)
+
+    db_exists = Path(db_path).exists()
+    if init or (not db_exists and not pg_conninfo):
+        data = json_mod.loads(json_str)
+        project_name = data.get("meta", {}).get("project_name", "")
+        init_db(db_path=db_path, force=False,
+                project_name=project_name,
+                pg_conninfo=pg_conninfo, project_id=project_id)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write(json_str)
+        temp_path = f.name
+
+    try:
+        result = import_json(temp_path, db_path=db_path,
+                             pg_conninfo=pg_conninfo, project_id=project_id)
+    finally:
+        Path(temp_path).unlink()
+
+    result["repo_id"] = parsed_id
+    return result
+
+
 def derive_prompt(domain: str | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Build a derive prompt from the current network.
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1301,7 +1301,7 @@ def import_hf(repo_id: str, init: bool = False, token: str | None = None,
     from .hf import download_network, _parse_repo_id
 
     parsed_id = _parse_repo_id(repo_id)
-    json_str = download_network(repo_id, token=token)
+    json_str = download_network(parsed_id, token=token)
 
     db_exists = Path(db_path).exists()
     if init or (not db_exists and not pg_conninfo):

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1298,10 +1298,9 @@ def import_hf(repo_id: str, init: bool = False, token: str | None = None,
     import json as json_mod
     import tempfile
 
-    from .hf import download_network, _parse_repo_id
+    from .hf import download_network
 
-    parsed_id = _parse_repo_id(repo_id)
-    json_str = download_network(parsed_id, token=token)
+    json_str = download_network(repo_id, token=token)
 
     db_exists = Path(db_path).exists()
     if not db_exists and (init or not pg_conninfo):
@@ -1321,7 +1320,8 @@ def import_hf(repo_id: str, init: bool = False, token: str | None = None,
     finally:
         Path(temp_path).unlink()
 
-    result["repo_id"] = parsed_id
+    from .hf import _parse_repo_id
+    result["repo_id"] = _parse_repo_id(repo_id)
     return result
 
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1304,7 +1304,7 @@ def import_hf(repo_id: str, init: bool = False, token: str | None = None,
     json_str = download_network(parsed_id, token=token)
 
     db_exists = Path(db_path).exists()
-    if init or (not db_exists and not pg_conninfo):
+    if not db_exists and (init or not pg_conninfo):
         data = json_mod.loads(json_str)
         project_name = data.get("meta", {}).get("project_name", "")
         init_db(db_path=db_path, force=False,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -579,6 +579,23 @@ def cmd_import_json(args):
         print(f"Imported {result['nogoods_imported']} nogoods")
 
 
+def cmd_import_hf(args):
+    try:
+        result = api.import_hf(
+            repo_id=args.repo_id,
+            init=args.init,
+            token=args.token,
+            **_backend_kwargs(args),
+        )
+    except (RuntimeError, FileExistsError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Imported {result['nodes_imported']} nodes from {result['repo_id']}")
+    if result['nogoods_imported']:
+        print(f"Imported {result['nogoods_imported']} nogoods")
+
+
 def cmd_export(args):
     data = api.export_network(visible_to=_parse_visible_to(args), **_backend_kwargs(args))
     output = json.dumps(data, indent=2)
@@ -1651,6 +1668,13 @@ def main():
     p = sub.add_parser("import-json", help="Import network from JSON (produced by export)")
     p.add_argument("json_file", help="Path to JSON file")
 
+    # import-hf
+    p = sub.add_parser("import-hf", help="Import network from HuggingFace repo")
+    p.add_argument("repo_id", help="HuggingFace repo (user/repo or URL)")
+    p.add_argument("--init", action="store_true",
+                   help="Initialize reasons.db if it doesn't exist")
+    p.add_argument("--token", help="HuggingFace token (default: from HF_TOKEN or ~/.cache/huggingface/token)")
+
     # export
     p = sub.add_parser("export", help="Export network as JSON")
     p.add_argument("-o", "--output", default="network.json", nargs="?", const="network.json",
@@ -1856,6 +1880,7 @@ def main():
         "sync-agent": cmd_sync_agent,
         "import-beliefs": cmd_import_beliefs,
         "import-json": cmd_import_json,
+        "import-hf": cmd_import_hf,
         "export": cmd_export,
         "export-markdown": cmd_export_markdown,
         "export-card": cmd_export_card,

--- a/reasons_lib/hf.py
+++ b/reasons_lib/hf.py
@@ -1,0 +1,69 @@
+"""Download belief networks from HuggingFace repos."""
+
+import os
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+HF_BASE = "https://huggingface.co"
+
+
+def _resolve_token(token: str | None = None) -> str | None:
+    """Resolve HuggingFace token: explicit > HF_TOKEN env > cached file."""
+    if token:
+        return token
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        return token
+    token_path = Path.home() / ".cache" / "huggingface" / "token"
+    if token_path.exists():
+        return token_path.read_text().strip()
+    return None
+
+
+def _parse_repo_id(repo_id: str) -> str:
+    """Extract user/repo from a repo ID or HuggingFace URL."""
+    repo_id = repo_id.rstrip("/")
+    if repo_id.startswith(("http://", "https://")):
+        # https://huggingface.co/user/repo -> user/repo
+        parts = repo_id.split("huggingface.co/", 1)
+        if len(parts) == 2:
+            return parts[1]
+        raise ValueError(f"Not a HuggingFace URL: {repo_id}")
+    return repo_id
+
+
+def download_network(repo_id: str, token: str | None = None) -> str:
+    """Download network.json from a HuggingFace repo.
+
+    Args:
+        repo_id: HuggingFace repo ID (user/repo) or full URL
+        token: Optional auth token (falls back to HF_TOKEN env or cached token)
+
+    Returns:
+        JSON string of the network
+    """
+    parsed_id = _parse_repo_id(repo_id)
+    url = f"{HF_BASE}/{parsed_id}/resolve/main/network.json"
+
+    resolved_token = _resolve_token(token)
+    headers = {}
+    if resolved_token:
+        headers["Authorization"] = f"Bearer {resolved_token}"
+
+    req = Request(url, headers=headers)
+    try:
+        with urlopen(req, timeout=30) as resp:
+            return resp.read().decode("utf-8")
+    except HTTPError as e:
+        if e.code == 401:
+            raise RuntimeError(
+                f"Authentication required for {parsed_id}. "
+                "Run 'huggingface-cli login' or pass --token."
+            ) from e
+        if e.code == 404:
+            raise RuntimeError(
+                f"Repository or file not found: {parsed_id}/network.json"
+            ) from e
+        raise

--- a/tests/test_import_hf.py
+++ b/tests/test_import_hf.py
@@ -148,12 +148,13 @@ class TestImportHfApi:
         assert Path(db).exists()
 
     @patch("reasons_lib.hf.urlopen")
-    def test_auto_init_when_no_db(self, mock_urlopen, tmp_path):
+    def test_auto_init_sets_project_name(self, mock_urlopen, tmp_path):
         mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
         db = str(tmp_path / "test.db")
-        result = api.import_hf("user/repo", init=False, token="tok", db_path=db)
-        assert result["nodes_imported"] == 2
+        api.import_hf("user/repo", init=False, token="tok", db_path=db)
         assert Path(db).exists()
+        data = api.export_network(db_path=db)
+        assert data["meta"]["project_name"] == "test-eem"
 
     @patch("reasons_lib.hf.urlopen")
     def test_import_into_existing_db(self, mock_urlopen, tmp_path):
@@ -164,9 +165,10 @@ class TestImportHfApi:
         assert result["nodes_imported"] == 2
 
     @patch("reasons_lib.hf.urlopen")
-    def test_project_name_from_meta(self, mock_urlopen, tmp_path):
+    def test_import_hf_with_url(self, mock_urlopen, tmp_path):
         mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
         db = str(tmp_path / "test.db")
-        api.import_hf("user/repo", init=True, token="tok", db_path=db)
-        status = api.get_status(db_path=db)
-        assert status["total"] == 2
+        result = api.import_hf(
+            "https://huggingface.co/user/repo", init=True, token="tok", db_path=db)
+        assert result["nodes_imported"] == 2
+        assert result["repo_id"] == "user/repo"

--- a/tests/test_import_hf.py
+++ b/tests/test_import_hf.py
@@ -1,0 +1,172 @@
+"""Tests for import-hf — importing belief networks from HuggingFace."""
+
+import json
+import os
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib.hf import _parse_repo_id, _resolve_token, download_network
+
+
+SAMPLE_NETWORK = {
+    "meta": {"schema_version": "1.0", "project_name": "test-eem"},
+    "nodes": {
+        "a": {"text": "Node A", "truth_value": "IN", "justifications": [],
+               "source": "", "source_hash": "", "date": "", "metadata": {}},
+        "b": {"text": "Node B", "truth_value": "IN", "justifications": [],
+               "source": "", "source_hash": "", "date": "", "metadata": {}},
+    },
+    "nogoods": [],
+    "repos": {},
+}
+
+
+def _mock_response(data):
+    """Create a mock urlopen response."""
+    body = json.dumps(data).encode("utf-8")
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestParseRepoId:
+
+    def test_simple_repo_id(self):
+        assert _parse_repo_id("user/repo") == "user/repo"
+
+    def test_https_url(self):
+        assert _parse_repo_id("https://huggingface.co/user/repo") == "user/repo"
+
+    def test_http_url(self):
+        assert _parse_repo_id("http://huggingface.co/user/repo") == "user/repo"
+
+    def test_trailing_slash(self):
+        assert _parse_repo_id("https://huggingface.co/user/repo/") == "user/repo"
+
+    def test_non_hf_url_raises(self):
+        with pytest.raises(ValueError, match="Not a HuggingFace URL"):
+            _parse_repo_id("https://github.com/user/repo")
+
+
+class TestResolveToken:
+
+    def test_explicit_token_wins(self):
+        assert _resolve_token("my-token") == "my-token"
+
+    def test_env_var(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "env-token")
+        assert _resolve_token() == "env-token"
+
+    def test_cached_file(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        token_file = tmp_path / ".cache" / "huggingface" / "token"
+        token_file.parent.mkdir(parents=True)
+        token_file.write_text("file-token\n")
+        with patch("reasons_lib.hf.Path.home", return_value=tmp_path):
+            assert _resolve_token() == "file-token"
+
+    def test_no_token_returns_none(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        with patch("reasons_lib.hf.Path.home", return_value=Path("/nonexistent")):
+            assert _resolve_token() is None
+
+    def test_explicit_over_env(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "env-token")
+        assert _resolve_token("explicit") == "explicit"
+
+
+class TestDownloadNetwork:
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_success(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        result = download_network("user/repo", token="tok")
+        data = json.loads(result)
+        assert data["nodes"]["a"]["text"] == "Node A"
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_correct_url(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        download_network("user/my-eem", token="tok")
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://huggingface.co/user/my-eem/resolve/main/network.json"
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_auth_header_present(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        download_network("user/repo", token="secret-tok")
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer secret-tok"
+
+    @patch("reasons_lib.hf._resolve_token", return_value=None)
+    @patch("reasons_lib.hf.urlopen")
+    def test_no_auth_header_without_token(self, mock_urlopen, mock_resolve):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        download_network("user/repo")
+        req = mock_urlopen.call_args[0][0]
+        assert not req.has_header("Authorization")
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_401_raises_auth_error(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError(
+            "url", 401, "Unauthorized", {}, BytesIO(b""))
+        with pytest.raises(RuntimeError, match="Authentication required"):
+            download_network("user/private-repo")
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_404_raises_not_found(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError(
+            "url", 404, "Not Found", {}, BytesIO(b""))
+        with pytest.raises(RuntimeError, match="not found"):
+            download_network("user/missing-repo")
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_url_input(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        download_network("https://huggingface.co/user/repo", token="tok")
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://huggingface.co/user/repo/resolve/main/network.json"
+
+
+class TestImportHfApi:
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_import_with_init(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        db = str(tmp_path / "test.db")
+        result = api.import_hf("user/repo", init=True, token="tok", db_path=db)
+        assert result["nodes_imported"] == 2
+        assert result["nogoods_imported"] == 0
+        assert result["repo_id"] == "user/repo"
+        assert Path(db).exists()
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_auto_init_when_no_db(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        db = str(tmp_path / "test.db")
+        result = api.import_hf("user/repo", init=False, token="tok", db_path=db)
+        assert result["nodes_imported"] == 2
+        assert Path(db).exists()
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_import_into_existing_db(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        result = api.import_hf("user/repo", token="tok", db_path=db)
+        assert result["nodes_imported"] == 2
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_project_name_from_meta(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        db = str(tmp_path / "test.db")
+        api.import_hf("user/repo", init=True, token="tok", db_path=db)
+        status = api.get_status(db_path=db)
+        assert status["total"] == 2

--- a/tests/test_import_hf.py
+++ b/tests/test_import_hf.py
@@ -165,6 +165,14 @@ class TestImportHfApi:
         assert result["nodes_imported"] == 2
 
     @patch("reasons_lib.hf.urlopen")
+    def test_init_flag_with_existing_db(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        result = api.import_hf("user/repo", init=True, token="tok", db_path=db)
+        assert result["nodes_imported"] == 2
+
+    @patch("reasons_lib.hf.urlopen")
     def test_import_hf_with_url(self, mock_urlopen, tmp_path):
         mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
         db = str(tmp_path / "test.db")


### PR DESCRIPTION
## Summary

- Adds `reasons import-hf user/repo` command to download and import belief networks from HuggingFace
- Accepts repo IDs (`user/repo`) or full URLs (`https://huggingface.co/user/repo`)
- Uses stdlib `urllib` with cached HF token (`~/.cache/huggingface/token`) for auth -- no new dependencies
- Auto-initializes `reasons.db` if it does not exist, using `project_name` from network metadata
- Supports `--init` flag for explicit init and `--token` for manual token override

Closes #149

## Test plan

- [x] 21 new tests in `tests/test_import_hf.py` covering URL parsing, token resolution, download, auth errors, 404 errors, API integration with init/auto-init
- [x] All HTTP calls mocked -- no real network requests in tests
- [x] Full test suite passes (1043 passed, 166 skipped)
- [ ] Manual smoke test: `reasons import-hf benthomasson/eem-expert --init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)