### PR TITLE
Add reasons research command

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2523,7 +2523,8 @@ def research(
         "softened": sum(1 for r in results if r["status"] == "softened"),
         "abandoned": sum(1 for r in results if r["status"] == "abandoned"),
         "failed": sum(1 for r in results if r["status"] in
-                       ("triage_failed", "no_candidates", "no_match", "soften_failed")),
+                       ("triage_failed", "no_candidates", "no_match",
+                        "soften_failed", "extraction_failed")),
         "errors": sum(1 for r in results if r["status"] == "error"),
     }
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2463,6 +2463,71 @@ def repair_smuggled(
     }
 
 
+def research(
+    review_file: str | None = None,
+    belief_ids: list[str] | None = None,
+    model: str = "claude",
+    timeout: int = 300,
+    dry_run: bool = False,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Research flagged beliefs: triage into search-and-link, soften, or abandon.
+
+    Two input modes:
+        review_file: path to a review-beliefs JSON report
+        belief_ids: re-review these beliefs inline, then research invalids
+
+    Returns dict with results list and summary counts.
+    """
+    from .repair import research_beliefs
+
+    if review_file:
+        import json as _json
+        with open(review_file) as f:
+            report = _json.load(f)
+        review_results = report.get("results", [])
+    elif belief_ids:
+        result = review_beliefs(
+            belief_ids=belief_ids, model=model, timeout=timeout,
+            dry_run=True, db_path=db_path,
+        )
+        review_results = result["results"]
+    else:
+        raise ValueError("Provide either review_file or belief_ids")
+
+    invalid = [r for r in review_results if not r.get("valid", True)]
+
+    if not invalid:
+        return {
+            "results": [],
+            "total_invalid": 0,
+            "linked": 0,
+            "softened": 0,
+            "abandoned": 0,
+            "failed": 0,
+            "errors": 0,
+        }
+
+    net = export_network(db_path=db_path)
+    nodes = net.get("nodes", {})
+
+    results = research_beliefs(
+        invalid, nodes, model=model, timeout=timeout,
+        db_path=db_path, dry_run=dry_run,
+    )
+
+    return {
+        "results": results,
+        "total_invalid": len(invalid),
+        "linked": sum(1 for r in results if r["status"] == "linked"),
+        "softened": sum(1 for r in results if r["status"] == "softened"),
+        "abandoned": sum(1 for r in results if r["status"] == "abandoned"),
+        "failed": sum(1 for r in results if r["status"] in
+                       ("triage_failed", "no_candidates", "no_match", "soften_failed")),
+        "errors": sum(1 for r in results if r["status"] == "error"),
+    }
+
+
 def detect_contradictions(
     belief_ids: list[str] | None = None,
     model: str = "claude",

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1466,6 +1466,50 @@ def cmd_repair_smuggled(args):
         print("\n  (dry run -- no changes applied)")
 
 
+def cmd_research(args):
+    _require_sqlite(args, "research")
+
+    model = getattr(args, "model", None) or "claude"
+    review_file = getattr(args, "review_file", None)
+    belief_ids = args.ids if args.ids else None
+
+    if not review_file and not belief_ids:
+        print("Error: provide either --review-file or belief IDs", file=sys.stderr)
+        sys.exit(1)
+
+    result = api.research(
+        review_file=review_file,
+        belief_ids=belief_ids,
+        model=model,
+        timeout=args.timeout,
+        dry_run=args.dry_run,
+        db_path=args.db,
+    )
+
+    for r in result["results"]:
+        status = r["status"].upper()
+        pattern = r.get("pattern") or "?"
+        print(f"  [{status}] {r['id']} ({pattern})")
+        if r.get("rationale"):
+            print(f"    {r['rationale']}")
+        if r.get("smuggled_claim"):
+            print(f"    Smuggled: {r['smuggled_claim']}")
+        if r.get("matched_premises"):
+            print(f"    Linked: {', '.join(r['matched_premises'])}")
+        if r.get("softened_text"):
+            print(f"    Softened: {r['softened_text']}")
+        if r.get("error"):
+            print(f"    Error: {r['error']}")
+
+    print(f"\nTotal invalid: {result['total_invalid']}")
+    print(f"  Linked: {result['linked']}  Softened: {result['softened']}"
+          f"  Abandoned: {result['abandoned']}  Failed: {result['failed']}"
+          f"  Errors: {result['errors']}")
+
+    if args.dry_run:
+        print("\n  (dry run -- no changes applied)")
+
+
 def cmd_contradictions(args):
     _require_sqlite(args, "detect-contradictions")
 
@@ -1935,6 +1979,19 @@ def main():
     p.add_argument("--dry-run", action="store_true",
                    help="Report findings without applying repairs")
 
+    # research
+    p = sub.add_parser("research",
+        help="Research flagged beliefs: search-and-link, soften, or abandon")
+    p.add_argument("ids", nargs="*", help="Belief IDs to research")
+    p.add_argument("--review-file", default=None,
+                   help="Path to review-beliefs JSON report")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude)")
+    p.add_argument("--timeout", type=int, default=300,
+                   help="LLM timeout in seconds (default: 300)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report findings without applying changes")
+
     # contradictions
     p = sub.add_parser("contradictions", help="Detect contradictions between IN beliefs")
     p.add_argument("ids", nargs="*", help="Specific belief IDs to check (default: all IN)")
@@ -2029,6 +2086,7 @@ def main():
         "list-negative": cmd_list_negative,
         "review-beliefs": cmd_review_beliefs,
         "repair-smuggled": cmd_repair_smuggled,
+        "research": cmd_research,
         "contradictions": cmd_contradictions,
         "namespaces": cmd_namespaces,
     }

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -301,7 +301,7 @@ def _do_search_and_link(belief_id, node, nodes, comment, model, timeout,
     claim = extract_smuggled_claim(belief_context, comment,
                                    model=model, timeout=timeout)
     if not claim:
-        return "no_candidates", claim, [], ""
+        return "extraction_failed", claim, [], ""
 
     existing_ants = set()
     for j in node.get("justifications", []):

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -1,12 +1,13 @@
-"""Repair smuggled premises by search-and-link.
+"""Research and repair flagged beliefs.
 
-Given beliefs flagged invalid by review-beliefs (smuggled premise —
-conclusion introduces facts not present in any antecedent), this module:
-1. Extracts the specific smuggled claim via LLM
-2. Searches the belief network for matching premises
-3. Wires found premises as new antecedents via add_justification
+Three patterns for resolving beliefs flagged invalid by review-beliefs:
 
-Requires two LLM calls per invalid belief (extract + match).
+1. Search-and-link — belief is sound but missing an antecedent; find and wire it
+2. Soften — belief overstates the evidence; weaken text to match antecedents
+3. Abandon — dependency tree too broken to repair; retract
+
+The `research_beliefs` orchestrator triages each invalid belief via LLM,
+then executes the appropriate pattern.
 """
 
 import json
@@ -62,6 +63,62 @@ Respond with ONLY a JSON object in this exact format:
 {{"matched_ids": ["premise-id-1", "premise-id-2"], "rationale": "brief explanation"}}
 
 If no match: {{"matched_ids": [], "rationale": "brief explanation"}}"""
+
+TRIAGE_PROMPT = """\
+You are triaging a derived belief that was flagged as invalid in a Truth Maintenance System.
+Your task: decide which repair pattern is most appropriate.
+
+## Invalid belief
+
+{belief_context}
+
+## Review finding
+
+{review_comment}
+
+## Dependency info
+
+- Belief depth: {depth}
+- Flagged ancestors in this batch: {flagged_ancestors}
+
+## Patterns
+
+1. **search_and_link** — The core claim is sound, but the derivation is missing an antecedent
+   that probably exists elsewhere in the network. Choose this when the conclusion is reasonable
+   but the justification chain has a gap that could be filled by finding an existing premise.
+
+2. **soften** — The claim overstates what the antecedents support. The insight is partially
+   valid but the wording is too strong (e.g., "sole mechanism" when evidence only supports
+   "primary mechanism"). Choose this when weakening the text would make it follow from
+   the antecedents.
+
+3. **abandon** — The belief sits atop a broken dependency chain or makes claims too far
+   removed from the evidence to repair. Choose this when neither linking nor softening
+   can make the derivation sound.
+
+Respond with ONLY a JSON object:
+{{"pattern": "search_and_link" | "soften" | "abandon", "rationale": "brief explanation"}}"""
+
+SOFTEN_PROMPT = """\
+You are rewriting a derived belief to match what its antecedents actually support.
+The original belief was flagged as invalid because it overstates the evidence.
+
+## Original belief
+
+{belief_text}
+
+## Antecedents (the evidence)
+
+{antecedents}
+
+Rewrite the belief so it follows strictly from the antecedents. Weaken any absolute claims
+to qualified ones (e.g., "the mechanism" -> "a primary mechanism", "ensures" -> "supports").
+Preserve the core insight but remove unsupported specificity.
+
+Respond with ONLY a JSON object:
+{{"softened_text": "the rewritten claim", "rationale": "what was weakened and why"}}"""
+
+VALID_PATTERNS = {"search_and_link", "soften", "abandon"}
 
 
 def parse_extract_response(response):
@@ -136,6 +193,278 @@ def find_matching_premises(smuggled_claim, candidates, model="claude",
     response = invoke_model(prompt, model=model, timeout=timeout)
     valid_ids = {c["id"] for c in candidates}
     return parse_match_response(response, valid_ids)
+
+
+def parse_triage_response(response):
+    """Extract triage result JSON from LLM response."""
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(response):
+        if ch != "{":
+            continue
+        try:
+            obj, _ = decoder.raw_decode(response, i)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        pattern = obj.get("pattern", "")
+        if pattern not in VALID_PATTERNS:
+            continue
+        return {
+            "pattern": pattern,
+            "rationale": obj.get("rationale", ""),
+        }
+    return {"pattern": "", "rationale": ""}
+
+
+def parse_soften_response(response):
+    """Extract softened text JSON from LLM response."""
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(response):
+        if ch != "{":
+            continue
+        try:
+            obj, _ = decoder.raw_decode(response, i)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        text = obj.get("softened_text", "")
+        if text:
+            return {
+                "softened_text": text,
+                "rationale": obj.get("rationale", ""),
+            }
+    return {"softened_text": "", "rationale": ""}
+
+
+def triage_belief(belief_context, review_comment, depth=0,
+                  flagged_ancestors=0, model="claude", timeout=300):
+    """LLM call: triage an invalid belief into a repair pattern."""
+    prompt = TRIAGE_PROMPT.format(
+        belief_context=belief_context,
+        review_comment=review_comment,
+        depth=depth,
+        flagged_ancestors=flagged_ancestors,
+    )
+    response = invoke_model(prompt, model=model, timeout=timeout)
+    return parse_triage_response(response)
+
+
+def soften_belief(belief_text, antecedents_text, model="claude", timeout=300):
+    """LLM call: produce a softened version of an overstated belief."""
+    prompt = SOFTEN_PROMPT.format(
+        belief_text=belief_text,
+        antecedents=antecedents_text,
+    )
+    response = invoke_model(prompt, model=model, timeout=timeout)
+    return parse_soften_response(response)
+
+
+def _compute_depth(node_id, nodes, memo=None):
+    """Compute derivation depth: 0 for premises, max(antecedent depths)+1."""
+    if memo is None:
+        memo = {}
+    if node_id in memo:
+        return memo[node_id]
+    node = nodes.get(node_id)
+    if not node or not node.get("justifications"):
+        memo[node_id] = 0
+        return 0
+    memo[node_id] = 0
+    max_d = 0
+    for j in node["justifications"]:
+        for a in j.get("antecedents", []):
+            max_d = max(max_d, _compute_depth(a, nodes, memo))
+    memo[node_id] = max_d + 1
+    return max_d + 1
+
+
+def _format_antecedents(node, nodes):
+    """Format antecedent texts for soften prompt."""
+    lines = []
+    for j in node.get("justifications", []):
+        for ant_id in j.get("antecedents", []):
+            ant = nodes.get(ant_id)
+            if ant:
+                lines.append(f"- {ant_id}: {ant.get('text', '')}")
+    return "\n".join(lines) if lines else "(no antecedents)"
+
+
+def _do_search_and_link(belief_id, node, nodes, comment, model, timeout,
+                        db_path, dry_run, search_fn):
+    """Execute Pattern 1: search-and-link for a single belief."""
+    from . import api
+
+    belief_context = format_belief_for_review(belief_id, nodes)
+
+    claim = extract_smuggled_claim(belief_context, comment,
+                                   model=model, timeout=timeout)
+    if not claim:
+        return "no_candidates", claim, [], ""
+
+    existing_ants = set()
+    for j in node.get("justifications", []):
+        existing_ants.update(j.get("antecedents", []))
+
+    raw = search_fn(claim, format="json", db_path=db_path)
+    try:
+        search_results = json.loads(raw) if isinstance(raw, str) else raw
+    except (json.JSONDecodeError, TypeError):
+        search_results = []
+
+    candidates = []
+    for sr in search_results:
+        sid = sr.get("id", "")
+        if sid == belief_id or sid in existing_ants:
+            continue
+        if sr.get("truth_value") != "IN":
+            continue
+        sr_node = nodes.get(sid)
+        if sr_node and sr_node.get("justifications"):
+            continue
+        candidates.append({"id": sid, "text": sr.get("text", "")})
+
+    if not candidates:
+        return "no_candidates", claim, [], ""
+
+    match = find_matching_premises(claim, candidates,
+                                   model=model, timeout=timeout)
+    matched_ids = match.get("matched_ids", [])
+
+    if not matched_ids:
+        return "no_match", claim, [], match.get("rationale", "")
+
+    if not dry_run:
+        first_just = node.get("justifications", [{}])[0]
+        original_ants = first_just.get("antecedents", [])
+        original_outlist = first_just.get("outlist", [])
+        new_ants = list(original_ants) + matched_ids
+        api.add_justification(
+            belief_id,
+            sl=",".join(new_ants),
+            unless=",".join(original_outlist) if original_outlist else "",
+            label=f"research: linked {claim[:50]}",
+            db_path=db_path,
+        )
+
+    return "linked", claim, matched_ids, match.get("rationale", "")
+
+
+def research_beliefs(review_results, nodes, model="claude",
+                     timeout=300, db_path=None, dry_run=False,
+                     search_fn=None):
+    """Orchestrate triage and repair for invalid beliefs.
+
+    Triages each invalid belief into search_and_link, soften, or abandon,
+    then executes the appropriate pattern.
+
+    Returns list of research result dicts.
+    """
+    from . import api
+
+    if search_fn is None:
+        search_fn = lambda query, **kw: api.search(query, **kw)
+
+    invalid = [r for r in review_results if not r.get("valid", True)]
+    invalid_ids = {r["id"] for r in invalid}
+    depth_memo = {}
+    results = []
+
+    for r in invalid:
+        belief_id = r["id"]
+        result = {
+            "id": belief_id,
+            "pattern": None,
+            "status": "error",
+            "rationale": None,
+            "smuggled_claim": None,
+            "matched_premises": [],
+            "softened_text": None,
+            "error": None,
+        }
+
+        try:
+            node = nodes.get(belief_id)
+            if not node:
+                result["error"] = "belief not found in network"
+                results.append(result)
+                continue
+
+            belief_context = format_belief_for_review(belief_id, nodes)
+            comment = r.get("comment", "")
+            depth = _compute_depth(belief_id, nodes, depth_memo)
+
+            flagged_ancestors = 0
+            for j in node.get("justifications", []):
+                for ant_id in j.get("antecedents", []):
+                    if ant_id in invalid_ids:
+                        flagged_ancestors += 1
+
+            print(f"  Triaging {belief_id} (depth={depth})...",
+                  file=sys.stderr)
+            triage = triage_belief(belief_context, comment,
+                                   depth=depth,
+                                   flagged_ancestors=flagged_ancestors,
+                                   model=model, timeout=timeout)
+            pattern = triage.get("pattern", "")
+            result["pattern"] = pattern
+            result["rationale"] = triage.get("rationale", "")
+
+            if not pattern:
+                result["status"] = "triage_failed"
+                results.append(result)
+                continue
+
+            if pattern == "search_and_link":
+                print(f"  Pattern: search-and-link for {belief_id}...",
+                      file=sys.stderr)
+                status, claim, matched, rationale = _do_search_and_link(
+                    belief_id, node, nodes, comment, model, timeout,
+                    db_path, dry_run, search_fn,
+                )
+                result["status"] = status
+                result["smuggled_claim"] = claim
+                result["matched_premises"] = matched
+                if rationale:
+                    result["rationale"] = rationale
+
+            elif pattern == "soften":
+                print(f"  Pattern: soften for {belief_id}...",
+                      file=sys.stderr)
+                ant_text = _format_antecedents(node, nodes)
+                soften_result = soften_belief(
+                    node.get("text", ""), ant_text,
+                    model=model, timeout=timeout,
+                )
+                softened = soften_result.get("softened_text", "")
+                if not softened:
+                    result["status"] = "soften_failed"
+                    results.append(result)
+                    continue
+                result["softened_text"] = softened
+                result["rationale"] = soften_result.get("rationale", "")
+                if not dry_run:
+                    api.update_node(belief_id, text=softened, db_path=db_path)
+                result["status"] = "softened"
+
+            elif pattern == "abandon":
+                print(f"  Pattern: abandon for {belief_id}...",
+                      file=sys.stderr)
+                if not dry_run:
+                    api.retract_node(
+                        belief_id,
+                        reason=f"research: abandoned — {triage.get('rationale', '')}",
+                        db_path=db_path,
+                    )
+                result["status"] = "abandoned"
+
+        except Exception as exc:
+            result["error"] = str(exc)
+
+        results.append(result)
+
+    return results
 
 
 def repair_smuggled_beliefs(review_results, nodes, model="claude",

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -384,6 +384,26 @@ class TestResearchBeliefs:
         assert results[0]["status"] == "error"
         assert "not found" in results[0]["error"]
 
+    def test_search_and_link_extraction_failed(self):
+        """When extract returns empty, status should be extraction_failed."""
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "smuggled",
+        }]
+        triage_resp = _mock_result('{"pattern": "search_and_link", "rationale": "gap"}')
+        extract_resp = _mock_result("   ")
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp, extract_resp]):
+            results = research_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=_mock_search([]),
+            )
+
+        assert results[0]["status"] == "extraction_failed"
+        assert results[0]["pattern"] == "search_and_link"
+
     def test_skips_valid_beliefs(self):
         nodes = _make_nodes()
         review_results = [
@@ -396,6 +416,60 @@ class TestResearchBeliefs:
         )
 
         assert len(results) == 0
+
+
+# --- API wrapper ---
+
+class TestApiResearch:
+    def test_from_belief_ids(self, tmp_path):
+        """Test the belief_ids input path through api.research."""
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("derived-a", "A extended", sl="premise-a", db_path=db)
+
+        review_resp = _mock_result(json.dumps([{
+            "id": "derived-a", "valid": False, "sufficient": True,
+            "necessary": True, "unnecessary_antecedents": [],
+            "comment": "overstated",
+        }]))
+        triage_resp = _mock_result('{"pattern": "abandon", "rationale": "broken"}')
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[review_resp, triage_resp]):
+            result = api.research(
+                belief_ids=["derived-a"],
+                model="claude",
+                dry_run=True,
+                db_path=db,
+            )
+
+        assert result["total_invalid"] == 1
+        assert result["abandoned"] == 1
+        assert len(result["results"]) == 1
+
+    def test_no_invalid(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A", db_path=db)
+        api.add_node("derived-a", "A ext", sl="premise-a", db_path=db)
+
+        review_resp = _mock_result(json.dumps([{
+            "id": "derived-a", "valid": True, "sufficient": True,
+            "necessary": True, "unnecessary_antecedents": [],
+            "comment": "fine",
+        }]))
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[review_resp]):
+            result = api.research(
+                belief_ids=["derived-a"],
+                model="claude",
+                db_path=db,
+            )
+
+        assert result["total_invalid"] == 0
+        assert result["results"] == []
 
 
 # --- CLI ---

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -1,0 +1,475 @@
+"""Tests for the research module (triage + soften + abandon)."""
+
+import json
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib.repair import (
+    parse_triage_response,
+    parse_soften_response,
+    triage_belief,
+    soften_belief,
+    research_beliefs,
+    _compute_depth,
+)
+from reasons_lib import api
+from reasons_lib.cli import main
+
+
+def run_cli(*args, db_path=None):
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+        except SystemExit as e:
+            return stdout.getvalue(), stderr.getvalue(), e.code
+    return stdout.getvalue(), stderr.getvalue(), 0
+
+
+def _make_nodes():
+    return {
+        "premise-a": {
+            "text": "Water boils at 100C at sea level",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "premise-b": {
+            "text": "The experiment was conducted at sea level",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "premise-c": {
+            "text": "The sample reached 100C",
+            "truth_value": "IN",
+            "justifications": [],
+        },
+        "derived-boil": {
+            "text": "The water in the sample boiled, releasing steam",
+            "truth_value": "IN",
+            "justifications": [{
+                "type": "SL",
+                "antecedents": ["premise-b", "premise-c"],
+                "outlist": [],
+                "label": "",
+            }],
+        },
+    }
+
+
+def _mock_result(stdout):
+    return type("R", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+
+
+def _mock_search(results):
+    return lambda query, **kw: json.dumps(results)
+
+
+# --- parse_triage_response ---
+
+class TestParseTriageResponse:
+    def test_valid_search_and_link(self):
+        resp = '{"pattern": "search_and_link", "rationale": "missing antecedent"}'
+        result = parse_triage_response(resp)
+        assert result["pattern"] == "search_and_link"
+        assert result["rationale"] == "missing antecedent"
+
+    def test_valid_soften(self):
+        resp = '{"pattern": "soften", "rationale": "overstated"}'
+        result = parse_triage_response(resp)
+        assert result["pattern"] == "soften"
+
+    def test_valid_abandon(self):
+        resp = '{"pattern": "abandon", "rationale": "too broken"}'
+        result = parse_triage_response(resp)
+        assert result["pattern"] == "abandon"
+
+    def test_invalid_pattern_ignored(self):
+        resp = '{"pattern": "unknown", "rationale": "hmm"}'
+        result = parse_triage_response(resp)
+        assert result["pattern"] == ""
+
+    def test_json_in_prose(self):
+        resp = 'I think:\n{"pattern": "soften", "rationale": "x"}\nDone.'
+        result = parse_triage_response(resp)
+        assert result["pattern"] == "soften"
+
+    def test_malformed(self):
+        result = parse_triage_response("no json here")
+        assert result["pattern"] == ""
+
+
+# --- parse_soften_response ---
+
+class TestParseSoftenResponse:
+    def test_valid(self):
+        resp = '{"softened_text": "weaker claim", "rationale": "removed absolute"}'
+        result = parse_soften_response(resp)
+        assert result["softened_text"] == "weaker claim"
+        assert result["rationale"] == "removed absolute"
+
+    def test_empty_text(self):
+        resp = '{"softened_text": "", "rationale": "nothing"}'
+        result = parse_soften_response(resp)
+        assert result["softened_text"] == ""
+
+    def test_malformed(self):
+        result = parse_soften_response("not json")
+        assert result["softened_text"] == ""
+
+    def test_json_in_prose(self):
+        resp = 'Here: {"softened_text": "x", "rationale": "y"} done'
+        result = parse_soften_response(resp)
+        assert result["softened_text"] == "x"
+
+
+# --- _compute_depth ---
+
+class TestComputeDepth:
+    def test_premise_depth_zero(self):
+        nodes = _make_nodes()
+        assert _compute_depth("premise-a", nodes) == 0
+
+    def test_derived_depth_one(self):
+        nodes = _make_nodes()
+        assert _compute_depth("derived-boil", nodes) == 1
+
+    def test_deep_chain(self):
+        nodes = _make_nodes()
+        nodes["derived-deep"] = {
+            "text": "deep",
+            "truth_value": "IN",
+            "justifications": [{
+                "type": "SL",
+                "antecedents": ["derived-boil"],
+                "outlist": [],
+                "label": "",
+            }],
+        }
+        assert _compute_depth("derived-deep", nodes) == 2
+
+    def test_missing_node(self):
+        assert _compute_depth("nonexistent", {}) == 0
+
+
+# --- triage_belief ---
+
+class TestTriageBelief:
+    def test_returns_pattern(self):
+        resp = _mock_result('{"pattern": "soften", "rationale": "overstated"}')
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=resp):
+            result = triage_belief("belief context", "review comment",
+                                   depth=3, flagged_ancestors=1)
+        assert result["pattern"] == "soften"
+
+    def test_prompt_includes_depth(self):
+        resp = _mock_result('{"pattern": "abandon", "rationale": "x"}')
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=resp) as mock_run:
+            triage_belief("ctx", "cmt", depth=5, flagged_ancestors=3)
+            prompt_sent = mock_run.call_args[1].get("input", "")
+            assert "5" in prompt_sent
+            assert "3" in prompt_sent
+
+
+# --- soften_belief ---
+
+class TestSoftenBelief:
+    def test_returns_softened_text(self):
+        resp = _mock_result('{"softened_text": "weaker", "rationale": "toned down"}')
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=resp):
+            result = soften_belief("strong claim", "- ant: evidence")
+        assert result["softened_text"] == "weaker"
+
+
+# --- research_beliefs ---
+
+class TestResearchBeliefs:
+    def test_search_and_link(self):
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False,
+            "comment": "missing antecedent",
+        }]
+        search_results = [
+            {"id": "premise-a", "text": "Water boils at 100C at sea level",
+             "truth_value": "IN", "source": "", "match": True},
+        ]
+        triage_resp = _mock_result('{"pattern": "search_and_link", "rationale": "gap"}')
+        extract_resp = _mock_result("Water boils at 100C")
+        match_resp = _mock_result(
+            '{"matched_ids": ["premise-a"], "rationale": "match"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp, extract_resp, match_resp]), \
+             patch("reasons_lib.api.add_justification"):
+            results = research_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=_mock_search(search_results),
+            )
+
+        assert len(results) == 1
+        assert results[0]["pattern"] == "search_and_link"
+        assert results[0]["status"] == "linked"
+        assert results[0]["matched_premises"] == ["premise-a"]
+
+    def test_soften(self):
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "overstated",
+        }]
+        triage_resp = _mock_result('{"pattern": "soften", "rationale": "too strong"}')
+        soften_resp = _mock_result(
+            '{"softened_text": "The water likely boiled", "rationale": "weakened"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp, soften_resp]), \
+             patch("reasons_lib.api.update_node") as mock_update:
+            results = research_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=_mock_search([]),
+            )
+
+        assert results[0]["pattern"] == "soften"
+        assert results[0]["status"] == "softened"
+        assert results[0]["softened_text"] == "The water likely boiled"
+        mock_update.assert_called_once_with(
+            "derived-boil", text="The water likely boiled", db_path="test.db",
+        )
+
+    def test_abandon(self):
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "broken chain",
+        }]
+        triage_resp = _mock_result('{"pattern": "abandon", "rationale": "too deep"}')
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp]), \
+             patch("reasons_lib.api.retract_node") as mock_retract:
+            results = research_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=_mock_search([]),
+            )
+
+        assert results[0]["pattern"] == "abandon"
+        assert results[0]["status"] == "abandoned"
+        mock_retract.assert_called_once()
+        assert "abandoned" in mock_retract.call_args[1]["reason"]
+
+    def test_triage_failed(self):
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "unclear",
+        }]
+        triage_resp = _mock_result("I cannot decide")
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp]):
+            results = research_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=_mock_search([]),
+            )
+
+        assert results[0]["status"] == "triage_failed"
+
+    def test_soften_failed(self):
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "overstated",
+        }]
+        triage_resp = _mock_result('{"pattern": "soften", "rationale": "x"}')
+        soften_resp = _mock_result('{"softened_text": "", "rationale": "cant"}')
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp, soften_resp]):
+            results = research_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=_mock_search([]),
+            )
+
+        assert results[0]["status"] == "soften_failed"
+
+    def test_dry_run_no_mutations(self):
+        nodes = _make_nodes()
+        review_results = [
+            {"id": "derived-boil", "valid": False, "comment": "overstated"},
+        ]
+        triage_resp = _mock_result('{"pattern": "soften", "rationale": "x"}')
+        soften_resp = _mock_result(
+            '{"softened_text": "weaker", "rationale": "y"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp, soften_resp]), \
+             patch("reasons_lib.api.update_node") as mock_update, \
+             patch("reasons_lib.api.retract_node") as mock_retract, \
+             patch("reasons_lib.api.add_justification") as mock_add:
+            results = research_beliefs(
+                review_results, nodes, db_path="test.db", dry_run=True,
+                search_fn=_mock_search([]),
+            )
+
+        assert results[0]["status"] == "softened"
+        mock_update.assert_not_called()
+        mock_retract.assert_not_called()
+        mock_add.assert_not_called()
+
+    def test_multiple_beliefs_different_patterns(self):
+        nodes = _make_nodes()
+        nodes["premise-d"] = {
+            "text": "Extra evidence", "truth_value": "IN", "justifications": [],
+        }
+        nodes["derived-steam"] = {
+            "text": "Steam was produced for sure",
+            "truth_value": "IN",
+            "justifications": [{
+                "type": "SL",
+                "antecedents": ["premise-c"],
+                "outlist": [],
+                "label": "",
+            }],
+        }
+        review_results = [
+            {"id": "derived-boil", "valid": False, "comment": "overstated"},
+            {"id": "derived-steam", "valid": False, "comment": "broken"},
+        ]
+        triage1 = _mock_result('{"pattern": "soften", "rationale": "x"}')
+        soften1 = _mock_result('{"softened_text": "weaker", "rationale": "y"}')
+        triage2 = _mock_result('{"pattern": "abandon", "rationale": "z"}')
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage1, soften1, triage2]), \
+             patch("reasons_lib.api.update_node"), \
+             patch("reasons_lib.api.retract_node"):
+            results = research_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=_mock_search([]),
+            )
+
+        assert len(results) == 2
+        assert results[0]["status"] == "softened"
+        assert results[1]["status"] == "abandoned"
+
+    def test_belief_not_found(self):
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "nonexistent", "valid": False, "comment": "x",
+        }]
+
+        results = research_beliefs(
+            review_results, nodes, db_path="test.db",
+            search_fn=_mock_search([]),
+        )
+
+        assert results[0]["status"] == "error"
+        assert "not found" in results[0]["error"]
+
+    def test_skips_valid_beliefs(self):
+        nodes = _make_nodes()
+        review_results = [
+            {"id": "derived-boil", "valid": True, "comment": "fine"},
+        ]
+
+        results = research_beliefs(
+            review_results, nodes, db_path="test.db",
+            search_fn=_mock_search([]),
+        )
+
+        assert len(results) == 0
+
+
+# --- CLI ---
+
+class TestCmdResearch:
+    def test_help(self):
+        stdout, stderr, code = run_cli("research", "--help")
+        assert code == 0
+        assert "research" in stdout.lower()
+
+    def test_no_args_error(self):
+        stdout, stderr, code = run_cli("research", db_path="test.db")
+        assert code == 1
+
+    def test_from_review_file(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("derived-a", "A extended", sl="premise-a", db_path=db)
+
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps({
+            "results": [{
+                "id": "derived-a",
+                "valid": False,
+                "comment": "overstated",
+            }],
+        }))
+
+        triage_resp = _mock_result('{"pattern": "soften", "rationale": "x"}')
+        soften_resp = _mock_result(
+            '{"softened_text": "A weakly extended", "rationale": "weakened"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp, soften_resp]):
+            stdout, stderr, code = run_cli(
+                "research",
+                "--review-file", str(review_file),
+                db_path=db,
+            )
+
+        assert code == 0
+        assert "SOFTENED" in stdout
+
+    def test_dry_run(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("derived-a", "A extended", sl="premise-a", db_path=db)
+
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps({
+            "results": [{
+                "id": "derived-a",
+                "valid": False,
+                "comment": "broken",
+            }],
+        }))
+
+        triage_resp = _mock_result('{"pattern": "abandon", "rationale": "x"}')
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp]):
+            stdout, stderr, code = run_cli(
+                "research",
+                "--review-file", str(review_file),
+                "--dry-run",
+                db_path=db,
+            )
+
+        assert code == 0
+        assert "ABANDONED" in stdout
+        assert "dry run" in stdout.lower()
+
+        node = api.show_node("derived-a", db_path=db)
+        assert node["truth_value"] == "IN"

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -448,6 +448,39 @@ class TestApiResearch:
         assert result["abandoned"] == 1
         assert len(result["results"]) == 1
 
+    def test_counts_add_up(self, tmp_path):
+        """Verify total_invalid == linked + softened + abandoned + failed + errors."""
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A", db_path=db)
+        api.add_node("derived-a", "A ext", sl="premise-a", db_path=db)
+
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps({
+            "results": [{
+                "id": "derived-a", "valid": False, "comment": "smuggled",
+            }],
+        }))
+
+        triage_resp = _mock_result(
+            '{"pattern": "search_and_link", "rationale": "gap"}'
+        )
+        extract_resp = _mock_result("   ")
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp, extract_resp]):
+            result = api.research(
+                review_file=str(review_file),
+                model="claude",
+                dry_run=True,
+                db_path=db,
+            )
+
+        total = (result["linked"] + result["softened"] + result["abandoned"]
+                 + result["failed"] + result["errors"])
+        assert total == result["total_invalid"]
+        assert result["failed"] == 1
+
     def test_no_invalid(self, tmp_path):
         db = str(tmp_path / "test.db")
         api.add_node("premise-a", "A", db_path=db)


### PR DESCRIPTION
## Summary

- Adds `reasons research` command that auto-triages invalid beliefs into three patterns:
  - **Search-and-link** (Pattern 1): reuses `repair-smuggled` to find missing antecedents
  - **Soften** (Pattern 2): LLM rewrites overstated claims to match evidence, applies via `update_node`
  - **Abandon** (Pattern 3): retracts irreparable beliefs via `retract_node`
- LLM triage call selects the appropriate pattern per belief based on review comment, depth, and flagged ancestors
- Accepts `--review-file` (JSON report) or belief IDs as input
- Builds on PR #163 (`repair-smuggled`) which implemented Pattern 1

## Test plan

- [x] 30 new tests in `tests/test_research.py` covering triage/soften parsers, depth computation, all three patterns, failure modes, dry run, and CLI integration
- [x] Full test suite passes (1137 passed, 166 skipped)
- [ ] Manual: `reasons review-beliefs --sample 5 && reasons research --review-file reviews/report.json --dry-run`

Closes #145

