### PR TITLE
Add git-aware source pinning for staleness detection

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1653,14 +1653,15 @@ def check_stale(
             1 for n in net.nodes.values()
             if n.truth_value == "IN" and n.source and n.source_hash
         )
-        results, upgraded = _check(net, repo_paths, db_dir=db_dir,
-                                   upgrade_hashes=upgrade_hashes,
-                                   git_aware=git_aware)
+        results, upgraded, sha_bumped = _check(net, repo_paths, db_dir=db_dir,
+                                               upgrade_hashes=upgrade_hashes,
+                                               git_aware=git_aware)
         return {
             "stale": results,
             "checked": in_with_source,
             "stale_count": len(results),
             "upgraded": upgraded,
+            "sha_bumped": sha_bumped,
         }
 
 

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1618,6 +1618,7 @@ def export_card(visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
 def check_stale(
     repos: dict[str, str] | None = None,
     upgrade_hashes: bool = False,
+    git_aware: bool = False,
     db_path: str = DEFAULT_DB,
     pg_conninfo=None, project_id=None,
 ) -> dict:
@@ -1625,6 +1626,9 @@ def check_stale(
 
     If upgrade_hashes=True, truncated hashes that prefix-match the current
     full hash are upgraded in place and saved to the database.
+
+    If git_aware=True, nodes with pinned_sha skip content hashing when
+    no commits touched the file since the pinned SHA.
 
     Returns: {"stale": list[dict], "checked": int, "stale_count": int,
               "upgraded": int}
@@ -1637,7 +1641,8 @@ def check_stale(
 
     db_dir = P(db_path).resolve().parent
 
-    with _with_network(db_path, write=upgrade_hashes) as net:
+    needs_write = upgrade_hashes or git_aware
+    with _with_network(db_path, write=needs_write) as net:
         repo_paths = repos
         if repo_paths is None and net.repos:
             repo_paths = net.repos
@@ -1649,7 +1654,8 @@ def check_stale(
             if n.truth_value == "IN" and n.source and n.source_hash
         )
         results, upgraded = _check(net, repo_paths, db_dir=db_dir,
-                                   upgrade_hashes=upgrade_hashes)
+                                   upgrade_hashes=upgrade_hashes,
+                                   git_aware=git_aware)
         return {
             "stale": results,
             "checked": in_with_source,
@@ -1685,6 +1691,62 @@ def hash_sources(
 
         results = _hash(net, repo_paths, force=force, db_dir=db_dir)
         return {"hashed": results, "count": len(results)}
+
+
+def pin_sources(
+    force: bool = False,
+    pin_urls: bool = False,
+    repos: dict[str, str] | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Pin IN nodes to their current git commit SHA.
+
+    Stores pinned_sha and verified_at in node metadata.
+
+    Returns: {"pinned": list[dict], "count": int}
+    """
+    from pathlib import Path as P
+    from .check_stale import pin_sources as _pin
+
+    db_dir = P(db_path).resolve().parent
+
+    with _with_network(db_path, write=True) as net:
+        repo_paths = repos
+        if repo_paths is None and net.repos:
+            repo_paths = net.repos
+        if repo_paths:
+            repo_paths = {k: P(v) for k, v in repo_paths.items()}
+
+        results = _pin(net, repo_paths, db_dir=db_dir,
+                        force=force, pin_urls=pin_urls)
+        return {"pinned": results, "count": len(results)}
+
+
+def pin_update(
+    node_ids: list[str],
+    repos: dict[str, str] | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Bump pinned_sha to current HEAD for specified nodes.
+
+    Returns: {"updated": list[dict], "count": int, "errors": int}
+    """
+    from pathlib import Path as P
+    from .check_stale import pin_update as _update
+
+    db_dir = P(db_path).resolve().parent
+
+    with _with_network(db_path, write=True) as net:
+        repo_paths = repos
+        if repo_paths is None and net.repos:
+            repo_paths = net.repos
+        if repo_paths:
+            repo_paths = {k: P(v) for k, v in repo_paths.items()}
+
+        results = _update(net, node_ids, repo_paths, db_dir=db_dir)
+        errors = sum(1 for r in results if "error" in r)
+        return {"updated": results, "count": len(results) - errors,
+                "errors": errors}
 
 
 def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1631,11 +1631,12 @@ def check_stale(
     no commits touched the file since the pinned SHA.
 
     Returns: {"stale": list[dict], "checked": int, "stale_count": int,
-              "upgraded": int}
+              "upgraded": int, "sha_bumped": int}
     """
     if pg_conninfo:
         return _pg_dispatch(pg_conninfo, project_id, "check_stale",
-                            repos=repos, upgrade_hashes=upgrade_hashes)
+                            repos=repos, upgrade_hashes=upgrade_hashes,
+                            git_aware=git_aware)
     from pathlib import Path as P
     from .check_stale import check_stale as _check
 

--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -6,6 +6,9 @@ source_hash against the current SHA-256 hash of the source file.
 """
 
 import hashlib
+import re
+import subprocess
+from datetime import date
 from pathlib import Path
 
 from .network import Network
@@ -61,11 +64,15 @@ def check_stale(
     repos: dict[str, Path] | None = None,
     db_dir: Path | None = None,
     upgrade_hashes: bool = False,
+    git_aware: bool = False,
 ) -> tuple[list[dict], int]:
     """Check all IN nodes for source staleness.
 
     If upgrade_hashes=True, truncated hashes that are a prefix of the
     current full hash are upgraded in place (caller must save the network).
+
+    If git_aware=True, nodes with pinned_sha in metadata skip content
+    hashing when no commits touched the file since the pinned SHA.
 
     Returns (stale_results, upgraded_count).
     """
@@ -94,6 +101,11 @@ def check_stale(
             })
             continue
 
+        pinned_sha = node.metadata.get("pinned_sha") if node.metadata else None
+        if git_aware and pinned_sha:
+            if not file_changed_since(path, pinned_sha):
+                continue
+
         current_hash = hash_file(path)
         if current_hash != node.source_hash:
             if len(node.source_hash) == 16 and current_hash.startswith(node.source_hash):
@@ -118,6 +130,13 @@ def check_stale(
                 "source_path": str(path),
                 "reason": "content_changed",
             })
+        elif git_aware and pinned_sha:
+            # Content hash unchanged despite commits — auto-bump pinned_sha
+            new_sha = get_file_commit_sha(path)
+            if new_sha and new_sha != pinned_sha:
+                node.metadata["pinned_sha"] = new_sha
+                node.metadata["verified_at"] = date.today().isoformat()
+                upgraded += 1
 
     return results, upgraded
 
@@ -160,6 +179,157 @@ def hash_sources(
             "source": node.source,
             "hash": new_hash,
             "was_empty": was_empty,
+        })
+
+    return results
+
+
+# --- Git-aware pinning ---
+
+
+def get_file_commit_sha(filepath: Path) -> str | None:
+    """Get the last commit SHA that touched this file."""
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%H", "--", str(filepath.name)],
+        capture_output=True, text=True,
+        cwd=str(filepath.parent),
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return None
+
+
+def file_changed_since(filepath: Path, since_sha: str) -> bool:
+    """Check if file was modified in any commit after since_sha."""
+    result = subprocess.run(
+        ["git", "log", "--format=%H", f"{since_sha}..HEAD",
+         "--", str(filepath.name)],
+        capture_output=True, text=True,
+        cwd=str(filepath.parent),
+    )
+    return bool(result.returncode == 0 and result.stdout.strip())
+
+
+def pin_source_url(url: str, sha: str) -> str:
+    """Rewrite GitHub blob URL from branch ref to commit SHA."""
+    m = re.match(r'(https://github\.com/[^/]+/[^/]+/blob/)[^/]+/(.*)', url)
+    if m:
+        return f"{m.group(1)}{sha}/{m.group(2)}"
+    return url
+
+
+def pin_sources(
+    network: Network,
+    repos: dict[str, Path] | None = None,
+    db_dir: Path | None = None,
+    force: bool = False,
+    pin_urls: bool = False,
+) -> list[dict]:
+    """Pin IN nodes to their current git commit SHA.
+
+    Stores pinned_sha and verified_at in node metadata. Also backfills
+    source_hash if missing.
+
+    Returns list of dicts: {"node_id", "source", "pinned_sha", "was_empty"}
+    """
+    if repos is None and network.repos:
+        repos = {k: Path(v) for k, v in network.repos.items()}
+
+    today = date.today().isoformat()
+    results = []
+
+    for nid, node in sorted(network.nodes.items()):
+        if node.truth_value != "IN":
+            continue
+        if not node.source:
+            continue
+        if not force and node.metadata.get("pinned_sha"):
+            continue
+
+        agent = node.metadata.get("agent") if node.metadata else None
+        path = resolve_source_path(node.source, repos, db_dir, agent=agent)
+        if path is None:
+            continue
+
+        sha = get_file_commit_sha(path)
+        if sha is None:
+            continue
+
+        was_empty = not node.metadata.get("pinned_sha")
+        node.metadata["pinned_sha"] = sha
+        node.metadata["verified_at"] = today
+
+        if not node.source_hash:
+            node.source_hash = hash_file(path)
+
+        if pin_urls and node.source_url:
+            node.source_url = pin_source_url(node.source_url, sha)
+
+        results.append({
+            "node_id": nid,
+            "source": node.source,
+            "pinned_sha": sha,
+            "was_empty": was_empty,
+        })
+
+    return results
+
+
+def pin_update(
+    network: Network,
+    node_ids: list[str],
+    repos: dict[str, Path] | None = None,
+    db_dir: Path | None = None,
+) -> list[dict]:
+    """Bump pinned_sha to current HEAD for specified nodes.
+
+    Returns list of dicts: {"node_id", "old_sha", "new_sha", "source"}
+    """
+    if repos is None and network.repos:
+        repos = {k: Path(v) for k, v in network.repos.items()}
+
+    today = date.today().isoformat()
+    results = []
+
+    for nid in node_ids:
+        node = network.nodes.get(nid)
+        if node is None:
+            results.append({
+                "node_id": nid, "error": "not found",
+            })
+            continue
+
+        if not node.source:
+            results.append({
+                "node_id": nid, "error": "no source",
+            })
+            continue
+
+        agent = node.metadata.get("agent") if node.metadata else None
+        path = resolve_source_path(node.source, repos, db_dir, agent=agent)
+        if path is None:
+            results.append({
+                "node_id": nid, "error": "source not found",
+            })
+            continue
+
+        sha = get_file_commit_sha(path)
+        if sha is None:
+            results.append({
+                "node_id": nid, "error": "not in git repo",
+            })
+            continue
+
+        old_sha = node.metadata.get("pinned_sha", "")
+        node.metadata["pinned_sha"] = sha
+        node.metadata["verified_at"] = today
+        node.source_hash = hash_file(path)
+
+        results.append({
+            "node_id": nid,
+            "old_sha": old_sha,
+            "new_sha": sha,
+            "source": node.source,
         })
 
     return results

--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -65,7 +65,7 @@ def check_stale(
     db_dir: Path | None = None,
     upgrade_hashes: bool = False,
     git_aware: bool = False,
-) -> tuple[list[dict], int]:
+) -> tuple[list[dict], int, int]:
     """Check all IN nodes for source staleness.
 
     If upgrade_hashes=True, truncated hashes that are a prefix of the
@@ -74,13 +74,14 @@ def check_stale(
     If git_aware=True, nodes with pinned_sha in metadata skip content
     hashing when no commits touched the file since the pinned SHA.
 
-    Returns (stale_results, upgraded_count).
+    Returns (stale_results, upgraded_count, sha_bumped_count).
     """
     if repos is None and network.repos:
         repos = {k: Path(v) for k, v in network.repos.items()}
 
     results = []
     upgraded = 0
+    sha_bumped = 0
 
     for nid, node in sorted(network.nodes.items()):
         if node.truth_value != "IN":
@@ -131,14 +132,13 @@ def check_stale(
                 "reason": "content_changed",
             })
         elif git_aware and pinned_sha:
-            # Content hash unchanged despite commits — auto-bump pinned_sha
             new_sha = get_file_commit_sha(path)
             if new_sha and new_sha != pinned_sha:
                 node.metadata["pinned_sha"] = new_sha
                 node.metadata["verified_at"] = date.today().isoformat()
-                upgraded += 1
+                sha_bumped += 1
 
-    return results, upgraded
+    return results, upgraded, sha_bumped
 
 
 def hash_sources(
@@ -200,14 +200,30 @@ def get_file_commit_sha(filepath: Path) -> str | None:
 
 
 def file_changed_since(filepath: Path, since_sha: str) -> bool:
-    """Check if file was modified in any commit after since_sha."""
+    """Check if file was modified since since_sha (committed or uncommitted).
+
+    Returns True on git errors to force fallback to content hashing.
+    """
+    # Check committed changes
     result = subprocess.run(
         ["git", "log", "--format=%H", f"{since_sha}..HEAD",
          "--", str(filepath.name)],
         capture_output=True, text=True,
         cwd=str(filepath.parent),
     )
-    return bool(result.returncode == 0 and result.stdout.strip())
+    if result.returncode != 0:
+        return True
+    if result.stdout.strip():
+        return True
+    # Check uncommitted changes (staged + unstaged)
+    result = subprocess.run(
+        ["git", "diff", "--quiet", "HEAD", "--", str(filepath.name)],
+        capture_output=True, text=True,
+        cwd=str(filepath.parent),
+    )
+    if result.returncode != 0:
+        return True
+    return False
 
 
 def pin_source_url(url: str, sha: str) -> str:

--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -193,6 +193,7 @@ def get_file_commit_sha(filepath: Path) -> str | None:
         ["git", "log", "-1", "--format=%H", "--", str(filepath.name)],
         capture_output=True, text=True,
         cwd=str(filepath.parent),
+        timeout=30,
     )
     if result.returncode == 0 and result.stdout.strip():
         return result.stdout.strip()
@@ -204,33 +205,49 @@ def file_changed_since(filepath: Path, since_sha: str) -> bool:
 
     Returns True on git errors to force fallback to content hashing.
     """
-    # Check committed changes
-    result = subprocess.run(
-        ["git", "log", "--format=%H", f"{since_sha}..HEAD",
-         "--", str(filepath.name)],
-        capture_output=True, text=True,
-        cwd=str(filepath.parent),
-    )
-    if result.returncode != 0:
+    try:
+        # Check committed changes
+        result = subprocess.run(
+            ["git", "log", "--format=%H", f"{since_sha}..HEAD",
+             "--", str(filepath.name)],
+            capture_output=True, text=True,
+            cwd=str(filepath.parent),
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return True
+        if result.stdout.strip():
+            return True
+        # Check uncommitted changes (staged + unstaged)
+        result = subprocess.run(
+            ["git", "diff", "--quiet", "HEAD", "--", str(filepath.name)],
+            capture_output=True, text=True,
+            cwd=str(filepath.parent),
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return True
+        return False
+    except subprocess.TimeoutExpired:
         return True
-    if result.stdout.strip():
-        return True
-    # Check uncommitted changes (staged + unstaged)
-    result = subprocess.run(
-        ["git", "diff", "--quiet", "HEAD", "--", str(filepath.name)],
-        capture_output=True, text=True,
-        cwd=str(filepath.parent),
-    )
-    if result.returncode != 0:
-        return True
-    return False
 
 
-def pin_source_url(url: str, sha: str) -> str:
-    """Rewrite GitHub blob URL from branch ref to commit SHA."""
-    m = re.match(r'(https://github\.com/[^/]+/[^/]+/blob/)[^/]+/(.*)', url)
-    if m:
-        return f"{m.group(1)}{sha}/{m.group(2)}"
+def pin_source_url(url: str, sha: str, source_path: str = "") -> str:
+    """Rewrite GitHub blob URL from branch ref to commit SHA.
+
+    If source_path is provided, uses it to locate the file path portion
+    of the URL (handles branch names containing slashes).
+    """
+    m = re.match(r'(https://github\.com/[^/]+/[^/]+/blob/).+', url)
+    if not m:
+        return url
+    prefix = m.group(1)
+    if source_path and url.endswith(source_path):
+        return f"{prefix}{sha}/{source_path}"
+    rest = url[len(prefix):]
+    parts = rest.split("/", 1)
+    if len(parts) == 2:
+        return f"{prefix}{sha}/{parts[1]}"
     return url
 
 
@@ -279,7 +296,7 @@ def pin_sources(
             node.source_hash = hash_file(path)
 
         if pin_urls and node.source_url:
-            node.source_url = pin_source_url(node.source_url, sha)
+            node.source_url = pin_source_url(node.source_url, sha, node.source)
 
         results.append({
             "node_id": nid,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -696,7 +696,9 @@ def cmd_hash_sources(args):
 
 
 def cmd_check_stale(args):
-    result = api.check_stale(upgrade_hashes=args.upgrade_hashes, **_backend_kwargs(args))
+    result = api.check_stale(upgrade_hashes=args.upgrade_hashes,
+                             git_aware=getattr(args, "git", False),
+                             **_backend_kwargs(args))
 
     if result.get("upgraded"):
         print(f"Upgraded {result['upgraded']} truncated hash(es) to full length.")
@@ -726,6 +728,51 @@ def cmd_check_stale(args):
     print(f"{fresh} fresh, {len(stale)} stale (of {result['checked']} checked)")
     if stale:
         sys.exit(1)
+
+
+def cmd_pin_sources(args):
+    _require_sqlite(args, "pin-sources")
+    result = api.pin_sources(
+        force=args.force,
+        pin_urls=getattr(args, "pin_urls", False),
+        db_path=args.db,
+    )
+
+    if not result["pinned"]:
+        print("No nodes to pin (all sources already pinned, or source files not in git).")
+        if not args.force:
+            print("Use --force to re-pin nodes that already have a pinned_sha.")
+        return
+
+    for item in result["pinned"]:
+        action = "pinned" if item["was_empty"] else "re-pinned"
+        print(f"  {action}  {item['node_id']}  {item['pinned_sha'][:12]}  ({item['source']})")
+
+    new = sum(1 for p in result["pinned"] if p["was_empty"])
+    re = result["count"] - new
+    parts = []
+    if new:
+        parts.append(f"{new} pinned")
+    if re:
+        parts.append(f"{re} re-pinned")
+    print(f"\n{', '.join(parts)}")
+
+
+def cmd_pin_update(args):
+    _require_sqlite(args, "pin-update")
+    result = api.pin_update(node_ids=args.node_ids, db_path=args.db)
+
+    for item in result["updated"]:
+        if "error" in item:
+            print(f"  ERROR  {item['node_id']}: {item['error']}")
+        else:
+            old = item['old_sha'][:12] if item['old_sha'] else "(none)"
+            print(f"  UPDATED  {item['node_id']}  {old} -> {item['new_sha'][:12]}")
+
+    if result["errors"]:
+        print(f"\n{result['count']} updated, {result['errors']} errors")
+    else:
+        print(f"\n{result['count']} updated")
 
 
 def cmd_compact(args):
@@ -1880,6 +1927,19 @@ def main():
     p = sub.add_parser("check-stale", help="Check IN nodes for source file staleness")
     p.add_argument("--upgrade-hashes", action="store_true",
                    help="Upgrade truncated hashes to full length in place")
+    p.add_argument("--git", action="store_true",
+                   help="Use git commit SHA for faster staleness detection")
+
+    # pin-sources
+    p = sub.add_parser("pin-sources", help="Pin source links to git commit SHA")
+    p.add_argument("--force", action="store_true",
+                   help="Re-pin even nodes that already have a pinned_sha")
+    p.add_argument("--pin-urls", action="store_true",
+                   help="Rewrite source_url from branch URLs to SHA-pinned URLs")
+
+    # pin-update
+    p = sub.add_parser("pin-update", help="Bump pinned_sha to current HEAD for beliefs")
+    p.add_argument("node_ids", nargs="+", help="Belief IDs to update")
 
     # compact
     p = sub.add_parser("compact", help="Token-budgeted belief state summary")
@@ -2097,6 +2157,8 @@ def main():
         "export-card": cmd_export_card,
         "hash-sources": cmd_hash_sources,
         "check-stale": cmd_check_stale,
+        "pin-sources": cmd_pin_sources,
+        "pin-update": cmd_pin_update,
         "compact": cmd_compact,
         "convert-to-premise": cmd_convert_to_premise,
         "summarize": cmd_summarize,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -702,6 +702,8 @@ def cmd_check_stale(args):
 
     if result.get("upgraded"):
         print(f"Upgraded {result['upgraded']} truncated hash(es) to full length.")
+    if result.get("sha_bumped"):
+        print(f"Auto-bumped {result['sha_bumped']} pinned SHA(s) (content unchanged).")
 
     if not result["stale"]:
         print(f"All {result['checked']} nodes with sources are fresh.")

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -818,7 +818,7 @@ class PgApi:
 
         return {"hashed": results, "count": len(results)}
 
-    def check_stale(self, repos=None, upgrade_hashes=False):
+    def check_stale(self, repos=None, upgrade_hashes=False, git_aware=False):
         """Check all IN nodes for source file staleness."""
         from pathlib import Path
         from .check_stale import hash_file, resolve_source_path
@@ -900,6 +900,7 @@ class PgApi:
             "checked": len(rows),
             "stale_count": len(results),
             "upgraded": upgraded,
+            "sha_bumped": 0,
         }
 
     def lookup(self, query, visible_to=None):

--- a/tests/test_check_stale.py
+++ b/tests/test_check_stale.py
@@ -107,7 +107,7 @@ class TestCheckStale:
         net = Network()
         net.add_node("a", "Premise A", source="entries/topic.md", source_hash=h)
 
-        results, _ = check_stale(net, db_dir=tmp_path)
+        results, *_ = check_stale(net, db_dir=tmp_path)
         assert results == []
 
     def test_fresh_node(self, tmp_path):
@@ -118,7 +118,7 @@ class TestCheckStale:
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/source.md", source_hash=h)
 
-        results, _ = check_stale(net, repos={"myrepo": tmp_path})
+        results, *_ = check_stale(net, repos={"myrepo": tmp_path})
         assert results == []
 
     def test_stale_node(self, tmp_path):
@@ -132,7 +132,7 @@ class TestCheckStale:
         # Change the file
         f.write_text("updated content")
 
-        results, _ = check_stale(net, repos={"myrepo": tmp_path})
+        results, *_ = check_stale(net, repos={"myrepo": tmp_path})
         assert len(results) == 1
         assert results[0]["node_id"] == "a"
         assert results[0]["old_hash"] == old_hash
@@ -150,21 +150,21 @@ class TestCheckStale:
 
         f.write_text("changed")
 
-        results, _ = check_stale(net, repos={"myrepo": tmp_path})
+        results, *_ = check_stale(net, repos={"myrepo": tmp_path})
         assert results == []
 
     def test_skips_nodes_without_hash(self, tmp_path):
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/source.md")  # no hash
 
-        results, _ = check_stale(net, repos={"myrepo": tmp_path})
+        results, *_ = check_stale(net, repos={"myrepo": tmp_path})
         assert results == []
 
     def test_reports_missing_source_files(self, tmp_path):
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/missing.md", source_hash="abc123")
 
-        results, _ = check_stale(net, repos={"myrepo": tmp_path})
+        results, *_ = check_stale(net, repos={"myrepo": tmp_path})
         assert len(results) == 1
         assert results[0]["node_id"] == "a"
         assert results[0]["reason"] == "source_deleted"
@@ -185,7 +185,7 @@ class TestCheckStale:
         f1.write_text("new a")
         f2.write_text("new b")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert len(results) == 2
 
     def test_agent_imported_node_resolves_via_agent_repo(self, tmp_path):
@@ -204,7 +204,7 @@ class TestCheckStale:
             metadata={"agent": "code"},
         )
 
-        results, _ = check_stale(net)
+        results, *_ = check_stale(net)
         assert results == []
 
     def test_agent_imported_node_detects_stale(self, tmp_path):
@@ -224,7 +224,7 @@ class TestCheckStale:
         )
 
         f.write_text("updated content")
-        results, _ = check_stale(net)
+        results, *_ = check_stale(net)
         assert len(results) == 1
         assert results[0]["node_id"] == "code:topic-belief"
         assert results[0]["reason"] == "content_changed"
@@ -241,7 +241,7 @@ class TestPrefixHashUpgrade:
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/source.md", source_hash=truncated)
 
-        results, upgraded = check_stale(net, repos={"myrepo": tmp_path},
+        results, upgraded, *_ = check_stale(net, repos={"myrepo": tmp_path},
                                         upgrade_hashes=True)
         assert results == []
         assert upgraded == 1
@@ -256,7 +256,7 @@ class TestPrefixHashUpgrade:
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/source.md", source_hash=truncated)
 
-        results, upgraded = check_stale(net, repos={"myrepo": tmp_path})
+        results, upgraded, *_ = check_stale(net, repos={"myrepo": tmp_path})
         assert len(results) == 1
         assert results[0]["reason"] == "truncated_hash"
         assert upgraded == 0
@@ -272,7 +272,7 @@ class TestPrefixHashUpgrade:
 
         f.write_text("different content")
 
-        results, upgraded = check_stale(net, repos={"myrepo": tmp_path},
+        results, upgraded, *_ = check_stale(net, repos={"myrepo": tmp_path},
                                         upgrade_hashes=True)
         assert len(results) == 1
         assert results[0]["reason"] == "content_changed"
@@ -286,7 +286,7 @@ class TestPrefixHashUpgrade:
         net = Network()
         net.add_node("a", "Premise A", source="myrepo/source.md", source_hash=full_hash)
 
-        results, upgraded = check_stale(net, repos={"myrepo": tmp_path},
+        results, upgraded, *_ = check_stale(net, repos={"myrepo": tmp_path},
                                         upgrade_hashes=True)
         assert results == []
         assert upgraded == 0

--- a/tests/test_check_stale_issue25.py
+++ b/tests/test_check_stale_issue25.py
@@ -24,7 +24,7 @@ class TestSourceDeletedResult:
         net = Network()
         net.add_node("a", "Belief A", source="r/gone.md", source_hash="abc123")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
 
         assert len(results) == 1
         r = results[0]
@@ -39,7 +39,7 @@ class TestSourceDeletedResult:
         net = Network()
         net.add_node("a", "Belief A", source="r/gone.md", source_hash="xyz")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
 
         required_keys = {"node_id", "old_hash", "new_hash", "source", "source_path", "reason"}
         assert set(results[0].keys()) == required_keys
@@ -55,7 +55,7 @@ class TestSourceDeletedResult:
 
         f.write_text("changed")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
 
         assert len(results) == 2
         changed = next(r for r in results if r["reason"] == "content_changed")
@@ -82,7 +82,7 @@ class TestMixedResults:
 
         changing.write_text("new content")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
 
         reasons = {r["node_id"]: r["reason"] for r in results}
         assert reasons["changed"] == "content_changed"
@@ -94,7 +94,7 @@ class TestMixedResults:
         net.add_node("a", "Belief A", source="r/shared.md", source_hash="h1")
         net.add_node("b", "Belief B", source="r/shared.md", source_hash="h2")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
 
         assert len(results) == 2
         assert all(r["reason"] == "source_deleted" for r in results)
@@ -110,28 +110,28 @@ class TestSkipBehavior:
         net.add_node("a", "Belief A", source="r/gone.md", source_hash="abc")
         net.retract("a")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert results == []
 
     def test_skips_nodes_without_source(self, tmp_path):
         net = Network()
         net.add_node("a", "Premise with no source")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert results == []
 
     def test_skips_nodes_without_hash(self, tmp_path):
         net = Network()
         net.add_node("a", "Has source but no hash", source="r/file.md")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert results == []
 
     def test_skips_nodes_with_empty_source_string(self, tmp_path):
         net = Network()
         net.add_node("a", "Empty source", source="", source_hash="abc")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert results == []
 
 
@@ -146,7 +146,7 @@ class TestEdgeCases:
         net = Network()
         net.add_node("a", "From empty file", source="r/empty.md", source_hash=empty_hash)
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert results == []
 
     def test_empty_file_with_wrong_hash_is_content_changed(self, tmp_path):
@@ -156,7 +156,7 @@ class TestEdgeCases:
         net = Network()
         net.add_node("a", "From empty file", source="r/empty.md", source_hash="wronghash")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert len(results) == 1
         assert results[0]["reason"] == "content_changed"
         assert results[0]["new_hash"] == _hash("")
@@ -165,7 +165,7 @@ class TestEdgeCases:
         net = Network()
         net.add_node("a", "Belief", source="nonexistent-repo/file.md", source_hash="abc")
 
-        results, _ = check_stale(net, repos=None)
+        results, *_ = check_stale(net, repos=None)
         assert len(results) == 1
         assert results[0]["reason"] == "source_deleted"
 
@@ -177,7 +177,7 @@ class TestEdgeCases:
         net = Network()
         net.add_node("a", "Belief A", source="r/src.md", source_hash=h)
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert results == []
 
     def test_results_sorted_by_node_id(self, tmp_path):
@@ -186,7 +186,7 @@ class TestEdgeCases:
         net.add_node("a-node", "A", source="r/a.md", source_hash="h")
         net.add_node("m-node", "M", source="r/m.md", source_hash="h")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         ids = [r["node_id"] for r in results]
         assert ids == sorted(ids)
 
@@ -199,6 +199,6 @@ class TestEdgeCases:
         net.add_node("a", "Belief", source="r/src.md", source_hash=h)
         f.write_text("new")
 
-        results, _ = check_stale(net, repos={"r": tmp_path})
+        results, *_ = check_stale(net, repos={"r": tmp_path})
         assert results[0]["source_path"] == str(f)
         assert results[0]["reason"] == "content_changed"

--- a/tests/test_pg_dispatch.py
+++ b/tests/test_pg_dispatch.py
@@ -398,7 +398,7 @@ class TestCheckStaleDispatch:
             MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
             MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
             result = check_stale(pg_conninfo="postgresql://...", project_id="test")
-        mock_pg.check_stale.assert_called_once_with(repos=None, upgrade_hashes=False)
+        mock_pg.check_stale.assert_called_once_with(repos=None, upgrade_hashes=False, git_aware=False)
         assert result["checked"] == 5
 
     def test_passes_upgrade_hashes(self):
@@ -411,7 +411,7 @@ class TestCheckStaleDispatch:
             MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
             result = check_stale(upgrade_hashes=True,
                                  pg_conninfo="postgresql://...", project_id="test")
-        mock_pg.check_stale.assert_called_once_with(repos=None, upgrade_hashes=True)
+        mock_pg.check_stale.assert_called_once_with(repos=None, upgrade_hashes=True, git_aware=False)
         assert result["upgraded"] == 2
 
 

--- a/tests/test_pin_sources.py
+++ b/tests/test_pin_sources.py
@@ -224,7 +224,7 @@ class TestCheckStaleGitAware:
         net.add_node("belief-1", "Test belief",
                       source="source.md", source_hash=content_hash)
         net.nodes["belief-1"].metadata["pinned_sha"] = sha
-        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=True)
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
         assert len(results) == 0
 
     def test_stale_when_content_changed(self, git_repo):
@@ -235,7 +235,7 @@ class TestCheckStaleGitAware:
                       source="source.md", source_hash=content_hash)
         net.nodes["belief-1"].metadata["pinned_sha"] = sha
         _commit_change(git_repo, "source.md", "changed content")
-        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=True)
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
         assert len(results) == 1
         assert results[0]["reason"] == "content_changed"
 
@@ -250,9 +250,10 @@ class TestCheckStaleGitAware:
         _commit_change(git_repo, "source.md", "temporary change")
         _commit_change(git_repo, "source.md", "initial content")
         new_head = _get_head_sha(git_repo)
-        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=True)
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
         assert len(results) == 0
-        assert upgraded == 1
+        assert upgraded == 0
+        assert sha_bumped == 1
         assert net.nodes["belief-1"].metadata["pinned_sha"] == new_head
 
     def test_falls_back_to_hash_without_pinned_sha(self, git_repo):
@@ -261,7 +262,7 @@ class TestCheckStaleGitAware:
         net.add_node("belief-1", "Test belief",
                       source="source.md", source_hash=content_hash)
         _commit_change(git_repo, "source.md", "changed content")
-        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=True)
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
         assert len(results) == 1
         assert results[0]["reason"] == "content_changed"
 
@@ -272,5 +273,5 @@ class TestCheckStaleGitAware:
         net.add_node("belief-1", "Test belief",
                       source="source.md", source_hash=content_hash)
         net.nodes["belief-1"].metadata["pinned_sha"] = sha
-        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=False)
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=False)
         assert len(results) == 0

--- a/tests/test_pin_sources.py
+++ b/tests/test_pin_sources.py
@@ -1,0 +1,276 @@
+"""Tests for git-aware source pinning."""
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from reasons_lib.network import Network
+from reasons_lib.check_stale import (
+    check_stale,
+    get_file_commit_sha,
+    file_changed_since,
+    hash_file,
+    pin_source_url,
+    pin_sources,
+    pin_update,
+)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """Create a temp git repo with one committed file."""
+    subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"],
+                   cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"],
+                   cwd=tmp_path, capture_output=True, check=True)
+    f = tmp_path / "source.md"
+    f.write_text("initial content")
+    subprocess.run(["git", "add", "source.md"], cwd=tmp_path, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True, check=True)
+    return tmp_path
+
+
+def _get_head_sha(repo_path):
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo_path,
+        capture_output=True, text=True,
+    )
+    return result.stdout.strip()
+
+
+def _commit_change(repo_path, filename, content, message="change"):
+    (repo_path / filename).write_text(content)
+    subprocess.run(["git", "add", filename], cwd=repo_path, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", message], cwd=repo_path, capture_output=True, check=True)
+
+
+class TestGetFileCommitSha:
+    def test_returns_sha_for_tracked_file(self, git_repo):
+        sha = get_file_commit_sha(git_repo / "source.md")
+        assert sha is not None
+        assert len(sha) == 40
+
+    def test_returns_none_for_untracked_file(self, git_repo):
+        (git_repo / "untracked.md").write_text("hello")
+        sha = get_file_commit_sha(git_repo / "untracked.md")
+        assert sha is None
+
+    def test_returns_none_outside_git(self, tmp_path):
+        f = tmp_path / "file.md"
+        f.write_text("hello")
+        sha = get_file_commit_sha(f)
+        assert sha is None
+
+    def test_sha_changes_after_commit(self, git_repo):
+        sha1 = get_file_commit_sha(git_repo / "source.md")
+        _commit_change(git_repo, "source.md", "changed content")
+        sha2 = get_file_commit_sha(git_repo / "source.md")
+        assert sha1 != sha2
+
+
+class TestFileChangedSince:
+    def test_no_change_since_head(self, git_repo):
+        sha = _get_head_sha(git_repo)
+        assert not file_changed_since(git_repo / "source.md", sha)
+
+    def test_detects_change(self, git_repo):
+        sha = _get_head_sha(git_repo)
+        _commit_change(git_repo, "source.md", "new content")
+        assert file_changed_since(git_repo / "source.md", sha)
+
+    def test_ignores_changes_to_other_files(self, git_repo):
+        sha = _get_head_sha(git_repo)
+        _commit_change(git_repo, "other.md", "other content")
+        assert not file_changed_since(git_repo / "source.md", sha)
+
+
+class TestPinSourceUrl:
+    def test_rewrites_branch_url(self):
+        url = "https://github.com/owner/repo/blob/main/path/to/file.py"
+        sha = "abc123def456" * 3 + "abcd"
+        result = pin_source_url(url, sha)
+        assert result == f"https://github.com/owner/repo/blob/{sha}/path/to/file.py"
+
+    def test_preserves_non_github_url(self):
+        url = "https://example.com/docs/file.md"
+        result = pin_source_url(url, "abc123")
+        assert result == url
+
+    def test_rewrites_any_branch(self):
+        url = "https://github.com/owner/repo/blob/feature-branch/src/main.py"
+        sha = "a" * 40
+        result = pin_source_url(url, sha)
+        assert f"/blob/{sha}/src/main.py" in result
+
+
+class TestPinSources:
+    def test_pins_node_with_source(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash="")
+        results = pin_sources(net, db_dir=git_repo)
+        assert len(results) == 1
+        assert results[0]["node_id"] == "belief-1"
+        assert len(results[0]["pinned_sha"]) == 40
+        assert results[0]["was_empty"] is True
+        node = net.nodes["belief-1"]
+        assert node.metadata["pinned_sha"] == results[0]["pinned_sha"]
+        assert "verified_at" in node.metadata
+
+    def test_backfills_source_hash(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash="")
+        pin_sources(net, db_dir=git_repo)
+        assert net.nodes["belief-1"].source_hash != ""
+
+    def test_skips_already_pinned(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash="")
+        net.nodes["belief-1"].metadata["pinned_sha"] = "existing"
+        results = pin_sources(net, db_dir=git_repo)
+        assert len(results) == 0
+
+    def test_force_re_pins(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash="")
+        net.nodes["belief-1"].metadata["pinned_sha"] = "old-sha"
+        results = pin_sources(net, db_dir=git_repo, force=True)
+        assert len(results) == 1
+        assert results[0]["was_empty"] is False
+
+    def test_skips_out_nodes(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash="")
+        net.nodes["belief-1"].truth_value = "OUT"
+        results = pin_sources(net, db_dir=git_repo)
+        assert len(results) == 0
+
+    def test_skips_nodes_without_source(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief")
+        results = pin_sources(net, db_dir=git_repo)
+        assert len(results) == 0
+
+    def test_skips_nonexistent_source(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="nonexistent.md", source_hash="")
+        results = pin_sources(net, db_dir=git_repo)
+        assert len(results) == 0
+
+    def test_pin_urls_rewrites_source_url(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash="",
+                      source_url="https://github.com/owner/repo/blob/main/source.md")
+        results = pin_sources(net, db_dir=git_repo, pin_urls=True)
+        assert len(results) == 1
+        sha = results[0]["pinned_sha"]
+        assert f"/blob/{sha}/source.md" in net.nodes["belief-1"].source_url
+
+
+class TestPinUpdate:
+    def test_updates_pinned_sha(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md",
+                      source_hash=hash_file(git_repo / "source.md"))
+        net.nodes["belief-1"].metadata["pinned_sha"] = "old" * 10
+        results = pin_update(net, ["belief-1"], db_dir=git_repo)
+        assert len(results) == 1
+        assert "error" not in results[0]
+        assert results[0]["old_sha"] == "old" * 10
+        assert len(results[0]["new_sha"]) == 40
+        assert net.nodes["belief-1"].metadata["pinned_sha"] == results[0]["new_sha"]
+
+    def test_error_on_missing_node(self, git_repo):
+        net = Network()
+        results = pin_update(net, ["nonexistent"], db_dir=git_repo)
+        assert results[0]["error"] == "not found"
+
+    def test_error_on_no_source(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief")
+        results = pin_update(net, ["belief-1"], db_dir=git_repo)
+        assert results[0]["error"] == "no source"
+
+    def test_error_on_source_not_found(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief", source="gone.md")
+        results = pin_update(net, ["belief-1"], db_dir=git_repo)
+        assert results[0]["error"] == "source not found"
+
+    def test_refreshes_source_hash(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash="stale-hash")
+        results = pin_update(net, ["belief-1"], db_dir=git_repo)
+        expected_hash = hash_file(git_repo / "source.md")
+        assert net.nodes["belief-1"].source_hash == expected_hash
+
+
+class TestCheckStaleGitAware:
+    def test_fresh_when_no_commits_since_pin(self, git_repo):
+        sha = _get_head_sha(git_repo)
+        content_hash = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash=content_hash)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 0
+
+    def test_stale_when_content_changed(self, git_repo):
+        sha = _get_head_sha(git_repo)
+        content_hash = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash=content_hash)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        _commit_change(git_repo, "source.md", "changed content")
+        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 1
+        assert results[0]["reason"] == "content_changed"
+
+    def test_auto_bumps_sha_when_content_unchanged(self, git_repo):
+        sha = _get_head_sha(git_repo)
+        content_hash = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash=content_hash)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        # Change file, commit, then revert to original
+        _commit_change(git_repo, "source.md", "temporary change")
+        _commit_change(git_repo, "source.md", "initial content")
+        new_head = _get_head_sha(git_repo)
+        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 0
+        assert upgraded == 1
+        assert net.nodes["belief-1"].metadata["pinned_sha"] == new_head
+
+    def test_falls_back_to_hash_without_pinned_sha(self, git_repo):
+        content_hash = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash=content_hash)
+        _commit_change(git_repo, "source.md", "changed content")
+        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 1
+        assert results[0]["reason"] == "content_changed"
+
+    def test_git_false_ignores_pinned_sha(self, git_repo):
+        sha = _get_head_sha(git_repo)
+        content_hash = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief",
+                      source="source.md", source_hash=content_hash)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        results, upgraded = check_stale(net, db_dir=git_repo, git_aware=False)
+        assert len(results) == 0

--- a/tests/test_pin_sources.py
+++ b/tests/test_pin_sources.py
@@ -105,6 +105,12 @@ class TestPinSourceUrl:
         result = pin_source_url(url, sha)
         assert f"/blob/{sha}/src/main.py" in result
 
+    def test_rewrites_slashed_branch_with_source_path(self):
+        url = "https://github.com/owner/repo/blob/feature/fix/src/main.py"
+        sha = "b" * 40
+        result = pin_source_url(url, sha, source_path="src/main.py")
+        assert result == f"https://github.com/owner/repo/blob/{sha}/src/main.py"
+
 
 class TestPinSources:
     def test_pins_node_with_source(self, git_repo):


### PR DESCRIPTION
## Summary

- Adds `pin-sources` command to store git commit SHA (`pinned_sha`) and verification date in node metadata
- Adds `pin-update` command to bump `pinned_sha` after re-verifying stale beliefs
- Adds `--git` flag to `check-stale` for tiered staleness detection: skip content hashing when no commits touched the file since pinned SHA, auto-bump SHA when content unchanged
- Adds `--pin-urls` flag to rewrite GitHub branch URLs to immutable SHA-pinned URLs

Closes #169

## Test plan

- [x] 28 new tests pass covering all pin functions and git-aware staleness
- [x] 45 existing check-stale tests still pass
- [ ] Manual integration test with real git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)