### PR TITLE
Add --namespace filter to review-beliefs

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2295,6 +2295,7 @@ def review_beliefs(
     timeout: int = 300,
     min_depth: int | None = None,
     depends_on: str | None = None,
+    namespace: str | None = None,
     sample: int | None = None,
     visible_to: list[str] | None = None,
     dry_run: bool = False,
@@ -2354,6 +2355,15 @@ def review_beliefs(
                 for j in v.get("justifications", [])
             )
         }
+
+    if namespace is not None:
+        if namespace == "":
+            candidates = {k: v for k, v in candidates.items() if ":" not in k}
+        else:
+            candidates = {
+                k: v for k, v in candidates.items()
+                if k.startswith(f"{namespace}:")
+            }
 
     if sample is not None and len(candidates) > sample:
         import random

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1317,6 +1317,7 @@ def cmd_review_beliefs(args):
                 "belief_ids": args.ids or None,
                 "min_depth": args.min_depth,
                 "depends_on": args.depends_on,
+                "namespace": args.namespace,
                 "sample": args.sample,
                 "visible_to": _parse_visible_to(args),
             },
@@ -1342,6 +1343,7 @@ def cmd_review_beliefs(args):
         timeout=args.timeout,
         min_depth=args.min_depth,
         depends_on=args.depends_on,
+        namespace=args.namespace,
         sample=args.sample,
         visible_to=_parse_visible_to(args),
         dry_run=args.dry_run,
@@ -1849,6 +1851,8 @@ def main():
                    help="Only review beliefs at this depth or deeper")
     p.add_argument("--depends-on", default=None,
                    help="Only review beliefs depending on this node")
+    p.add_argument("-n", "--namespace", default=None,
+                   help="Filter by agent namespace (use empty string '' for local beliefs only)")
     p.add_argument("--sample", type=int, default=None,
                    help="Randomly sample N beliefs to review")
     p.add_argument("--dry-run", action="store_true",

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -358,6 +358,40 @@ class TestReviewBeliefsApi:
         # Only derived-abc depends on derived-ab
         assert result["reviewed"] == 1
 
+    def test_namespace_filter(self, db_path):
+        api.add_node("eng:premise-x", "X is true", db_path=db_path)
+        api.add_node("eng:derived-x", "X derived", sl="eng:premise-x",
+                      label="eng", db_path=db_path)
+        mock_response = json.dumps([
+            {"id": "eng:derived-x", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_beliefs(namespace="eng", db_path=db_path)
+        assert result["reviewed"] == 1
+        assert result["results"][0]["id"] == "eng:derived-x"
+
+    def test_empty_namespace_filters_local(self, db_path):
+        api.add_node("eng:premise-x", "X is true", db_path=db_path)
+        api.add_node("eng:derived-x", "X derived", sl="eng:premise-x",
+                      label="eng", db_path=db_path)
+        mock_response = json.dumps([
+            {"id": "derived-ab", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+            {"id": "derived-abc", "valid": True, "sufficient": True,
+             "necessary": True, "unnecessary_antecedents": [], "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": mock_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_beliefs(namespace="", db_path=db_path)
+        # Only local derived beliefs (no colon in ID)
+        assert result["reviewed"] == 2
+        ids = [r["id"] for r in result["results"]]
+        assert "eng:derived-x" not in ids
+
     def test_returns_summary_counts(self, db_path):
         mock_response = json.dumps([
             {"id": "derived-ab", "valid": False, "sufficient": True,


### PR DESCRIPTION
## Summary

- Adds `--namespace` / `-n` flag to `reasons review-beliefs` to filter by agent namespace
- `--namespace engineering` reviews only beliefs from that agent
- `--namespace ''` reviews only local (no-namespace) beliefs — the main use case for cross-domain beliefs
- Filter recorded in review report metadata

## Test plan

- [x] 2 new tests: namespace filter, empty namespace for local-only
- [x] Full test suite passes (1074 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)