### PR TITLE
Add reasons repair-smuggled command

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2399,6 +2399,70 @@ def review_beliefs(
     }
 
 
+def repair_smuggled(
+    review_file: str | None = None,
+    belief_ids: list[str] | None = None,
+    model: str = "claude",
+    timeout: int = 300,
+    dry_run: bool = False,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Repair smuggled premises by searching for and linking existing premises.
+
+    Two input modes:
+        review_file: path to a review-beliefs JSON report — extract invalid results
+        belief_ids: re-review these beliefs inline, then repair invalids
+
+    Returns dict with repairs list and summary counts.
+    """
+    from .repair import repair_smuggled_beliefs
+
+    if review_file:
+        import json as _json
+        with open(review_file) as f:
+            report = _json.load(f)
+        review_results = report.get("results", [])
+    elif belief_ids:
+        result = review_beliefs(
+            belief_ids=belief_ids, model=model, timeout=timeout,
+            dry_run=True, db_path=db_path,
+        )
+        review_results = result["results"]
+    else:
+        raise ValueError("Provide either review_file or belief_ids")
+
+    invalid = [r for r in review_results if not r.get("valid", True)]
+
+    if not invalid:
+        return {
+            "repairs": [],
+            "total_invalid": 0,
+            "repaired": 0,
+            "no_candidates": 0,
+            "no_match": 0,
+            "extraction_failed": 0,
+            "errors": 0,
+        }
+
+    net = export_network(db_path=db_path)
+    nodes = net.get("nodes", {})
+
+    repairs = repair_smuggled_beliefs(
+        invalid, nodes, model=model, timeout=timeout,
+        db_path=db_path, dry_run=dry_run,
+    )
+
+    return {
+        "repairs": repairs,
+        "total_invalid": len(invalid),
+        "repaired": sum(1 for r in repairs if r["status"] == "repaired"),
+        "no_candidates": sum(1 for r in repairs if r["status"] == "no_candidates"),
+        "no_match": sum(1 for r in repairs if r["status"] == "no_match"),
+        "extraction_failed": sum(1 for r in repairs if r["status"] == "extraction_failed"),
+        "errors": sum(1 for r in repairs if r["status"] == "error"),
+    }
+
+
 def detect_contradictions(
     belief_ids: list[str] | None = None,
     model: str = "claude",

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1424,6 +1424,48 @@ def cmd_review_beliefs(args):
                 print(f"  ERROR retracting {r['id']}: {e}", file=sys.stderr)
 
 
+def cmd_repair_smuggled(args):
+    _require_sqlite(args, "repair-smuggled")
+
+    model = getattr(args, "model", None) or "claude"
+    review_file = getattr(args, "review_file", None)
+    belief_ids = args.ids if args.ids else None
+
+    if not review_file and not belief_ids:
+        print("Error: provide either --review-file or belief IDs", file=sys.stderr)
+        sys.exit(1)
+
+    result = api.repair_smuggled(
+        review_file=review_file,
+        belief_ids=belief_ids,
+        model=model,
+        timeout=args.timeout,
+        dry_run=args.dry_run,
+        db_path=args.db,
+    )
+
+    repairs = result["repairs"]
+    for r in repairs:
+        status = r["status"].upper()
+        print(f"  [{status}] {r['id']}")
+        if r.get("smuggled_claim"):
+            print(f"    Smuggled: {r['smuggled_claim']}")
+        if r.get("matched_premises"):
+            print(f"    Linked: {', '.join(r['matched_premises'])}")
+        if r.get("rationale"):
+            print(f"    Rationale: {r['rationale']}")
+        if r.get("error"):
+            print(f"    Error: {r['error']}")
+
+    print(f"\nTotal invalid: {result['total_invalid']}")
+    print(f"  Repaired: {result['repaired']}  No candidates: {result['no_candidates']}"
+          f"  No match: {result['no_match']}  Extract failed: {result['extraction_failed']}"
+          f"  Errors: {result['errors']}")
+
+    if args.dry_run:
+        print("\n  (dry run -- no changes applied)")
+
+
 def cmd_contradictions(args):
     _require_sqlite(args, "detect-contradictions")
 
@@ -1880,6 +1922,19 @@ def main():
     p.add_argument("--no-report", action="store_true",
                    help="Skip JSON report generation")
 
+    # repair-smuggled
+    p = sub.add_parser("repair-smuggled",
+        help="Repair smuggled premises by finding and linking existing premises")
+    p.add_argument("ids", nargs="*", help="Belief IDs to review and repair")
+    p.add_argument("--review-file", default=None,
+                   help="Path to review-beliefs JSON report")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude)")
+    p.add_argument("--timeout", type=int, default=300,
+                   help="LLM timeout in seconds (default: 300)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report findings without applying repairs")
+
     # contradictions
     p = sub.add_parser("contradictions", help="Detect contradictions between IN beliefs")
     p.add_argument("ids", nargs="*", help="Specific belief IDs to check (default: all IN)")
@@ -1973,6 +2028,7 @@ def main():
         "list-gated": cmd_list_gated,
         "list-negative": cmd_list_negative,
         "review-beliefs": cmd_review_beliefs,
+        "repair-smuggled": cmd_repair_smuggled,
         "contradictions": cmd_contradictions,
         "namespaces": cmd_namespaces,
     }

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -1,0 +1,260 @@
+"""Repair smuggled premises by search-and-link.
+
+Given beliefs flagged invalid by review-beliefs (smuggled premise —
+conclusion introduces facts not present in any antecedent), this module:
+1. Extracts the specific smuggled claim via LLM
+2. Searches the belief network for matching premises
+3. Wires found premises as new antecedents via add_justification
+
+Requires two LLM calls per invalid belief (extract + match).
+"""
+
+import json
+import sys
+
+from .llm import invoke_model
+from .review import format_belief_for_review
+
+EXTRACT_PROMPT = """\
+You are analyzing a derived belief that was flagged as invalid in a Truth Maintenance System.
+The belief's conclusion introduces a factual claim not supported by its antecedents (a smuggled premise).
+
+Your task: identify the specific factual claim that the conclusion smuggles in — the fact it
+relies on that is NOT stated or implied by any antecedent.
+
+## Invalid belief
+
+{belief_context}
+
+## Review finding
+
+{review_comment}
+
+Respond with ONLY a single concise factual claim (one sentence, no preamble) that captures
+what specific knowledge the conclusion assumes but the antecedents do not provide.
+Do NOT restate the conclusion. Extract the missing piece — the gap between what the
+antecedents establish and what the conclusion asserts.
+
+Smuggled claim:"""
+
+MATCH_PROMPT = """\
+You are matching a smuggled claim against existing premises in a belief network.
+The smuggled claim is a factual assertion that was missing from a derivation's antecedents.
+Your task: determine which (if any) of the candidate premises below directly supports
+this smuggled claim.
+
+## Smuggled claim
+
+{smuggled_claim}
+
+## Candidate premises
+
+{candidates}
+
+Rules:
+- A premise "supports" the smuggled claim if it states or directly implies the same fact.
+- Do NOT match premises that are merely topically related — they must actually establish
+  the smuggled fact.
+- If multiple premises jointly support the claim, list all of them.
+- If no premise supports the claim, say "none".
+
+Respond with ONLY a JSON object in this exact format:
+{{"matched_ids": ["premise-id-1", "premise-id-2"], "rationale": "brief explanation"}}
+
+If no match: {{"matched_ids": [], "rationale": "brief explanation"}}"""
+
+
+def parse_extract_response(response):
+    """Extract the smuggled claim string from LLM response."""
+    text = response.strip()
+    if not text:
+        return ""
+    for prefix in ("Smuggled claim:", "smuggled claim:"):
+        if text.lower().startswith(prefix.lower()):
+            text = text[len(prefix):].strip()
+    if len(text) > 2 and text[0] in ('"', "'") and text[-1] == text[0]:
+        text = text[1:-1].strip()
+    return text
+
+
+def parse_match_response(response, valid_ids):
+    """Extract match result JSON from LLM response.
+
+    Uses raw_decode to find JSON object in response text.
+    Filters matched_ids to only include IDs in valid_ids.
+    """
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(response):
+        if ch != "{":
+            continue
+        try:
+            obj, _ = decoder.raw_decode(response, i)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        matched = obj.get("matched_ids", [])
+        if not isinstance(matched, list):
+            matched = []
+        filtered = [mid for mid in matched if mid in valid_ids]
+        return {
+            "matched_ids": filtered,
+            "rationale": obj.get("rationale", ""),
+        }
+    return {"matched_ids": [], "rationale": ""}
+
+
+def extract_smuggled_claim(belief_context, review_comment, model="claude",
+                           timeout=300):
+    """LLM call 1: extract the smuggled claim from an invalid belief."""
+    prompt = EXTRACT_PROMPT.format(
+        belief_context=belief_context,
+        review_comment=review_comment,
+    )
+    response = invoke_model(prompt, model=model, timeout=timeout)
+    return parse_extract_response(response)
+
+
+def find_matching_premises(smuggled_claim, candidates, model="claude",
+                           timeout=300):
+    """LLM call 2: match smuggled claim against candidate premises.
+
+    Args:
+        smuggled_claim: extracted claim string
+        candidates: list of {"id": str, "text": str} dicts (IN premises)
+    """
+    if not candidates:
+        return {"matched_ids": [], "rationale": "no candidates found"}
+
+    candidate_lines = "\n".join(
+        f"- `{c['id']}`: {c['text']}" for c in candidates
+    )
+    prompt = MATCH_PROMPT.format(
+        smuggled_claim=smuggled_claim,
+        candidates=candidate_lines,
+    )
+    response = invoke_model(prompt, model=model, timeout=timeout)
+    valid_ids = {c["id"] for c in candidates}
+    return parse_match_response(response, valid_ids)
+
+
+def repair_smuggled_beliefs(review_results, nodes, model="claude",
+                            timeout=300, db_path=None, dry_run=False,
+                            search_fn=None):
+    """Orchestrate search-and-link repair for invalid beliefs.
+
+    Args:
+        review_results: list of review dicts with valid=False
+        nodes: full nodes dict from export_network()
+        model: LLM model for extract/match calls
+        timeout: LLM timeout
+        db_path: database path for add_justification
+        dry_run: if True, report without applying
+        search_fn: callable(query, format, db_path) for search (injectable for tests)
+
+    Returns:
+        list of repair result dicts
+    """
+    from . import api
+
+    if search_fn is None:
+        search_fn = lambda query, **kw: api.search(query, **kw)
+
+    invalid = [r for r in review_results if not r.get("valid", True)]
+    repairs = []
+
+    for r in invalid:
+        belief_id = r["id"]
+        result = {
+            "id": belief_id,
+            "status": "error",
+            "smuggled_claim": None,
+            "matched_premises": [],
+            "rationale": None,
+            "error": None,
+        }
+
+        try:
+            node = nodes.get(belief_id)
+            if not node:
+                result["error"] = "belief not found in network"
+                repairs.append(result)
+                continue
+
+            belief_context = format_belief_for_review(belief_id, nodes)
+            comment = r.get("comment", "")
+
+            print(f"  Extracting smuggled claim for {belief_id}...",
+                  file=sys.stderr)
+            claim = extract_smuggled_claim(belief_context, comment,
+                                           model=model, timeout=timeout)
+            result["smuggled_claim"] = claim
+
+            if not claim:
+                result["status"] = "extraction_failed"
+                repairs.append(result)
+                continue
+
+            existing_ants = set()
+            for j in node.get("justifications", []):
+                existing_ants.update(j.get("antecedents", []))
+
+            print(f"  Searching for: {claim[:80]}...", file=sys.stderr)
+            raw = search_fn(claim, format="json", db_path=db_path)
+            try:
+                search_results = json.loads(raw) if isinstance(raw, str) else raw
+            except (json.JSONDecodeError, TypeError):
+                search_results = []
+
+            candidates = []
+            for sr in search_results:
+                sid = sr.get("id", "")
+                if sid == belief_id:
+                    continue
+                if sid in existing_ants:
+                    continue
+                if sr.get("truth_value") != "IN":
+                    continue
+                sr_node = nodes.get(sid)
+                if sr_node and sr_node.get("justifications"):
+                    continue
+                candidates.append({"id": sid, "text": sr.get("text", "")})
+
+            if not candidates:
+                result["status"] = "no_candidates"
+                repairs.append(result)
+                continue
+
+            print(f"  Matching against {len(candidates)} candidate(s)...",
+                  file=sys.stderr)
+            match = find_matching_premises(claim, candidates,
+                                           model=model, timeout=timeout)
+            matched_ids = match.get("matched_ids", [])
+            result["rationale"] = match.get("rationale", "")
+
+            if not matched_ids:
+                result["status"] = "no_match"
+                repairs.append(result)
+                continue
+
+            result["matched_premises"] = matched_ids
+
+            if not dry_run:
+                first_just = node.get("justifications", [{}])[0]
+                original_ants = first_just.get("antecedents", [])
+                new_ants = list(original_ants) + matched_ids
+                api.add_justification(
+                    belief_id,
+                    sl=",".join(new_ants),
+                    label=f"repair-smuggled: {claim[:60]}",
+                    db_path=db_path,
+                )
+
+            result["status"] = "repaired"
+
+        except Exception as exc:
+            result["error"] = str(exc)
+
+        repairs.append(result)
+
+    return repairs

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -242,10 +242,12 @@ def repair_smuggled_beliefs(review_results, nodes, model="claude",
             if not dry_run:
                 first_just = node.get("justifications", [{}])[0]
                 original_ants = first_just.get("antecedents", [])
+                original_outlist = first_just.get("outlist", [])
                 new_ants = list(original_ants) + matched_ids
                 api.add_justification(
                     belief_id,
                     sl=",".join(new_ants),
+                    unless=",".join(original_outlist) if original_outlist else "",
                     label=f"repair-smuggled: {claim[:60]}",
                     db_path=db_path,
                 )

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,0 +1,452 @@
+"""Tests for the repair module (smuggled premise search-and-link)."""
+
+import json
+import sys
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from reasons_lib.repair import (
+    parse_extract_response,
+    parse_match_response,
+    extract_smuggled_claim,
+    find_matching_premises,
+    repair_smuggled_beliefs,
+)
+from reasons_lib import api
+from reasons_lib.cli import main
+
+
+def run_cli(*args, db_path=None):
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+        except SystemExit as e:
+            return stdout.getvalue(), stderr.getvalue(), e.code
+    return stdout.getvalue(), stderr.getvalue(), 0
+
+
+def _make_repair_nodes():
+    """Build nodes with a smuggled-premise scenario."""
+    return {
+        "premise-a": {
+            "text": "Water boils at 100C at sea level",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "premise-b": {
+            "text": "The experiment was conducted at sea level",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "premise-c": {
+            "text": "The sample reached 100C",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "derived-boil": {
+            "text": "The water in the sample boiled, releasing steam",
+            "truth_value": "IN",
+            "justifications": [{
+                "type": "SL",
+                "antecedents": ["premise-b", "premise-c"],
+                "outlist": [],
+                "label": "boiling inference",
+            }],
+        },
+    }
+
+
+# --- parse_extract_response ---
+
+class TestParseExtractResponse:
+    def test_plain_text(self):
+        assert parse_extract_response("Water boils at 100C") == "Water boils at 100C"
+
+    def test_strips_whitespace(self):
+        assert parse_extract_response("  Water boils at 100C  \n") == "Water boils at 100C"
+
+    def test_strips_quotes(self):
+        assert parse_extract_response('"Water boils at 100C"') == "Water boils at 100C"
+        assert parse_extract_response("'Water boils at 100C'") == "Water boils at 100C"
+
+    def test_strips_prefix(self):
+        assert parse_extract_response("Smuggled claim: Water boils") == "Water boils"
+
+    def test_empty(self):
+        assert parse_extract_response("") == ""
+        assert parse_extract_response("   ") == ""
+
+    def test_multiline_returns_full(self):
+        resp = "Water boils at 100C.\nThis is a known physical fact."
+        result = parse_extract_response(resp)
+        assert "Water boils at 100C" in result
+
+
+# --- parse_match_response ---
+
+class TestParseMatchResponse:
+    def test_valid_json(self):
+        resp = '{"matched_ids": ["premise-a"], "rationale": "directly states it"}'
+        result = parse_match_response(resp, {"premise-a", "premise-b"})
+        assert result["matched_ids"] == ["premise-a"]
+        assert result["rationale"] == "directly states it"
+
+    def test_json_in_prose(self):
+        resp = 'Here is my answer:\n{"matched_ids": ["premise-a"], "rationale": "match"}\nDone.'
+        result = parse_match_response(resp, {"premise-a"})
+        assert result["matched_ids"] == ["premise-a"]
+
+    def test_filters_invalid_ids(self):
+        resp = '{"matched_ids": ["premise-a", "nonexistent"], "rationale": "partial"}'
+        result = parse_match_response(resp, {"premise-a"})
+        assert result["matched_ids"] == ["premise-a"]
+
+    def test_empty_match(self):
+        resp = '{"matched_ids": [], "rationale": "no match found"}'
+        result = parse_match_response(resp, {"premise-a"})
+        assert result["matched_ids"] == []
+        assert result["rationale"] == "no match found"
+
+    def test_malformed_json(self):
+        result = parse_match_response("no json here", {"premise-a"})
+        assert result["matched_ids"] == []
+
+    def test_no_matched_ids_key(self):
+        resp = '{"rationale": "something"}'
+        result = parse_match_response(resp, {"premise-a"})
+        assert result["matched_ids"] == []
+
+
+# --- extract_smuggled_claim ---
+
+class TestExtractSmuggledClaim:
+    def test_calls_llm_with_context(self):
+        mock_result = type("R", (), {
+            "returncode": 0,
+            "stdout": "Water boils at 100C at sea level",
+            "stderr": "",
+        })()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result) as mock_run:
+            claim = extract_smuggled_claim(
+                "### derived-boil\nClaim: water boiled",
+                "Conclusion assumes boiling point knowledge",
+            )
+            assert claim == "Water boils at 100C at sea level"
+            prompt_sent = mock_run.call_args[1].get("input") or mock_run.call_args[0][0]
+            if isinstance(prompt_sent, str):
+                assert "derived-boil" in prompt_sent or "boiling" in prompt_sent
+
+    def test_empty_response(self):
+        mock_result = type("R", (), {
+            "returncode": 0, "stdout": "  ", "stderr": "",
+        })()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            claim = extract_smuggled_claim("context", "comment")
+            assert claim == ""
+
+
+# --- find_matching_premises ---
+
+class TestFindMatchingPremises:
+    def test_matches_premise(self):
+        mock_result = type("R", (), {
+            "returncode": 0,
+            "stdout": '{"matched_ids": ["premise-a"], "rationale": "states the fact"}',
+            "stderr": "",
+        })()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = find_matching_premises(
+                "Water boils at 100C",
+                [{"id": "premise-a", "text": "Water boils at 100C at sea level"}],
+            )
+            assert result["matched_ids"] == ["premise-a"]
+
+    def test_empty_candidates_skips_llm(self):
+        with patch("reasons_lib.llm.subprocess.run") as mock_run:
+            result = find_matching_premises("some claim", [])
+            mock_run.assert_not_called()
+            assert result["matched_ids"] == []
+            assert "no candidates" in result["rationale"]
+
+
+# --- repair_smuggled_beliefs ---
+
+class TestRepairSmuggledBeliefs:
+    def _mock_result(self, stdout):
+        return type("R", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+
+    def _mock_search(self, results):
+        return lambda query, **kw: json.dumps(results)
+
+    def test_full_repair_flow(self):
+        nodes = _make_repair_nodes()
+        review_results = [{
+            "id": "derived-boil",
+            "valid": False,
+            "comment": "Assumes boiling point knowledge not in antecedents",
+        }]
+        search_results = [
+            {"id": "premise-a", "text": "Water boils at 100C at sea level",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        extract_resp = self._mock_result("Water boils at 100C at sea level")
+        match_resp = self._mock_result(
+            '{"matched_ids": ["premise-a"], "rationale": "directly states it"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp, match_resp]), \
+             patch("reasons_lib.api.add_justification") as mock_add:
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=self._mock_search(search_results),
+            )
+
+        assert len(repairs) == 1
+        assert repairs[0]["status"] == "repaired"
+        assert repairs[0]["matched_premises"] == ["premise-a"]
+        mock_add.assert_called_once()
+        call_kwargs = mock_add.call_args
+        assert "premise-a" in call_kwargs[1]["sl"] or "premise-a" in call_kwargs[0][1] if call_kwargs[0] else call_kwargs[1]["sl"]
+
+    def test_dry_run_no_apply(self):
+        nodes = _make_repair_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "smuggled",
+        }]
+        search_results = [
+            {"id": "premise-a", "text": "Water boils at 100C at sea level",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        extract_resp = self._mock_result("Water boils at 100C")
+        match_resp = self._mock_result(
+            '{"matched_ids": ["premise-a"], "rationale": "match"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp, match_resp]), \
+             patch("reasons_lib.api.add_justification") as mock_add:
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db", dry_run=True,
+                search_fn=self._mock_search(search_results),
+            )
+
+        assert repairs[0]["status"] == "repaired"
+        mock_add.assert_not_called()
+
+    def test_no_candidates(self):
+        nodes = _make_repair_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "smuggled",
+        }]
+        extract_resp = self._mock_result("Water boils at 100C")
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp]):
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=self._mock_search([]),
+            )
+
+        assert repairs[0]["status"] == "no_candidates"
+
+    def test_no_match(self):
+        nodes = _make_repair_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "smuggled",
+        }]
+        search_results = [
+            {"id": "premise-a", "text": "Water boils at 100C at sea level",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        extract_resp = self._mock_result("Water boils at 100C")
+        match_resp = self._mock_result(
+            '{"matched_ids": [], "rationale": "no match"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp, match_resp]):
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=self._mock_search(search_results),
+            )
+
+        assert repairs[0]["status"] == "no_match"
+
+    def test_extraction_failed(self):
+        nodes = _make_repair_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "smuggled",
+        }]
+        extract_resp = self._mock_result("   ")
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp]):
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=self._mock_search([]),
+            )
+
+        assert repairs[0]["status"] == "extraction_failed"
+
+    def test_skips_existing_antecedents(self):
+        """Search results that are already antecedents should be filtered out."""
+        nodes = _make_repair_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "smuggled",
+        }]
+        search_results = [
+            {"id": "premise-b", "text": "The experiment was conducted at sea level",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        extract_resp = self._mock_result("Something about sea level")
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp]):
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=self._mock_search(search_results),
+            )
+
+        assert repairs[0]["status"] == "no_candidates"
+
+    def test_skips_derived_beliefs_in_candidates(self):
+        """Derived beliefs (with justifications) should not be candidates."""
+        nodes = _make_repair_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "smuggled",
+        }]
+        search_results = [
+            {"id": "derived-boil", "text": "The water boiled",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        extract_resp = self._mock_result("Boiling occurs")
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp]):
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=self._mock_search(search_results),
+            )
+
+        assert repairs[0]["status"] == "no_candidates"
+
+    def test_belief_not_in_network(self):
+        nodes = _make_repair_nodes()
+        review_results = [{
+            "id": "nonexistent", "valid": False, "comment": "smuggled",
+        }]
+
+        repairs = repair_smuggled_beliefs(
+            review_results, nodes, db_path="test.db",
+            search_fn=self._mock_search([]),
+        )
+
+        assert repairs[0]["status"] == "error"
+        assert "not found" in repairs[0]["error"]
+
+    def test_skips_valid_beliefs(self):
+        """Only processes beliefs where valid=False."""
+        nodes = _make_repair_nodes()
+        review_results = [
+            {"id": "derived-boil", "valid": True, "comment": "looks good"},
+        ]
+
+        repairs = repair_smuggled_beliefs(
+            review_results, nodes, db_path="test.db",
+            search_fn=self._mock_search([]),
+        )
+
+        assert len(repairs) == 0
+
+
+# --- CLI ---
+
+class TestCmdRepairSmuggled:
+    def test_help(self):
+        stdout, stderr, code = run_cli("repair-smuggled", "--help")
+        assert code == 0
+        assert "repair" in stdout.lower() or "smuggled" in stdout.lower()
+
+    def test_no_args_error(self):
+        stdout, stderr, code = run_cli("repair-smuggled", db_path="test.db")
+        assert code == 1
+        assert "provide" in stderr.lower() or "provide" in stdout.lower()
+
+    def test_from_review_file(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("premise-b", "B is true", db_path=db)
+        api.add_node("derived-ab", "AB follows", sl="premise-a", db_path=db)
+
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps({
+            "results": [{
+                "id": "derived-ab",
+                "valid": False,
+                "comment": "smuggles B",
+            }],
+        }))
+
+        extract_resp = type("R", (), {
+            "returncode": 0, "stdout": "B is true", "stderr": "",
+        })()
+        match_resp = type("R", (), {
+            "returncode": 0,
+            "stdout": '{"matched_ids": ["premise-b"], "rationale": "match"}',
+            "stderr": "",
+        })()
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp, match_resp]):
+            stdout, stderr, code = run_cli(
+                "repair-smuggled",
+                "--review-file", str(review_file),
+                db_path=db,
+            )
+
+        assert code == 0
+        assert "REPAIRED" in stdout
+        assert "premise-b" in stdout
+
+    def test_dry_run(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("derived-a", "A extended", sl="premise-a", db_path=db)
+
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps({
+            "results": [{
+                "id": "derived-a",
+                "valid": False,
+                "comment": "smuggled",
+            }],
+        }))
+
+        extract_resp = type("R", (), {
+            "returncode": 0, "stdout": "some claim", "stderr": "",
+        })()
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp]):
+            stdout, stderr, code = run_cli(
+                "repair-smuggled",
+                "--review-file", str(review_file),
+                "--dry-run",
+                db_path=db,
+            )
+
+        assert code == 0
+        assert "dry run" in stdout.lower()

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -218,8 +218,7 @@ class TestRepairSmuggledBeliefs:
         assert repairs[0]["status"] == "repaired"
         assert repairs[0]["matched_premises"] == ["premise-a"]
         mock_add.assert_called_once()
-        call_kwargs = mock_add.call_args
-        assert "premise-a" in call_kwargs[1]["sl"] or "premise-a" in call_kwargs[0][1] if call_kwargs[0] else call_kwargs[1]["sl"]
+        assert "premise-a" in mock_add.call_args[1]["sl"]
 
     def test_dry_run_no_apply(self):
         nodes = _make_repair_nodes()
@@ -356,6 +355,96 @@ class TestRepairSmuggledBeliefs:
 
         assert repairs[0]["status"] == "error"
         assert "not found" in repairs[0]["error"]
+
+    def test_preserves_outlist(self):
+        """Repaired justification should preserve the original outlist."""
+        nodes = _make_repair_nodes()
+        nodes["premise-d"] = {
+            "text": "Pressure is normal", "truth_value": "IN", "justifications": [],
+        }
+        nodes["blocker-x"] = {
+            "text": "Experiment was invalid", "truth_value": "OUT", "justifications": [],
+        }
+        nodes["derived-boil"]["justifications"][0]["outlist"] = ["blocker-x"]
+
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "smuggled",
+        }]
+        search_results = [
+            {"id": "premise-d", "text": "Pressure is normal",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        extract_resp = self._mock_result("Normal pressure assumed")
+        match_resp = self._mock_result(
+            '{"matched_ids": ["premise-d"], "rationale": "match"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[extract_resp, match_resp]), \
+             patch("reasons_lib.api.add_justification") as mock_add:
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=self._mock_search(search_results),
+            )
+
+        assert repairs[0]["status"] == "repaired"
+        mock_add.assert_called_once()
+        assert mock_add.call_args[1]["unless"] == "blocker-x"
+
+    def test_multiple_invalid_beliefs(self):
+        """Processes multiple invalid beliefs in one batch."""
+        nodes = _make_repair_nodes()
+        nodes["premise-d"] = {
+            "text": "Steam is gaseous water", "truth_value": "IN", "justifications": [],
+        }
+        nodes["derived-steam"] = {
+            "text": "Steam was produced",
+            "truth_value": "IN",
+            "justifications": [{
+                "type": "SL",
+                "antecedents": ["premise-c"],
+                "outlist": [],
+                "label": "",
+            }],
+        }
+        review_results = [
+            {"id": "derived-boil", "valid": False, "comment": "smuggled boiling"},
+            {"id": "derived-steam", "valid": False, "comment": "smuggled steam"},
+        ]
+        extract_resp1 = self._mock_result("Water boils at 100C")
+        match_resp1 = self._mock_result(
+            '{"matched_ids": ["premise-a"], "rationale": "match"}'
+        )
+        extract_resp2 = self._mock_result("Steam is gaseous water")
+        match_resp2 = self._mock_result(
+            '{"matched_ids": ["premise-d"], "rationale": "match"}'
+        )
+        search1 = [
+            {"id": "premise-a", "text": "Water boils at 100C at sea level",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        search2 = [
+            {"id": "premise-d", "text": "Steam is gaseous water",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        call_count = [0]
+        def mock_search(query, **kw):
+            call_count[0] += 1
+            return json.dumps(search1 if call_count[0] == 1 else search2)
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=[
+                 extract_resp1, match_resp1, extract_resp2, match_resp2,
+             ]), \
+             patch("reasons_lib.api.add_justification"):
+            repairs = repair_smuggled_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=mock_search,
+            )
+
+        assert len(repairs) == 2
+        assert repairs[0]["status"] == "repaired"
+        assert repairs[1]["status"] == "repaired"
 
     def test_skips_valid_beliefs(self):
         """Only processes beliefs where valid=False."""


### PR DESCRIPTION
## Summary

- Adds `reasons repair-smuggled` command to automate search-and-link repair for smuggled premises (issue #155)
- Uses two LLM calls per invalid belief: extract the smuggled claim, then match against existing premises via search
- Wires matched premises as new antecedents via `add_justification` (appends alternative support path)
- Accepts either a `--review-file` JSON report or belief IDs to re-review inline

## Test plan

- [x] 29 new tests in `tests/test_repair.py` covering parse functions, mocked LLM calls, orchestration flows, and CLI integration
- [x] Full test suite passes (1105 passed, 166 skipped)
- [ ] Manual test with real beliefs: `reasons review-beliefs --sample 5 -o review.json && reasons repair-smuggled --review-file review.json --dry-run`

Closes #155
