### PR TITLE
Add --label filter to reasons list

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2032,6 +2032,7 @@ def list_nodes(
     not_reviewed_since: int | None = None,
     never_reviewed: bool = False,
     by_impact: bool = False,
+    label: str | None = None,
     db_path: str = DEFAULT_DB,
     pg_conninfo=None, project_id=None,
 ) -> dict:
@@ -2059,7 +2060,7 @@ def list_nodes(
         return _pg_dispatch(pg_conninfo, project_id, "list_nodes",
                             status=status, premises_only=premises_only,
                             has_dependents=has_dependents, namespace=namespace,
-                            visible_to=visible_to)
+                            visible_to=visible_to, label=label)
     from datetime import datetime, timedelta
 
     with _with_network(db_path) as net:
@@ -2079,6 +2080,8 @@ def list_nodes(
             if has_dependents and not node.dependents:
                 continue
             if challenged and not node.metadata.get("challenges"):
+                continue
+            if label and not any(j.label == label for j in node.justifications):
                 continue
             if visible_to is not None and not _is_visible(node, visible_to):
                 continue

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1223,6 +1223,7 @@ def cmd_list(args):
         not_reviewed_since=args.not_reviewed_since,
         never_reviewed=args.never_reviewed,
         by_impact=args.by_impact,
+        label=args.label,
         **_backend_kwargs(args),
     )
 
@@ -1901,6 +1902,7 @@ def main():
                    help="Derived beliefs that have never been reviewed")
     p.add_argument("--by-impact", action="store_true",
                    help="Sort output by dependent count (descending)")
+    p.add_argument("--label", help="Filter to nodes with a justification matching this label")
 
     args = parser.parse_args()
     if not args.command:

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1093,7 +1093,7 @@ class PgApi:
         }
 
     def list_nodes(self, status=None, premises_only=False, has_dependents=False,
-                   namespace=None, visible_to=None):
+                   namespace=None, visible_to=None, label=None):
         pid = self.project_id
         conditions = ["n.project_id = %s"]
         params = [pid]
@@ -1111,6 +1111,14 @@ class PgApi:
         if namespace:
             conditions.append("n.id LIKE %s")
             params.append(f"{namespace}:%")
+
+        if label:
+            conditions.append(
+                "EXISTS (SELECT 1 FROM rms_justifications j "
+                "WHERE j.node_id = n.id AND j.project_id = n.project_id "
+                "AND j.label = %s)"
+            )
+            params.append(label)
 
         where = " AND ".join(conditions)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -262,6 +262,31 @@ class TestListNodesDepth:
         ids = [n["id"] for n in result["nodes"]]
         assert ids == ["mid"]
 
+    def test_list_by_label(self, db_path):
+        api.add_node("a", "Node A", db_path=db_path)
+        api.add_node("b", "Node B", sl="a", label="WARNING", db_path=db_path)
+        api.add_node("c", "Node C", sl="a", label="INFO", db_path=db_path)
+
+        result = api.list_nodes(label="WARNING", db_path=db_path)
+        ids = [n["id"] for n in result["nodes"]]
+        assert ids == ["b"]
+
+    def test_list_by_label_no_match(self, db_path):
+        api.add_node("a", "Node A", db_path=db_path)
+        api.add_node("b", "Node B", sl="a", label="INFO", db_path=db_path)
+
+        result = api.list_nodes(label="WARNING", db_path=db_path)
+        assert result["count"] == 0
+
+    def test_list_by_label_premise_excluded(self, db_path):
+        api.add_node("a", "Premise", db_path=db_path)
+        api.add_node("b", "Derived", sl="a", label="WARNING", db_path=db_path)
+
+        result = api.list_nodes(label="WARNING", db_path=db_path)
+        ids = [n["id"] for n in result["nodes"]]
+        assert "a" not in ids
+        assert "b" in ids
+
 
 class TestFtsSearch:
 


### PR DESCRIPTION
## Summary

- Adds `--label` flag to `reasons list` to filter nodes by justification label
- Matches nodes with at least one justification whose label equals the given value
- Supported on both SQLite and PostgreSQL backends

## Test plan

- [x] 3 new tests: match, no-match, premise-excluded
- [x] Full test suite passes (1070 passed)
- [ ] Manual: `reasons add x "test" --label WARNING && reasons list --label WARNING`

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)