### PR TITLE
Cap derived section in derive prompt to match budget

### DIFF
--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -318,11 +318,15 @@ def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
     return "\n".join(lines), None
 
 
-def _build_derived_section(nodes, derived):
+def _build_derived_section(nodes, derived, max_derived=300):
     """Build the derived conclusions section for the derive prompt."""
     memo = {}
     lines = []
+    count = 0
     for k in sorted(derived, key=lambda x: -_get_depth(x, nodes, derived, memo)):
+        if count >= max_derived:
+            lines.append(f"\n... ({len(derived) - count} more derived conclusions omitted)")
+            break
         depth = _get_depth(k, nodes, derived, memo)
         text = nodes[k]["text"][:150]
         justs = derived[k]["justifications"]
@@ -335,6 +339,7 @@ def _build_derived_section(nodes, derived):
         lines.append(f"- Antecedents: {', '.join(antes)}")
         if outlist:
             lines.append(f"- Unless: {', '.join(outlist)}")
+        count += 1
 
     return "\n".join(lines) if lines else "(No derived conclusions yet)"
 
@@ -494,7 +499,7 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
         cluster=cluster, cluster_cache=cluster_cache,
         embedding_model=embedding_model, n_clusters=n_clusters,
     )
-    derived_section = _build_derived_section(nodes, derived)
+    derived_section = _build_derived_section(nodes, derived, max_derived=budget)
 
     template = prompt_template or DERIVE_PROMPT
     try:

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -18,6 +18,7 @@ from reasons_lib.derive import (
     _get_depth,
     _tokenize_id,
     _jaccard,
+    _build_derived_section,
 )
 
 
@@ -361,6 +362,40 @@ def test_build_prompt_with_budget(simple_network):
     assert len(prompt_small) < len(prompt_large)
     assert stats_small["budget"] == 2
     assert stats_large["budget"] == 100
+
+
+def test_build_derived_section_cap():
+    nodes = {"p": {"text": "Premise", "truth_value": "IN", "justifications": []}}
+    derived = {}
+    for i in range(10):
+        nid = f"d-{i}"
+        nodes[nid] = {
+            "text": f"Derived {i}",
+            "truth_value": "IN",
+            "justifications": [{"type": "SL", "antecedents": ["p"], "outlist": []}],
+        }
+        derived[nid] = nodes[nid]
+
+    section = _build_derived_section(nodes, derived, max_derived=3)
+    assert section.count("####") == 3
+    assert "7 more derived conclusions omitted" in section
+
+
+def test_build_derived_section_under_cap():
+    nodes = {"p": {"text": "Premise", "truth_value": "IN", "justifications": []}}
+    derived = {}
+    for i in range(3):
+        nid = f"d-{i}"
+        nodes[nid] = {
+            "text": f"Derived {i}",
+            "truth_value": "IN",
+            "justifications": [{"type": "SL", "antecedents": ["p"], "outlist": []}],
+        }
+        derived[nid] = nodes[nid]
+
+    section = _build_derived_section(nodes, derived, max_derived=10)
+    assert section.count("####") == 3
+    assert "omitted" not in section
 
 
 # --- Sampling tests ---


### PR DESCRIPTION
## Summary

- The derived conclusions section in the derive prompt was unbounded, including all derived beliefs (~13K+ at 3.6M chars for large networks)
- Now capped to `budget` (default 300), showing deepest-first with an omission note
- The post-generation validator still catches duplicate proposals, so capping the prompt section is safe

## Test plan

- [x] All 102 derive tests pass
- [x] Full test suite passes (1070 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)