### PR TITLE
Add import-api and export-api for agentic-mind-service sync

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -8,6 +8,7 @@ All functions return dicts suitable for JSON serialization.
 """
 
 import json
+import logging
 import re
 import sqlite3
 import sys
@@ -20,6 +21,8 @@ from .metadata import build_meta
 from .network import Network
 from .storage import Storage
 
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_DB = "reasons.db"
 
@@ -1399,7 +1402,8 @@ def export_api(url: str | None = None, agent_id: str | None = None,
                 source=ndata.get("source", ""),
             )
             exported += 1
-        except Exception:
+        except Exception as exc:
+            logger.warning("Failed to push node %s: %s", nid, exc)
             errors += 1
 
     return {"nodes_exported": exported, "errors": errors}

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1338,7 +1338,6 @@ def import_api(url: str | None = None, agent_id: str | None = None,
 
     Returns: {"nodes_imported": int, "nogoods_imported": int}
     """
-    import json as json_mod
     import tempfile
 
     from .mind_service import _resolve_config, fetch_export
@@ -1349,7 +1348,7 @@ def import_api(url: str | None = None, agent_id: str | None = None,
 
     db_exists = Path(db_path).exists()
     if not db_exists and (init or not pg_conninfo):
-        data = json_mod.loads(json_str)
+        data = json.loads(json_str)
         project_name = data.get("meta", {}).get("project_name", "")
         init_db(db_path=db_path, force=False,
                 project_name=project_name,

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1325,6 +1325,86 @@ def import_hf(repo_id: str, init: bool = False, token: str | None = None,
     return result
 
 
+def import_api(url: str | None = None, agent_id: str | None = None,
+               api_key: str | None = None, init: bool = False,
+               db_path: str = DEFAULT_DB,
+               pg_conninfo=None, project_id=None) -> dict:
+    """Import beliefs from agentic-mind-service.
+
+    Downloads the full network via GET /export and imports it locally.
+
+    Returns: {"nodes_imported": int, "nogoods_imported": int}
+    """
+    import json as json_mod
+    import tempfile
+
+    from .mind_service import _resolve_config, fetch_export
+
+    resolved_url, resolved_agent_id, resolved_api_key = _resolve_config(
+        url, agent_id, api_key)
+    json_str = fetch_export(resolved_url, resolved_agent_id, resolved_api_key)
+
+    db_exists = Path(db_path).exists()
+    if not db_exists and (init or not pg_conninfo):
+        data = json_mod.loads(json_str)
+        project_name = data.get("meta", {}).get("project_name", "")
+        init_db(db_path=db_path, force=False,
+                project_name=project_name,
+                pg_conninfo=pg_conninfo, project_id=project_id)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write(json_str)
+        temp_path = f.name
+
+    try:
+        return import_json(temp_path, db_path=db_path,
+                           pg_conninfo=pg_conninfo, project_id=project_id)
+    finally:
+        Path(temp_path).unlink()
+
+
+def export_api(url: str | None = None, agent_id: str | None = None,
+               api_key: str | None = None,
+               db_path: str = DEFAULT_DB,
+               pg_conninfo=None, project_id=None) -> dict:
+    """Export local beliefs to agentic-mind-service.
+
+    Pushes each node via POST /beliefs. Idempotent on node_id.
+
+    Returns: {"nodes_exported": int, "errors": int}
+    """
+    from .mind_service import _resolve_config, push_belief
+
+    resolved_url, resolved_agent_id, resolved_api_key = _resolve_config(
+        url, agent_id, api_key)
+
+    data = export_network(db_path=db_path, pg_conninfo=pg_conninfo,
+                          project_id=project_id)
+
+    exported = 0
+    errors = 0
+    for nid, ndata in data.get("nodes", {}).items():
+        sl_parts = []
+        for j in ndata.get("justifications", []):
+            if j.get("type") == "SL" and j.get("antecedents"):
+                sl_parts.extend(j["antecedents"])
+        sl = ",".join(sl_parts) if sl_parts else ""
+
+        try:
+            push_belief(
+                resolved_url, resolved_agent_id, resolved_api_key,
+                node_id=nid,
+                text=ndata.get("text", ""),
+                sl=sl,
+                source=ndata.get("source", ""),
+            )
+            exported += 1
+        except Exception:
+            errors += 1
+
+    return {"nodes_exported": exported, "errors": errors}
+
+
 def derive_prompt(domain: str | None = None, db_path: str = DEFAULT_DB) -> dict:
     """Build a derive prompt from the current network.
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -596,6 +596,41 @@ def cmd_import_hf(args):
         print(f"Imported {result['nogoods_imported']} nogoods")
 
 
+def cmd_import_api(args):
+    try:
+        result = api.import_api(
+            url=args.url,
+            agent_id=args.agent_id,
+            api_key=args.api_key,
+            init=args.init,
+            **_backend_kwargs(args),
+        )
+    except (RuntimeError, FileExistsError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Imported {result['nodes_imported']} nodes")
+    if result['nogoods_imported']:
+        print(f"Imported {result['nogoods_imported']} nogoods")
+
+
+def cmd_export_api(args):
+    try:
+        result = api.export_api(
+            url=args.url,
+            agent_id=args.agent_id,
+            api_key=args.api_key,
+            **_backend_kwargs(args),
+        )
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Exported {result['nodes_exported']} nodes")
+    if result['errors']:
+        print(f"Errors: {result['errors']}")
+
+
 def cmd_export(args):
     data = api.export_network(visible_to=_parse_visible_to(args), **_backend_kwargs(args))
     output = json.dumps(data, indent=2)
@@ -1675,6 +1710,20 @@ def main():
                    help="Initialize reasons.db if it doesn't exist")
     p.add_argument("--token", help="HuggingFace token (default: from HF_TOKEN or ~/.cache/huggingface/token)")
 
+    # import-api
+    p = sub.add_parser("import-api", help="Import beliefs from agentic-mind-service")
+    p.add_argument("--url", help="Service URL (default: MIND_SERVICE_URL env)")
+    p.add_argument("--agent-id", help="Agent UUID (default: MIND_AGENT_ID env)")
+    p.add_argument("--api-key", help="API key (default: MIND_API_KEY env)")
+    p.add_argument("--init", action="store_true",
+                   help="Initialize reasons.db if it doesn't exist")
+
+    # export-api
+    p = sub.add_parser("export-api", help="Export beliefs to agentic-mind-service")
+    p.add_argument("--url", help="Service URL (default: MIND_SERVICE_URL env)")
+    p.add_argument("--agent-id", help="Agent UUID (default: MIND_AGENT_ID env)")
+    p.add_argument("--api-key", help="API key (default: MIND_API_KEY env)")
+
     # export
     p = sub.add_parser("export", help="Export network as JSON")
     p.add_argument("-o", "--output", default="network.json", nargs="?", const="network.json",
@@ -1881,6 +1930,8 @@ def main():
         "import-beliefs": cmd_import_beliefs,
         "import-json": cmd_import_json,
         "import-hf": cmd_import_hf,
+        "import-api": cmd_import_api,
+        "export-api": cmd_export_api,
         "export": cmd_export,
         "export-markdown": cmd_export_markdown,
         "export-card": cmd_export_card,

--- a/reasons_lib/mind_service.py
+++ b/reasons_lib/mind_service.py
@@ -1,0 +1,81 @@
+"""HTTP client for agentic-mind-service belief sync."""
+
+import json
+import os
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def _resolve_config(
+    url: str | None = None,
+    agent_id: str | None = None,
+    api_key: str | None = None,
+) -> tuple[str, str, str]:
+    """Resolve service config: explicit params > environment variables."""
+    url = url or os.environ.get("MIND_SERVICE_URL", "")
+    agent_id = agent_id or os.environ.get("MIND_AGENT_ID", "")
+    api_key = api_key or os.environ.get("MIND_API_KEY", "")
+
+    missing = []
+    if not url:
+        missing.append("url (--url or MIND_SERVICE_URL)")
+    if not agent_id:
+        missing.append("agent-id (--agent-id or MIND_AGENT_ID)")
+    if not api_key:
+        missing.append("api-key (--api-key or MIND_API_KEY)")
+    if missing:
+        raise RuntimeError(f"Missing required config: {', '.join(missing)}")
+
+    return url.rstrip("/"), agent_id, api_key
+
+
+def fetch_export(url: str, agent_id: str, api_key: str) -> str:
+    """GET /api/agents/{agent_id}/export — download full network JSON."""
+    endpoint = f"{url}/api/agents/{agent_id}/export"
+    req = Request(endpoint, headers={"Authorization": f"Bearer {api_key}"})
+    try:
+        with urlopen(req, timeout=60) as resp:
+            return resp.read().decode("utf-8")
+    except HTTPError as e:
+        if e.code == 401:
+            raise RuntimeError(
+                "Authentication failed. Check your MIND_API_KEY."
+            ) from e
+        if e.code == 404:
+            raise RuntimeError(
+                f"Agent not found: {agent_id}"
+            ) from e
+        raise
+
+
+def push_belief(
+    url: str, agent_id: str, api_key: str,
+    node_id: str, text: str, sl: str = "", source: str = "",
+) -> dict:
+    """POST /api/agents/{agent_id}/beliefs — push one belief."""
+    endpoint = f"{url}/api/agents/{agent_id}/beliefs"
+    body = {"node_id": node_id, "text": text}
+    if sl:
+        body["sl"] = sl
+    if source:
+        body["source"] = source
+
+    data = json.dumps(body).encode("utf-8")
+    req = Request(
+        endpoint,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except HTTPError as e:
+        if e.code == 401:
+            raise RuntimeError(
+                "Authentication failed. Check your MIND_API_KEY."
+            ) from e
+        raise

--- a/tests/test_mind_service.py
+++ b/tests/test_mind_service.py
@@ -1,0 +1,227 @@
+"""Tests for import-api and export-api — agentic-mind-service sync."""
+
+import json
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib.mind_service import _resolve_config, fetch_export, push_belief
+
+
+SAMPLE_EXPORT = {
+    "meta": {"schema_version": "1.0", "project_name": "agent-beliefs"},
+    "nodes": {
+        "a": {"text": "Node A", "truth_value": "IN", "justifications": [],
+               "source": "", "source_hash": "", "date": "", "metadata": {}},
+        "b": {"text": "Node B", "truth_value": "IN",
+               "justifications": [{"type": "SL", "antecedents": ["a"], "outlist": [], "label": ""}],
+               "source": "obs", "source_hash": "", "date": "", "metadata": {}},
+    },
+    "nogoods": [],
+    "repos": {},
+}
+
+
+def _mock_response(data):
+    body = json.dumps(data).encode("utf-8")
+    resp = MagicMock()
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestResolveConfig:
+
+    def test_explicit_params(self):
+        url, aid, key = _resolve_config("http://localhost", "agent-1", "key-1")
+        assert url == "http://localhost"
+        assert aid == "agent-1"
+        assert key == "key-1"
+
+    def test_env_vars(self, monkeypatch):
+        monkeypatch.setenv("MIND_SERVICE_URL", "http://env-url")
+        monkeypatch.setenv("MIND_AGENT_ID", "env-agent")
+        monkeypatch.setenv("MIND_API_KEY", "env-key")
+        url, aid, key = _resolve_config()
+        assert url == "http://env-url"
+        assert aid == "env-agent"
+        assert key == "env-key"
+
+    def test_explicit_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("MIND_SERVICE_URL", "http://env")
+        url, _, _ = _resolve_config(url="http://explicit", agent_id="a", api_key="k")
+        assert url == "http://explicit"
+
+    def test_missing_url_raises(self, monkeypatch):
+        monkeypatch.delenv("MIND_SERVICE_URL", raising=False)
+        monkeypatch.delenv("MIND_AGENT_ID", raising=False)
+        monkeypatch.delenv("MIND_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="url"):
+            _resolve_config()
+
+    def test_missing_agent_id_raises(self, monkeypatch):
+        monkeypatch.delenv("MIND_AGENT_ID", raising=False)
+        monkeypatch.delenv("MIND_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="agent-id"):
+            _resolve_config(url="http://x")
+
+    def test_trailing_slash_stripped(self):
+        url, _, _ = _resolve_config("http://localhost/", "a", "k")
+        assert url == "http://localhost"
+
+
+class TestFetchExport:
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_correct_url(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(SAMPLE_EXPORT)
+        fetch_export("http://localhost", "agent-1", "key-1")
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "http://localhost/api/agents/agent-1/export"
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_auth_header(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(SAMPLE_EXPORT)
+        fetch_export("http://localhost", "agent-1", "my-key")
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer my-key"
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_returns_json_string(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response(SAMPLE_EXPORT)
+        result = fetch_export("http://localhost", "a", "k")
+        data = json.loads(result)
+        assert "nodes" in data
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_401_raises(self, mock_urlopen):
+        from urllib.error import HTTPError
+        mock_urlopen.side_effect = HTTPError("url", 401, "Unauthorized", {}, BytesIO(b""))
+        with pytest.raises(RuntimeError, match="Authentication failed"):
+            fetch_export("http://localhost", "a", "k")
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_404_raises(self, mock_urlopen):
+        from urllib.error import HTTPError
+        mock_urlopen.side_effect = HTTPError("url", 404, "Not Found", {}, BytesIO(b""))
+        with pytest.raises(RuntimeError, match="Agent not found"):
+            fetch_export("http://localhost", "agent-1", "k")
+
+
+class TestPushBelief:
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_correct_url(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"node_id": "a", "truth_value": "IN"})
+        push_belief("http://localhost", "agent-1", "key", "a", "text A")
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "http://localhost/api/agents/agent-1/beliefs"
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_post_method(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"node_id": "a"})
+        push_belief("http://localhost", "a", "k", "node-1", "text")
+        req = mock_urlopen.call_args[0][0]
+        assert req.method == "POST"
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_json_body(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"node_id": "a"})
+        push_belief("http://localhost", "a", "k", "node-1", "some text", sl="x,y", source="obs")
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["node_id"] == "node-1"
+        assert body["text"] == "some text"
+        assert body["sl"] == "x,y"
+        assert body["source"] == "obs"
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_omits_empty_sl(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"node_id": "a"})
+        push_belief("http://localhost", "a", "k", "node-1", "text")
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        assert "sl" not in body
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_auth_header(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response({"node_id": "a"})
+        push_belief("http://localhost", "a", "my-key", "node-1", "text")
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer my-key"
+
+
+class TestImportApi:
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_import_with_init(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_EXPORT)
+        db = str(tmp_path / "test.db")
+        result = api.import_api(
+            url="http://localhost", agent_id="a", api_key="k",
+            init=True, db_path=db)
+        assert result["nodes_imported"] == 2
+        assert result["nogoods_imported"] == 0
+        assert Path(db).exists()
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_import_into_existing_db(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_EXPORT)
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        result = api.import_api(
+            url="http://localhost", agent_id="a", api_key="k", db_path=db)
+        assert result["nodes_imported"] == 2
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_missing_config_raises(self, mock_urlopen, monkeypatch):
+        monkeypatch.delenv("MIND_SERVICE_URL", raising=False)
+        monkeypatch.delenv("MIND_AGENT_ID", raising=False)
+        monkeypatch.delenv("MIND_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="Missing required config"):
+            api.import_api()
+
+
+class TestExportApi:
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_export_pushes_all_nodes(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response({"node_id": "a", "truth_value": "IN"})
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        api.add_node("a", "Node A", db_path=db)
+        api.add_node("b", "Node B", db_path=db)
+        result = api.export_api(
+            url="http://localhost", agent_id="agent-1", api_key="k", db_path=db)
+        assert result["nodes_exported"] == 2
+        assert result["errors"] == 0
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_export_sends_sl_justifications(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response({"node_id": "d", "truth_value": "IN"})
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        api.add_node("a", "Premise A", db_path=db)
+        api.add_node("b", "Premise B", db_path=db)
+        api.add_node("d", "Derived", sl="a,b", db_path=db)
+        result = api.export_api(
+            url="http://localhost", agent_id="agent-1", api_key="k", db_path=db)
+        assert result["nodes_exported"] == 3
+        # Check the derived node's POST body has sl
+        calls = mock_urlopen.call_args_list
+        bodies = [json.loads(c[0][0].data.decode("utf-8")) for c in calls]
+        derived_body = [b for b in bodies if b["node_id"] == "d"][0]
+        assert "a" in derived_body["sl"]
+        assert "b" in derived_body["sl"]
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_missing_config_raises(self, mock_urlopen, monkeypatch):
+        monkeypatch.delenv("MIND_SERVICE_URL", raising=False)
+        monkeypatch.delenv("MIND_AGENT_ID", raising=False)
+        monkeypatch.delenv("MIND_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="Missing required config"):
+            api.export_api()

--- a/tests/test_mind_service.py
+++ b/tests/test_mind_service.py
@@ -3,7 +3,7 @@
 import json
 from io import BytesIO
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -217,6 +217,22 @@ class TestExportApi:
         derived_body = [b for b in bodies if b["node_id"] == "d"][0]
         assert "a" in derived_body["sl"]
         assert "b" in derived_body["sl"]
+
+    @patch("reasons_lib.mind_service.urlopen")
+    def test_export_counts_errors(self, mock_urlopen, tmp_path):
+        from urllib.error import HTTPError
+        mock_urlopen.side_effect = [
+            _mock_response({"node_id": "a"}),
+            HTTPError("url", 500, "Server Error", {}, BytesIO(b"")),
+        ]
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        api.add_node("a", "Node A", db_path=db)
+        api.add_node("b", "Node B", db_path=db)
+        result = api.export_api(
+            url="http://localhost", agent_id="agent-1", api_key="k", db_path=db)
+        assert result["nodes_exported"] == 1
+        assert result["errors"] == 1
 
     @patch("reasons_lib.mind_service.urlopen")
     def test_missing_config_raises(self, mock_urlopen, monkeypatch):


### PR DESCRIPTION
## Summary

- Adds `reasons import-api` — downloads full belief network from agentic-mind-service via `GET /api/agents/{agent_id}/export` and imports into local `reasons.db`
- Adds `reasons export-api` — pushes each local belief to agentic-mind-service via `POST /api/agents/{agent_id}/beliefs`
- New `reasons_lib/mind_service.py` HTTP client module (stdlib `urllib`, no new deps) with config resolution from CLI flags or `MIND_SERVICE_URL` / `MIND_AGENT_ID` / `MIND_API_KEY` env vars

## Test plan

- [x] 22 new tests in `tests/test_mind_service.py` (all mocked HTTP, no real network calls)
- [x] Full test suite passes (1066 passed, 166 skipped)
- [ ] Manual smoke test with live agentic-mind-service credentials

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)