### PR TITLE
Add --intra-cluster option to reasons derive

### DIFF
--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -935,7 +935,8 @@ def _derive_one_round(args, round_num=None, report_state=None,
         budget=args.budget, sample=args.sample, seed=args.seed,
         min_depth=args.min_depth, max_depth_filter=args.max_depth,
         premises_only=args.premises, has_dependents=args.has_dependents,
-        cluster=args.cluster, cluster_cache=cluster_cache,
+        cluster=args.cluster, intra_cluster=args.intra_cluster,
+        round_num=round_num or 0, cluster_cache=cluster_cache,
         embedding_model=args.embedding_model, n_clusters=args.n_clusters,
         prompt_template=prompt_template,
     )
@@ -950,8 +951,11 @@ def _derive_one_round(args, round_num=None, report_state=None,
         hi = stats.get("max_depth_filter", "∞")
         print(f"{prefix}Depth filter: {lo}–{hi}", file=sys.stderr)
     if stats.get("cluster"):
-        print(f"{prefix}Clustering: {stats['n_clusters']} clusters, "
+        cluster_mode = "intra" if stats.get("intra_cluster") else "inter"
+        print(f"{prefix}Clustering ({cluster_mode}): {stats['n_clusters']} clusters, "
               f"model={stats['embedding_model']}", file=sys.stderr)
+        if stats.get("focus_cluster") is not None:
+            print(f"{prefix}Focus: cluster {stats['focus_cluster']}", file=sys.stderr)
     elif stats.get("sample"):
         print(f"{prefix}Sampling: {stats['budget']} beliefs (random)", file=sys.stderr)
     elif stats.get("budget", 300) != 300:
@@ -1086,13 +1090,18 @@ def cmd_derive(args):
             sys.exit(1)
         prompt_template = prompt_path.read_text()
 
-    if args.cluster and args.sample:
-        print("Error: --cluster and --sample are mutually exclusive.",
+    if (args.cluster or args.intra_cluster) and args.sample:
+        print("Error: --cluster/--intra-cluster and --sample are mutually exclusive.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if args.cluster and args.intra_cluster:
+        print("Error: --cluster and --intra-cluster are mutually exclusive.",
               file=sys.stderr)
         sys.exit(1)
 
     cluster_cache = None
-    if args.cluster:
+    if args.cluster or args.intra_cluster:
         try:
             from .cluster import ClusterCache
             print("Loading embedding model...", file=sys.stderr)
@@ -1126,6 +1135,7 @@ def cmd_derive(args):
                 "budget": args.budget,
                 "sample": args.sample,
                 "cluster": args.cluster,
+                "intra_cluster": args.intra_cluster,
                 "embedding_model": args.embedding_model,
                 "n_clusters": args.n_clusters,
                 "prompt_file": args.prompt_file,
@@ -1670,11 +1680,13 @@ def main():
                    help="Suppress JSON report generation")
     p.add_argument("--cluster", action="store_true",
                    help="Use semantic clustering to sample across domains")
+    p.add_argument("--intra-cluster", action="store_true",
+                   help="Focus on one cluster per round (rotate in --exhaust mode)")
     p.add_argument("--embedding-model", default=None,
-                   help="Sentence-transformers model for --cluster "
+                   help="Sentence-transformers model for --cluster/--intra-cluster "
                         "(default: all-MiniLM-L6-v2)")
     p.add_argument("--n-clusters", type=int, default=None,
-                   help="Override automatic cluster count for --cluster")
+                   help="Override automatic cluster count for --cluster/--intra-cluster")
     p.add_argument("--prompt-file", default=None,
                    help="Custom prompt template file (overrides built-in DERIVE_PROMPT)")
 

--- a/reasons_lib/cluster.py
+++ b/reasons_lib/cluster.py
@@ -147,6 +147,60 @@ def cluster_beliefs(beliefs, budget, seed=None, n_clusters=None,
     }
 
 
+def cluster_beliefs_intra(beliefs, budget, round_num=0, seed=None,
+                          n_clusters=None, cache=None,
+                          model_name=DEFAULT_MODEL):
+    """Cluster beliefs and focus budget on one cluster per round.
+
+    Rotates through clusters via round_num % k, giving the LLM
+    topically adjacent beliefs that are more likely to combine.
+
+    Returns:
+        (selected_ids, cluster_stats) with focus_cluster index.
+    """
+    _require_cluster_deps()
+
+    if len(beliefs) <= budget:
+        return list(beliefs.keys()), {
+            "n_clusters": 1,
+            "cluster_sizes": [len(beliefs)],
+            "embedding_model": model_name,
+            "focus_cluster": 0,
+        }
+
+    if cache is None:
+        cache = ClusterCache(model_name)
+
+    ids, embeddings = cache.embed(beliefs)
+
+    k = _auto_k(len(beliefs), n_clusters, max_k=min(budget // 3, 20))
+
+    km = KMeans(n_clusters=k, random_state=seed, n_init=10)
+    labels = km.fit_predict(embeddings)
+
+    clusters = {}
+    for i, nid in enumerate(ids):
+        clusters.setdefault(labels[i], []).append(nid)
+
+    cluster_sizes = [len(clusters[c]) for c in sorted(clusters)]
+
+    sorted_labels = sorted(clusters, key=lambda c: -len(clusters[c]))
+    focus_idx = round_num % k
+    focus_label = sorted_labels[focus_idx]
+    members = clusters[focus_label]
+
+    rng = random.Random(seed)
+    alloc = min(budget, len(members))
+    selected = rng.sample(members, alloc)
+
+    return selected, {
+        "n_clusters": k,
+        "cluster_sizes": cluster_sizes,
+        "embedding_model": cache.model_name,
+        "focus_cluster": focus_idx,
+    }
+
+
 def list_clusters(beliefs, n_clusters=None, seed=None, cache=None,
                   model_name=DEFAULT_MODEL):
     """Cluster beliefs and return full cluster assignments.

--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -165,7 +165,8 @@ def _sample_beliefs(belief_ids, budget, rng=None):
 
 def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
                            sample=False, seed=None,
-                           cluster=False, cluster_cache=None,
+                           cluster=False, intra_cluster=False,
+                           round_num=0, cluster_cache=None,
                            embedding_model=None, n_clusters=None):
     """Build a compact beliefs section for the derive prompt.
 
@@ -174,6 +175,8 @@ def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
         sample: If True, randomly sample beliefs instead of alphabetical truncation.
         seed: Random seed for reproducible sampling.
         cluster: If True, use semantic clustering to sample across domains.
+        intra_cluster: If True, focus budget on one cluster per round.
+        round_num: Current round number (for intra-cluster rotation).
         cluster_cache: Optional ClusterCache for embedding reuse across rounds.
         embedding_model: Sentence-transformers model name for clustering.
         n_clusters: Override automatic cluster count.
@@ -186,7 +189,15 @@ def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
     in_nodes = {k: v for k, v in nodes.items()
                 if v.get("truth_value") == "IN" and k not in derived}
 
-    if cluster:
+    if intra_cluster:
+        from .cluster import cluster_beliefs_intra as _cluster_intra
+        belief_texts = {k: v["text"] for k, v in in_nodes.items()}
+        selected_ids, cluster_stats = _cluster_intra(
+            belief_texts, max_beliefs, round_num=round_num, seed=seed,
+            n_clusters=n_clusters, cache=cluster_cache,
+            model_name=embedding_model or "all-MiniLM-L6-v2",
+        )
+    elif cluster:
         from .cluster import cluster_beliefs as _cluster
         belief_texts = {k: v["text"] for k, v in in_nodes.items()}
         selected_ids, cluster_stats = _cluster(
@@ -194,6 +205,7 @@ def _build_beliefs_section(nodes, derived, agents=None, max_beliefs=300,
             cache=cluster_cache, model_name=embedding_model or "all-MiniLM-L6-v2",
         )
 
+    if intra_cluster or cluster:
         if agents:
             for agent_name in sorted(agents, key=lambda a: -len(agents[a])):
                 agent_sel = sorted(k for k in selected_ids
@@ -405,7 +417,8 @@ def parse_proposals(response):
 def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
                  seed=None, min_depth=None, max_depth_filter=None,
                  premises_only=False, has_dependents=False,
-                 cluster=False, cluster_cache=None, embedding_model=None,
+                 cluster=False, intra_cluster=False, round_num=0,
+                 cluster_cache=None, embedding_model=None,
                  n_clusters=None, prompt_template=None):
     """Build the full derive prompt from a network's nodes dict.
 
@@ -496,7 +509,8 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
     beliefs_section, cluster_stats = _build_beliefs_section(
         nodes, derived, agents, max_beliefs=budget,
         sample=sample, seed=seed,
-        cluster=cluster, cluster_cache=cluster_cache,
+        cluster=cluster, intra_cluster=intra_cluster,
+        round_num=round_num, cluster_cache=cluster_cache,
         embedding_model=embedding_model, n_clusters=n_clusters,
     )
     derived_section = _build_derived_section(nodes, derived, max_derived=budget)
@@ -543,11 +557,14 @@ def build_prompt(nodes, domain=None, topic=None, budget=300, sample=False,
         stats["max_depth_filter"] = max_depth_filter
     stats["budget"] = budget
     stats["sample"] = sample
-    if cluster and cluster_stats:
+    if (cluster or intra_cluster) and cluster_stats:
         stats["cluster"] = True
+        stats["intra_cluster"] = intra_cluster
         stats["n_clusters"] = cluster_stats["n_clusters"]
         stats["cluster_sizes"] = cluster_stats["cluster_sizes"]
         stats["embedding_model"] = cluster_stats["embedding_model"]
+        if "focus_cluster" in cluster_stats:
+            stats["focus_cluster"] = cluster_stats["focus_cluster"]
 
     return prompt, stats
 

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -964,6 +964,27 @@ def test_build_prompt_cluster_with_agents(agent_network):
     assert "Agent: agent-b" in prompt
 
 
+@skip_no_cluster
+def test_build_prompt_with_intra_cluster(simple_network):
+    nodes = api.export_network(db_path=simple_network)["nodes"]
+    prompt, stats = build_prompt(nodes, intra_cluster=True, budget=10, seed=42)
+    assert stats.get("cluster") is True
+    assert stats.get("intra_cluster") is True
+    assert "focus_cluster" in stats
+    assert "n_clusters" in stats
+    assert len(prompt) > 0
+
+
+@skip_no_cluster
+def test_intra_cluster_rotation():
+    from reasons_lib.cluster import cluster_beliefs_intra
+    beliefs = {f"b-{i}": f"Belief about topic {i % 3}" for i in range(30)}
+    ids_r0, stats_r0 = cluster_beliefs_intra(beliefs, budget=5, round_num=0, seed=42)
+    ids_r1, stats_r1 = cluster_beliefs_intra(beliefs, budget=5, round_num=1, seed=42)
+    assert stats_r0["focus_cluster"] != stats_r1["focus_cluster"]
+    assert set(ids_r0) != set(ids_r1)
+
+
 def test_build_prompt_custom_template(simple_network):
     data = api.export_network(db_path=simple_network)
     template = "Custom prompt with {total_in} beliefs and depth {max_depth}. {beliefs_section}{derived_section}{domain_context}{cross_agent_task}{agents_stats}{total_derived}"


### PR DESCRIPTION
## Summary

- Adds `--intra-cluster` flag to `reasons derive` that focuses the entire belief budget on one semantic cluster per round
- Rotates through clusters in `--exhaust` mode via `round_num % k`, so each round explores a different topic area
- Improves derive yield on smaller networks (~1,675 nodes) where cross-cluster sampling can fail to find combinable pairs
- Mutually exclusive with `--cluster` (inter-cluster) and `--sample`
- New `cluster_beliefs_intra()` function in `cluster.py` reuses the same embedding/KMeans machinery

## Test plan

- [x] 2 new tests: intra-cluster through build_prompt, cluster rotation across rounds
- [x] Full test suite passes (1076 passed)
- [ ] Manual: `reasons derive --intra-cluster --budget 50 --exhaust`

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)