### PR TITLE
Add reasons topics command for agent onboarding

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2131,6 +2131,41 @@ def list_nodes(
         return {"nodes": nodes, "count": len(nodes)}
 
 
+_TOPIC_STOP_WORDS = {
+    "a", "an", "the", "is", "are", "was", "were", "in", "on", "at", "to",
+    "for", "of", "and", "or", "not", "as", "by", "via", "can", "with",
+    "from", "than", "that", "this", "be", "has", "have", "it", "its",
+    "no", "do", "if", "so", "up", "out", "all", "but", "get", "set",
+    "only", "per", "use", "may", "one", "two", "new", "any", "each",
+    "must", "when", "how", "also", "into", "over", "more", "both",
+    "same", "own", "used", "using", "based", "does", "then",
+}
+
+
+def topics(
+    limit: int = 20,
+    db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
+) -> dict:
+    """Extract topics from node IDs by word frequency.
+
+    Returns: {"topics": [{"topic": str, "count": int}, ...], "total_nodes": int}
+    """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "topics", limit=limit)
+    with _with_network(db_path) as net:
+        word_counts: dict[str, int] = {}
+        for nid in net.nodes:
+            for word in re.split(r'[-._:]', nid):
+                if word and len(word) > 2 and word not in _TOPIC_STOP_WORDS:
+                    word_counts[word] = word_counts.get(word, 0) + 1
+        ranked = sorted(word_counts, key=lambda w: (-word_counts[w], w))[:limit]
+        return {
+            "topics": [{"topic": t, "count": word_counts[t]} for t in ranked],
+            "total_nodes": len(net.nodes),
+        }
+
+
 def list_gated(
     visible_to: list[str] | None = None,
     db_path: str = DEFAULT_DB,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1304,6 +1304,23 @@ def cmd_list_negative(args):
           f"({result['candidates']} candidates from {result['total']} IN nodes)")
 
 
+def cmd_topics(args):
+    result = api.topics(
+        limit=args.limit,
+        **_backend_kwargs(args),
+    )
+    if getattr(args, "json", False):
+        import json
+        print(json.dumps(result, indent=2))
+        return
+    if not result["topics"]:
+        print("No topics found.")
+        return
+    for item in result["topics"]:
+        print(f"  {item['topic']} ({item['count']})")
+    print(f"\n{len(result['topics'])} topics from {result['total_nodes']} nodes")
+
+
 def cmd_review_beliefs(args):
     _require_sqlite(args, "review-beliefs")
     import json
@@ -1946,6 +1963,11 @@ def main():
 
     sub.add_parser("namespaces", help="List all agent namespaces in the database")
 
+    # topics
+    p = sub.add_parser("topics", help="Extract topics from node IDs by word frequency")
+    p.add_argument("--limit", type=int, default=20, help="Max topics to show (default: 20)")
+    p.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+
     # review-beliefs
     p = sub.add_parser("review-beliefs", help="Review derived beliefs for validity, sufficiency, and necessity")
     p.add_argument("ids", nargs="*", help="Specific belief IDs to review (default: all derived)")
@@ -2092,6 +2114,7 @@ def main():
         "list": cmd_list,
         "list-gated": cmd_list_gated,
         "list-negative": cmd_list_negative,
+        "topics": cmd_topics,
         "review-beliefs": cmd_review_beliefs,
         "repair-smuggled": cmd_repair_smuggled,
         "research": cmd_research,

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1237,6 +1237,25 @@ class PgApi:
         gated_count = sum(len(b["gated"]) for b in blockers.values())
         return {"blockers": blockers, "gated_count": gated_count, "blocker_count": len(blockers)}
 
+    def topics(self, limit=20):
+        from reasons_lib.api import _TOPIC_STOP_WORDS
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM rms_nodes WHERE project_id = %s", (pid,),
+            )
+            node_ids = [row[0] for row in cur.fetchall()]
+        word_counts: dict[str, int] = {}
+        for nid in node_ids:
+            for word in re.split(r'[-._:]', nid):
+                if word and len(word) > 2 and word not in _TOPIC_STOP_WORDS:
+                    word_counts[word] = word_counts.get(word, 0) + 1
+        ranked = sorted(word_counts, key=lambda w: (-word_counts[w], w))[:limit]
+        return {
+            "topics": [{"topic": t, "count": word_counts[t]} for t in ranked],
+            "total_nodes": len(node_ids),
+        }
+
     def export_network(self, visible_to=None):
         pid = self.project_id
         with self.conn.cursor() as cur:

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,0 +1,140 @@
+"""Tests for the topics command."""
+
+import json
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib import api
+
+
+def run_cli(*args, db_path=None):
+    from reasons_lib.cli import main
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+            code = 0
+        except SystemExit as e:
+            code = e.code if e.code is not None else 0
+    return stdout.getvalue(), stderr.getvalue(), code
+
+
+class TestTopicsApi:
+    def test_empty_db(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        result = api.topics(db_path=db)
+        assert result["topics"] == []
+        assert result["total_nodes"] == 0
+
+    def test_extracts_words_from_ids(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("belief-about-caching", "Caching is good", db_path=db)
+        api.add_node("belief-about-testing", "Testing matters", db_path=db)
+        api.add_node("caching-strategy-redis", "Use Redis", db_path=db)
+        result = api.topics(db_path=db)
+        topic_names = [t["topic"] for t in result["topics"]]
+        assert "caching" in topic_names
+        assert "belief" in topic_names
+        assert "about" in topic_names
+        caching = next(t for t in result["topics"] if t["topic"] == "caching")
+        assert caching["count"] == 2
+
+    def test_filters_stop_words(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("the-use-of-caching", "Cache it", db_path=db)
+        result = api.topics(db_path=db)
+        topic_names = [t["topic"] for t in result["topics"]]
+        assert "the" not in topic_names
+        assert "use" not in topic_names
+        assert "caching" in topic_names
+
+    def test_filters_short_words(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("ab-cd-caching", "Cache", db_path=db)
+        result = api.topics(db_path=db)
+        topic_names = [t["topic"] for t in result["topics"]]
+        assert "ab" not in topic_names
+        assert "cd" not in topic_names
+        assert "caching" in topic_names
+
+    def test_splits_on_delimiters(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("module.class:method_name", "A method", db_path=db)
+        result = api.topics(db_path=db)
+        topic_names = [t["topic"] for t in result["topics"]]
+        assert "module" in topic_names
+        assert "class" in topic_names
+        assert "method" in topic_names
+        assert "name" in topic_names
+
+    def test_limit(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        for i in range(30):
+            api.add_node(f"topic-{i}-word{i}", f"Belief {i}", db_path=db)
+        result = api.topics(limit=5, db_path=db)
+        assert len(result["topics"]) == 5
+
+    def test_sorted_by_frequency(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("alpha-beta", "One", db_path=db)
+        api.add_node("alpha-gamma", "Two", db_path=db)
+        api.add_node("alpha-delta", "Three", db_path=db)
+        api.add_node("beta-gamma", "Four", db_path=db)
+        result = api.topics(db_path=db)
+        assert result["topics"][0]["topic"] == "alpha"
+        assert result["topics"][0]["count"] == 3
+
+    def test_total_nodes(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("node-one", "First", db_path=db)
+        api.add_node("node-two", "Second", db_path=db)
+        result = api.topics(db_path=db)
+        assert result["total_nodes"] == 2
+
+
+class TestCmdTopics:
+    def test_help(self):
+        stdout, stderr, code = run_cli("topics", "--help")
+        assert code == 0
+        assert "topics" in stdout.lower()
+
+    def test_basic_output(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("belief-about-caching", "Cache it", db_path=db)
+        api.add_node("belief-about-testing", "Test it", db_path=db)
+        stdout, stderr, code = run_cli("topics", db_path=db)
+        assert code == 0
+        assert "belief" in stdout
+        assert "topics from" in stdout
+
+    def test_json_output(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("belief-about-caching", "Cache", db_path=db)
+        stdout, stderr, code = run_cli("topics", "--json", db_path=db)
+        assert code == 0
+        data = json.loads(stdout)
+        assert "topics" in data
+        assert "total_nodes" in data
+
+    def test_limit_flag(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        for i in range(20):
+            api.add_node(f"topic-{i}-word{i}", f"Belief {i}", db_path=db)
+        stdout, stderr, code = run_cli("topics", "--limit", "3", db_path=db)
+        assert code == 0
+        assert "3 topics from" in stdout
+
+    def test_empty_db(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        stdout, stderr, code = run_cli("topics", db_path=db)
+        assert code == 0
+        assert "No topics found" in stdout


### PR DESCRIPTION
## Summary

- Add `reasons topics` command that extracts topics from node IDs by word frequency
- Splits IDs on `[-._:]` delimiters, filters stop words and short tokens, ranks by frequency
- Supports `--limit` (default 20) and `--json` for machine-readable output
- Zero LLM calls — pure string processing
- 13 new tests covering API and CLI

Closes #167

## Test plan

- [x] `reasons topics` shows top topics with counts
- [x] `reasons topics --limit 5` limits output
- [x] `reasons topics --json` returns valid JSON with topics and total_nodes
- [x] Stop words and short tokens filtered
- [x] Splits on `-`, `.`, `_`, `:` delimiters
- [x] Sorted by frequency descending, then alphabetically
- [x] Empty database shows "No topics found"
- [x] Full test suite passes (1168 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
