### PR TITLE
Add --example flag to add, update, and show commands

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -199,7 +199,8 @@ def add_node(
         return _pg_dispatch(pg_conninfo, project_id, "add_node",
                             node_id=node_id, text=text, sl=sl, cp=cp, unless=unless,
                             label=label, source=source, source_url=source_url,
-                            access_tags=access_tags, namespace=namespace)
+                            access_tags=access_tags, namespace=namespace,
+                            example=example)
     outlist = [o.strip() for o in unless.split(",") if o.strip()] if unless else []
     justifications = []
     if sl:
@@ -253,7 +254,7 @@ def add_node(
         metadata = {}
         if access_tags:
             metadata["access_tags"] = sorted(set(access_tags))
-        if example:
+        if example is not None:
             metadata["example"] = example
 
         node = net.add_node(
@@ -772,7 +773,7 @@ def update_node(
     if pg_conninfo:
         return _pg_dispatch(pg_conninfo, project_id, "update_node",
                             node_id=node_id, text=text, source=source,
-                            source_url=source_url)
+                            source_url=source_url, example=example)
     with _with_network(db_path, write=True) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -172,6 +172,7 @@ def add_node(
     namespace: str | None = None,
     any_mode: bool = False,
     access_tags: list[str] | None = None,
+    example: str | None = None,
     db_path: str = DEFAULT_DB,
     pg_conninfo=None, project_id=None,
 ) -> dict:
@@ -252,6 +253,8 @@ def add_node(
         metadata = {}
         if access_tags:
             metadata["access_tags"] = sorted(set(access_tags))
+        if example:
+            metadata["example"] = example
 
         node = net.add_node(
             id=node_id,
@@ -758,10 +761,11 @@ def update_node(
     text: str | None = None,
     source: str | None = None,
     source_url: str | None = None,
+    example: str | None = None,
     db_path: str = DEFAULT_DB,
     pg_conninfo=None, project_id=None,
 ) -> dict:
-    """Update a node's text, source, or source_url in place.
+    """Update a node's text, source, source_url, or example in place.
 
     Returns: {"node_id": str, "updated_fields": list[str]}
     """
@@ -783,6 +787,11 @@ def update_node(
         if source_url is not None:
             node.source_url = source_url
             updated.append("source_url")
+        if example is not None:
+            meta = node.metadata or {}
+            meta["example"] = example
+            node.metadata = meta
+            updated.append("example")
         return {"node_id": node_id, "updated_fields": updated}
 
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -276,7 +276,8 @@ def cmd_show(args):
         print(f"\nRetract reason: {node['metadata']['retract_reason']}")
 
     if node["metadata"].get("example"):
-        print(f"\nExample:\n  {node['metadata']['example']}")
+        indented = node["metadata"]["example"].replace("\n", "\n  ")
+        print(f"\nExample:\n  {indented}")
 
     if node["dependents"]:
         print(f"\nDependents: {', '.join(node['dependents'])}")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -56,6 +56,7 @@ def cmd_add(args):
             namespace=getattr(args, "namespace", None),
             any_mode=getattr(args, "any", False),
             access_tags=access_tags,
+            example=getattr(args, "example", None),
             **_backend_kwargs(args),
         )
         print(f"Added {result['node_id']} [{result['truth_value']}] ({result['type']})")
@@ -274,6 +275,9 @@ def cmd_show(args):
     if node["metadata"].get("retract_reason"):
         print(f"\nRetract reason: {node['metadata']['retract_reason']}")
 
+    if node["metadata"].get("example"):
+        print(f"\nExample:\n  {node['metadata']['example']}")
+
     if node["dependents"]:
         print(f"\nDependents: {', '.join(node['dependents'])}")
 
@@ -347,8 +351,8 @@ def cmd_supersede(args):
 
 
 def cmd_update(args):
-    if not any([args.text, args.source, args.source_url]):
-        print("Error: at least one of --text, --source, or --source-url required",
+    if not any([args.text, args.source, args.source_url, args.example]):
+        print("Error: at least one of --text, --source, --source-url, or --example required",
               file=sys.stderr)
         sys.exit(1)
     try:
@@ -356,6 +360,7 @@ def cmd_update(args):
             args.node_id, text=args.text,
             source=args.source,
             source_url=args.source_url,
+            example=args.example,
             **_backend_kwargs(args),
         )
     except KeyError as e:
@@ -1618,6 +1623,7 @@ def main():
     p.add_argument("--source-url", help="URL for the source document")
     p.add_argument("-n", "--namespace", help="Namespace prefix (auto-creates ns:active premise)")
     p.add_argument("--access-tags", metavar="TAG,TAG", help="Data source provenance tags (comma-separated)")
+    p.add_argument("--example", default=None, help="Code example demonstrating the belief")
 
     # add-justification
     p = sub.add_parser("add-justification", help="Add a justification to an existing node")
@@ -1684,6 +1690,7 @@ def main():
     p.add_argument("--text", default=None, help="New text for the belief")
     p.add_argument("--source", default=None, help="Update source path")
     p.add_argument("--source-url", default=None, help="Update source URL")
+    p.add_argument("--example", default=None, help="Code example demonstrating the belief")
 
     # challenge
     p = sub.add_parser("challenge", help="Challenge a node — target goes OUT")

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1425,11 +1425,10 @@ class PgApi:
                 raise KeyError(f"Node '{node_id}' not found")
 
             if example is not None:
-                import json as _json
-                meta = _json.loads(row[1]) if row[1] else {}
+                meta = json.loads(row[1]) if row[1] else {}
                 meta["example"] = example
                 updates.append("metadata_json = %s")
-                params.append(_json.dumps(meta))
+                params.append(json.dumps(meta))
                 updated_fields.append("example")
 
             if not updates:

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -198,11 +198,13 @@ class PgApi:
 
     def add_node(self, node_id, text, sl="", cp="", unless="", label="",
                  source="", source_url="", access_tags=None,
-                 namespace=None):
+                 namespace=None, example=None):
         pid = self.project_id
         metadata = {}
         if access_tags:
             metadata["access_tags"] = sorted(access_tags)
+        if example is not None:
+            metadata["example"] = example
 
         if namespace:
             if ":" not in node_id:
@@ -1393,7 +1395,8 @@ class PgApi:
             "changed": changed,
         }
 
-    def update_node(self, node_id, text=None, source=None, source_url=None):
+    def update_node(self, node_id, text=None, source=None, source_url=None,
+                    example=None):
         pid = self.project_id
         updates = []
         params = []
@@ -1412,16 +1415,25 @@ class PgApi:
             params.append(source_url)
             updated_fields.append("source_url")
 
-        if not updates:
-            return {"node_id": node_id, "updated_fields": []}
-
         with self.conn.cursor() as cur:
             cur.execute(
-                "SELECT id FROM rms_nodes WHERE id = %s AND project_id = %s",
+                "SELECT id, metadata_json FROM rms_nodes WHERE id = %s AND project_id = %s",
                 (node_id, pid),
             )
-            if not cur.fetchone():
+            row = cur.fetchone()
+            if not row:
                 raise KeyError(f"Node '{node_id}' not found")
+
+            if example is not None:
+                import json as _json
+                meta = _json.loads(row[1]) if row[1] else {}
+                meta["example"] = example
+                updates.append("metadata_json = %s")
+                params.append(_json.dumps(meta))
+                updated_fields.append("example")
+
+            if not updates:
+                return {"node_id": node_id, "updated_fields": []}
 
             params.extend([node_id, pid])
             cur.execute(

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -132,6 +132,29 @@ class TestCmdShowExample:
         assert "Example:" in stdout
         assert "x = func()" in stdout
 
+    def test_show_multiline_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        code_snippet = "x = 1\ny = 2\nprint(x + y)"
+        api.add_node("n1", "A belief", example=code_snippet, db_path=db)
+        stdout, stderr, code = run_cli("show", "n1", db_path=db)
+        assert code == 0
+        lines = stdout.split("\n")
+        example_lines = []
+        capture = False
+        for line in lines:
+            if line.strip().startswith("Example:"):
+                capture = True
+                continue
+            if capture:
+                if line.startswith("  "):
+                    example_lines.append(line)
+                elif line.strip() == "":
+                    continue
+                else:
+                    break
+        assert len(example_lines) == 3
+        assert all(line.startswith("  ") for line in example_lines)
+
     def test_show_no_example(self, tmp_path):
         db = str(tmp_path / "test.db")
         api.add_node("n1", "A belief", db_path=db)

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,140 @@
+"""Tests for the --example flag on add, update, and show commands."""
+
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib import api
+
+
+def run_cli(*args, db_path=None):
+    from reasons_lib.cli import main
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+            code = 0
+        except SystemExit as e:
+            code = e.code if e.code is not None else 0
+    return stdout.getvalue(), stderr.getvalue(), code
+
+
+class TestAddNodeExample:
+    def test_add_with_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        result = api.add_node("n1", "Node one", example="x = 1 + 2", db_path=db)
+        assert result["node_id"] == "n1"
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["example"] == "x = 1 + 2"
+
+    def test_add_without_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("n1", "Node one", db_path=db)
+        node = api.show_node("n1", db_path=db)
+        assert "example" not in node["metadata"]
+
+    def test_add_example_with_access_tags(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("n1", "Node one", example="print('hi')",
+                     access_tags=["tag1"], db_path=db)
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["example"] == "print('hi')"
+        assert node["metadata"]["access_tags"] == ["tag1"]
+
+
+class TestUpdateNodeExample:
+    def test_update_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("n1", "Node one", db_path=db)
+        result = api.update_node("n1", example="y = 2", db_path=db)
+        assert "example" in result["updated_fields"]
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["example"] == "y = 2"
+
+    def test_update_replaces_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("n1", "Node one", example="old code", db_path=db)
+        api.update_node("n1", example="new code", db_path=db)
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["example"] == "new code"
+
+    def test_update_example_only(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("n1", "Original text", db_path=db)
+        api.update_node("n1", example="z = 3", db_path=db)
+        node = api.show_node("n1", db_path=db)
+        assert node["text"] == "Original text"
+        assert node["metadata"]["example"] == "z = 3"
+
+    def test_update_example_preserves_other_metadata(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("n1", "Node one", access_tags=["internal"], db_path=db)
+        api.update_node("n1", example="code()", db_path=db)
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["access_tags"] == ["internal"]
+        assert node["metadata"]["example"] == "code()"
+
+
+class TestCmdAddExample:
+    def test_cli_add_with_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        stdout, stderr, code = run_cli(
+            "add", "n1", "A belief", "--example", "reasons add n1 'A belief'",
+            db_path=db,
+        )
+        assert code == 0
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["example"] == "reasons add n1 'A belief'"
+
+    def test_cli_add_without_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        stdout, stderr, code = run_cli("add", "n1", "A belief", db_path=db)
+        assert code == 0
+        node = api.show_node("n1", db_path=db)
+        assert "example" not in node["metadata"]
+
+
+class TestCmdUpdateExample:
+    def test_cli_update_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        run_cli("add", "n1", "A belief", db_path=db)
+        stdout, stderr, code = run_cli(
+            "update", "n1", "--example", "reasons update n1 --text 'new'",
+            db_path=db,
+        )
+        assert code == 0
+        assert "example" in stdout
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["example"] == "reasons update n1 --text 'new'"
+
+    def test_cli_update_no_flags_error(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        run_cli("add", "n1", "A belief", db_path=db)
+        stdout, stderr, code = run_cli("update", "n1", db_path=db)
+        assert code == 1
+        assert "--example" in stderr
+
+
+class TestCmdShowExample:
+    def test_show_displays_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("n1", "A belief", example="x = func()", db_path=db)
+        stdout, stderr, code = run_cli("show", "n1", db_path=db)
+        assert code == 0
+        assert "Example:" in stdout
+        assert "x = func()" in stdout
+
+    def test_show_no_example(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("n1", "A belief", db_path=db)
+        stdout, stderr, code = run_cli("show", "n1", db_path=db)
+        assert code == 0
+        assert "Example:" not in stdout


### PR DESCRIPTION
## Summary

- Add `--example` parameter to `reasons add` and `reasons update` commands
- Store code examples in node metadata for agent learning
- Display examples in `reasons show` output
- 13 new tests covering API and CLI integration

Closes #165

## Test plan

- [x] `reasons add n1 "text" --example "code snippet"` stores example in metadata
- [x] `reasons update n1 --example "new code"` updates/adds example
- [x] `reasons show n1` displays example when present, omits when absent
- [x] Update with only `--example` (no `--text`) is valid
- [x] Example coexists with access_tags and other metadata
- [x] Full test suite passes (1154 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)