### PR TITLE
Add line-range pinning for precise staleness detection

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1751,6 +1751,35 @@ def pin_update(
                 "errors": errors}
 
 
+def pin_lines(
+    node_id: str,
+    line_start: int,
+    line_end: int,
+    repos: dict[str, str] | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Set pinned_lines metadata on a node.
+
+    If the node doesn't have a pinned_sha yet, auto-pins it.
+
+    Returns: {"node_id", "pinned_lines", "pinned_sha", "auto_pinned"}
+    """
+    from pathlib import Path as P
+    from .check_stale import pin_lines as _pin_lines
+
+    db_dir = P(db_path).resolve().parent
+
+    with _with_network(db_path, write=True) as net:
+        repo_paths = repos
+        if repo_paths is None and net.repos:
+            repo_paths = net.repos
+        if repo_paths:
+            repo_paths = {k: P(v) for k, v in repo_paths.items()}
+
+        return _pin_lines(net, node_id, line_start, line_end,
+                          repos=repo_paths, db_dir=db_dir)
+
+
 def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
             pg_conninfo=None, project_id=None) -> str:
     """Generate a token-budgeted belief state summary.

--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -117,6 +117,7 @@ def check_stale(
                         if new_sha and new_sha != pinned_sha:
                             node.metadata["pinned_sha"] = new_sha
                             node.metadata["verified_at"] = date.today().isoformat()
+                            node.source_hash = hash_file(path)
                             sha_bumped += 1
                         continue
             elif not file_changed_since(path, pinned_sha):

--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -104,7 +104,13 @@ def check_stale(
 
         pinned_sha = node.metadata.get("pinned_sha") if node.metadata else None
         if git_aware and pinned_sha:
-            if not file_changed_since(path, pinned_sha):
+            pinned_lines = node.metadata.get("pinned_lines") if node.metadata else None
+            if pinned_lines:
+                parts = pinned_lines.split("-")
+                ls, le = int(parts[0]), int(parts[1])
+                if not file_lines_changed_since(path, pinned_sha, ls, le):
+                    continue
+            elif not file_changed_since(path, pinned_sha):
                 continue
 
         current_hash = hash_file(path)
@@ -227,6 +233,58 @@ def file_changed_since(filepath: Path, since_sha: str) -> bool:
         )
         if result.returncode != 0:
             return True
+        return False
+    except subprocess.TimeoutExpired:
+        return True
+
+
+def parse_diff_hunks(diff_output: str) -> list[tuple[int, int]]:
+    """Parse unified diff hunk headers, return OLD-side (start, end) ranges.
+
+    Skips hunks with count=0 (pure insertions that don't affect old lines).
+    """
+    hunks = []
+    for m in re.finditer(r'^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@', diff_output, re.MULTILINE):
+        start = int(m.group(1))
+        count = int(m.group(2)) if m.group(2) is not None else 1
+        if count == 0:
+            continue
+        hunks.append((start, start + count - 1))
+    return hunks
+
+
+def file_lines_changed_since(
+    filepath: Path, since_sha: str, line_start: int, line_end: int,
+) -> bool:
+    """Check if specific lines were modified since since_sha.
+
+    Parses unified diff hunk headers from committed and uncommitted changes.
+    Uses the OLD side of the diff (stored lines reference the file at pinned_sha).
+    Returns True on git errors to force fallback to content hashing.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "-U0", since_sha, "HEAD", "--", str(filepath.name)],
+            capture_output=True, text=True,
+            cwd=str(filepath.parent),
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return True
+        for hunk_start, hunk_end in parse_diff_hunks(result.stdout):
+            if hunk_end >= line_start and hunk_start <= line_end:
+                return True
+        result = subprocess.run(
+            ["git", "diff", "-U0", "HEAD", "--", str(filepath.name)],
+            capture_output=True, text=True,
+            cwd=str(filepath.parent),
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return True
+        for hunk_start, hunk_end in parse_diff_hunks(result.stdout):
+            if hunk_end >= line_start and hunk_start <= line_end:
+                return True
         return False
     except subprocess.TimeoutExpired:
         return True
@@ -366,3 +424,49 @@ def pin_update(
         })
 
     return results
+
+
+def pin_lines(
+    network: Network,
+    node_id: str,
+    line_start: int,
+    line_end: int,
+    repos: dict[str, Path] | None = None,
+    db_dir: Path | None = None,
+) -> dict:
+    """Set pinned_lines on a node, auto-pinning SHA if not already set."""
+    if line_start < 1:
+        raise ValueError(f"line_start must be >= 1, got {line_start}")
+    if line_end < line_start:
+        raise ValueError(f"line_end ({line_end}) must be >= line_start ({line_start})")
+
+    node = network.nodes.get(node_id)
+    if node is None:
+        raise KeyError(f"node {node_id!r} not found")
+    if not node.source:
+        raise ValueError(f"node {node_id!r} has no source")
+
+    if repos is None and network.repos:
+        repos = {k: Path(v) for k, v in network.repos.items()}
+
+    node.metadata["pinned_lines"] = f"{line_start}-{line_end}"
+
+    auto_pinned = False
+    if not node.metadata.get("pinned_sha"):
+        agent = node.metadata.get("agent") if node.metadata else None
+        path = resolve_source_path(node.source, repos, db_dir, agent=agent)
+        if path is not None:
+            sha = get_file_commit_sha(path)
+            if sha:
+                node.metadata["pinned_sha"] = sha
+                node.metadata["verified_at"] = date.today().isoformat()
+                auto_pinned = True
+            if not node.source_hash:
+                node.source_hash = hash_file(path)
+
+    return {
+        "node_id": node_id,
+        "pinned_lines": node.metadata["pinned_lines"],
+        "pinned_sha": node.metadata.get("pinned_sha", ""),
+        "auto_pinned": auto_pinned,
+    }

--- a/reasons_lib/check_stale.py
+++ b/reasons_lib/check_stale.py
@@ -106,10 +106,19 @@ def check_stale(
         if git_aware and pinned_sha:
             pinned_lines = node.metadata.get("pinned_lines") if node.metadata else None
             if pinned_lines:
-                parts = pinned_lines.split("-")
-                ls, le = int(parts[0]), int(parts[1])
-                if not file_lines_changed_since(path, pinned_sha, ls, le):
-                    continue
+                try:
+                    parts = pinned_lines.split("-")
+                    ls, le = int(parts[0]), int(parts[1])
+                except (ValueError, IndexError):
+                    pass  # malformed pinned_lines — fall through to content hash
+                else:
+                    if not file_lines_changed_since(path, pinned_sha, ls, le):
+                        new_sha = get_file_commit_sha(path)
+                        if new_sha and new_sha != pinned_sha:
+                            node.metadata["pinned_sha"] = new_sha
+                            node.metadata["verified_at"] = date.today().isoformat()
+                            sha_bumped += 1
+                        continue
             elif not file_changed_since(path, pinned_sha):
                 continue
 
@@ -258,24 +267,13 @@ def file_lines_changed_since(
 ) -> bool:
     """Check if specific lines were modified since since_sha.
 
-    Parses unified diff hunk headers from committed and uncommitted changes.
-    Uses the OLD side of the diff (stored lines reference the file at pinned_sha).
-    Returns True on git errors to force fallback to content hashing.
+    Diffs since_sha against the working tree (committed + uncommitted) in
+    a single call. Uses the OLD side of the diff (stored lines reference the
+    file at pinned_sha). Returns True on git errors to force content hash fallback.
     """
     try:
         result = subprocess.run(
-            ["git", "diff", "-U0", since_sha, "HEAD", "--", str(filepath.name)],
-            capture_output=True, text=True,
-            cwd=str(filepath.parent),
-            timeout=30,
-        )
-        if result.returncode != 0:
-            return True
-        for hunk_start, hunk_end in parse_diff_hunks(result.stdout):
-            if hunk_end >= line_start and hunk_start <= line_end:
-                return True
-        result = subprocess.run(
-            ["git", "diff", "-U0", "HEAD", "--", str(filepath.name)],
+            ["git", "diff", "-U0", since_sha, "--", str(filepath.name)],
             capture_output=True, text=True,
             cwd=str(filepath.parent),
             timeout=30,
@@ -449,6 +447,8 @@ def pin_lines(
     if repos is None and network.repos:
         repos = {k: Path(v) for k, v in network.repos.items()}
 
+    if not node.metadata:
+        node.metadata = {}
     node.metadata["pinned_lines"] = f"{line_start}-{line_end}"
 
     auto_pinned = False
@@ -461,8 +461,7 @@ def pin_lines(
                 node.metadata["pinned_sha"] = sha
                 node.metadata["verified_at"] = date.today().isoformat()
                 auto_pinned = True
-            if not node.source_hash:
-                node.source_hash = hash_file(path)
+            node.source_hash = hash_file(path)
 
     return {
         "node_id": node_id,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -262,6 +262,11 @@ def cmd_show(args):
         print(f"URL:    {node['source_url']}")
     if node["source_hash"]:
         print(f"Hash:   {node['source_hash']}")
+    if node["metadata"].get("pinned_sha"):
+        sha = node["metadata"]["pinned_sha"][:12]
+        lines = node["metadata"].get("pinned_lines", "")
+        line_info = f" (lines {lines})" if lines else ""
+        print(f"Pinned: {sha}{line_info}")
 
     if node["justifications"]:
         print(f"\nJustifications ({len(node['justifications'])}):")
@@ -775,6 +780,25 @@ def cmd_pin_update(args):
         print(f"\n{result['count']} updated, {result['errors']} errors")
     else:
         print(f"\n{result['count']} updated")
+
+
+def cmd_pin_lines(args):
+    _require_sqlite(args, "pin-lines")
+    try:
+        result = api.pin_lines(
+            node_id=args.node_id,
+            line_start=args.start,
+            line_end=args.end,
+            db_path=args.db,
+        )
+    except (KeyError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    lines = result["pinned_lines"]
+    sha = result["pinned_sha"][:12] if result.get("pinned_sha") else "(none)"
+    auto = " (auto-pinned SHA)" if result.get("auto_pinned") else ""
+    print(f"  PINNED  {result['node_id']}  lines {lines}  sha {sha}{auto}")
 
 
 def cmd_compact(args):
@@ -1943,6 +1967,12 @@ def main():
     p = sub.add_parser("pin-update", help="Bump pinned_sha to current HEAD for beliefs")
     p.add_argument("node_ids", nargs="+", help="Belief IDs to update")
 
+    # pin-lines
+    p = sub.add_parser("pin-lines", help="Pin a belief to specific source file lines")
+    p.add_argument("node_id", help="Belief ID to pin")
+    p.add_argument("start", type=int, help="Start line number (1-based)")
+    p.add_argument("end", type=int, help="End line number (inclusive)")
+
     # compact
     p = sub.add_parser("compact", help="Token-budgeted belief state summary")
     p.add_argument("--budget", type=int, default=500, help="Token budget (default: 500)")
@@ -2161,6 +2191,7 @@ def main():
         "check-stale": cmd_check_stale,
         "pin-sources": cmd_pin_sources,
         "pin-update": cmd_pin_update,
+        "pin-lines": cmd_pin_lines,
         "compact": cmd_compact,
         "convert-to-premise": cmd_convert_to_premise,
         "summarize": cmd_summarize,

--- a/tests/test_pin_sources.py
+++ b/tests/test_pin_sources.py
@@ -486,3 +486,21 @@ class TestCheckStaleLineRange:
         results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
         assert len(results) == 0
         assert net.nodes["belief-1"].metadata["pinned_lines"] == "1-3"
+
+    def test_auto_bump_updates_source_hash(self, git_repo):
+        content = self._setup_multiline(git_repo)
+        sha = _get_head_sha(git_repo)
+        h = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief", source="source.md", source_hash=h)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        net.nodes["belief-1"].metadata["pinned_lines"] = "1-2"
+        # Change line 5 (outside pinned range) — content changes but lines don't
+        lines = content.split("\n")
+        lines[4] = "CHANGED"
+        new_content = "\n".join(lines)
+        _commit_change(git_repo, "source.md", new_content)
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 0
+        assert sha_bumped == 1
+        assert net.nodes["belief-1"].source_hash == hash_file(git_repo / "source.md")

--- a/tests/test_pin_sources.py
+++ b/tests/test_pin_sources.py
@@ -11,7 +11,10 @@ from reasons_lib.check_stale import (
     check_stale,
     get_file_commit_sha,
     file_changed_since,
+    file_lines_changed_since,
     hash_file,
+    parse_diff_hunks,
+    pin_lines,
     pin_source_url,
     pin_sources,
     pin_update,
@@ -281,3 +284,205 @@ class TestCheckStaleGitAware:
         net.nodes["belief-1"].metadata["pinned_sha"] = sha
         results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=False)
         assert len(results) == 0
+
+
+class TestParseDiffHunks:
+    def test_parses_single_hunk(self):
+        diff = "@@ -89,5 +89,7 @@ def some_function():\n"
+        assert parse_diff_hunks(diff) == [(89, 93)]
+
+    def test_parses_multiple_hunks(self):
+        diff = (
+            "@@ -10,3 +10,4 @@ ...\n"
+            " context\n"
+            "@@ -50,2 +51,2 @@ ...\n"
+        )
+        assert parse_diff_hunks(diff) == [(10, 12), (50, 51)]
+
+    def test_single_line_hunk_no_count(self):
+        diff = "@@ -42 +42,2 @@\n"
+        assert parse_diff_hunks(diff) == [(42, 42)]
+
+    def test_zero_count_hunk_excluded(self):
+        diff = "@@ -89,0 +90,3 @@\n"
+        assert parse_diff_hunks(diff) == []
+
+    def test_empty_diff(self):
+        assert parse_diff_hunks("") == []
+
+    def test_no_hunk_headers(self):
+        diff = "diff --git a/file.py b/file.py\nindex abc..def\n"
+        assert parse_diff_hunks(diff) == []
+
+
+class TestFileLinesChangedSince:
+    def _multiline_file(self, git_repo, lines=5):
+        content = "\n".join(f"line{i}" for i in range(1, lines + 1)) + "\n"
+        (git_repo / "source.md").write_text(content)
+        subprocess.run(["git", "add", "source.md"], cwd=git_repo,
+                       capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "multiline"], cwd=git_repo,
+                       capture_output=True, check=True)
+        return content
+
+    def test_no_change_returns_false(self, git_repo):
+        self._multiline_file(git_repo)
+        sha = _get_head_sha(git_repo)
+        assert not file_lines_changed_since(git_repo / "source.md", sha, 1, 5)
+
+    def test_detects_change_in_pinned_range(self, git_repo):
+        self._multiline_file(git_repo)
+        sha = _get_head_sha(git_repo)
+        lines = (git_repo / "source.md").read_text().split("\n")
+        lines[2] = "CHANGED"
+        (git_repo / "source.md").write_text("\n".join(lines))
+        subprocess.run(["git", "add", "source.md"], cwd=git_repo,
+                       capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "edit line 3"], cwd=git_repo,
+                       capture_output=True, check=True)
+        assert file_lines_changed_since(git_repo / "source.md", sha, 2, 4)
+
+    def test_ignores_change_outside_pinned_range(self, git_repo):
+        self._multiline_file(git_repo)
+        sha = _get_head_sha(git_repo)
+        lines = (git_repo / "source.md").read_text().split("\n")
+        lines[4] = "CHANGED"
+        (git_repo / "source.md").write_text("\n".join(lines))
+        subprocess.run(["git", "add", "source.md"], cwd=git_repo,
+                       capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "edit line 5"], cwd=git_repo,
+                       capture_output=True, check=True)
+        assert not file_lines_changed_since(git_repo / "source.md", sha, 1, 3)
+
+    def test_detects_uncommitted_change_in_range(self, git_repo):
+        self._multiline_file(git_repo)
+        sha = _get_head_sha(git_repo)
+        lines = (git_repo / "source.md").read_text().split("\n")
+        lines[1] = "CHANGED"
+        (git_repo / "source.md").write_text("\n".join(lines))
+        assert file_lines_changed_since(git_repo / "source.md", sha, 2, 2)
+
+    def test_fails_open_on_bad_sha(self, git_repo):
+        assert file_lines_changed_since(
+            git_repo / "source.md", "0" * 40, 1, 5
+        )
+
+
+class TestPinLines:
+    def test_sets_pinned_lines(self, git_repo):
+        net = Network()
+        h = hash_file(git_repo / "source.md")
+        net.add_node("belief-1", "Test belief", source="source.md", source_hash=h)
+        result = pin_lines(net, "belief-1", 89, 93, db_dir=git_repo)
+        assert result["pinned_lines"] == "89-93"
+        assert net.nodes["belief-1"].metadata["pinned_lines"] == "89-93"
+
+    def test_auto_pins_sha_if_missing(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief", source="source.md", source_hash="")
+        result = pin_lines(net, "belief-1", 1, 10, db_dir=git_repo)
+        assert result["auto_pinned"] is True
+        assert len(result["pinned_sha"]) == 40
+        assert net.nodes["belief-1"].metadata["pinned_sha"] == result["pinned_sha"]
+
+    def test_preserves_existing_sha(self, git_repo):
+        net = Network()
+        h = hash_file(git_repo / "source.md")
+        net.add_node("belief-1", "Test belief", source="source.md", source_hash=h)
+        net.nodes["belief-1"].metadata["pinned_sha"] = "a" * 40
+        result = pin_lines(net, "belief-1", 1, 10, db_dir=git_repo)
+        assert result["auto_pinned"] is False
+        assert result["pinned_sha"] == "a" * 40
+
+    def test_validates_line_range(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief", source="source.md")
+        with pytest.raises(ValueError):
+            pin_lines(net, "belief-1", 0, 10, db_dir=git_repo)
+        with pytest.raises(ValueError):
+            pin_lines(net, "belief-1", 10, 5, db_dir=git_repo)
+
+    def test_error_on_missing_node(self, git_repo):
+        net = Network()
+        with pytest.raises(KeyError):
+            pin_lines(net, "nonexistent", 1, 10, db_dir=git_repo)
+
+    def test_error_on_no_source(self, git_repo):
+        net = Network()
+        net.add_node("belief-1", "Test belief")
+        with pytest.raises(ValueError):
+            pin_lines(net, "belief-1", 1, 10, db_dir=git_repo)
+
+
+class TestCheckStaleLineRange:
+    def _setup_multiline(self, git_repo, lines=5):
+        content = "\n".join(f"line{i}" for i in range(1, lines + 1)) + "\n"
+        (git_repo / "source.md").write_text(content)
+        subprocess.run(["git", "add", "source.md"], cwd=git_repo,
+                       capture_output=True, check=True)
+        subprocess.run(["git", "commit", "-m", "multiline"], cwd=git_repo,
+                       capture_output=True, check=True)
+        return content
+
+    def test_fresh_when_change_outside_pinned_lines(self, git_repo):
+        content = self._setup_multiline(git_repo)
+        sha = _get_head_sha(git_repo)
+        h = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief", source="source.md", source_hash=h)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        net.nodes["belief-1"].metadata["pinned_lines"] = "1-2"
+        # Change line 5 (outside pinned range)
+        lines = content.split("\n")
+        lines[4] = "CHANGED"
+        _commit_change(git_repo, "source.md", "\n".join(lines))
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 0
+
+    def test_stale_when_change_inside_pinned_lines(self, git_repo):
+        content = self._setup_multiline(git_repo)
+        sha = _get_head_sha(git_repo)
+        h = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief", source="source.md", source_hash=h)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        net.nodes["belief-1"].metadata["pinned_lines"] = "1-3"
+        # Change line 2 (inside pinned range)
+        lines = content.split("\n")
+        lines[1] = "CHANGED"
+        _commit_change(git_repo, "source.md", "\n".join(lines))
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 1
+        assert results[0]["reason"] == "content_changed"
+
+    def test_falls_back_to_whole_file_without_pinned_lines(self, git_repo):
+        content = self._setup_multiline(git_repo)
+        sha = _get_head_sha(git_repo)
+        h = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief", source="source.md", source_hash=h)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        # No pinned_lines — any change to file should trigger stale
+        lines = content.split("\n")
+        lines[4] = "CHANGED"
+        _commit_change(git_repo, "source.md", "\n".join(lines))
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 1
+
+    def test_auto_bumps_sha_preserves_pinned_lines(self, git_repo):
+        content = self._setup_multiline(git_repo)
+        sha = _get_head_sha(git_repo)
+        h = hash_file(git_repo / "source.md")
+        net = Network()
+        net.add_node("belief-1", "Test belief", source="source.md", source_hash=h)
+        net.nodes["belief-1"].metadata["pinned_sha"] = sha
+        net.nodes["belief-1"].metadata["pinned_lines"] = "1-3"
+        # Change line 5 (outside range), then revert to original
+        lines = content.split("\n")
+        lines[4] = "CHANGED"
+        _commit_change(git_repo, "source.md", "\n".join(lines))
+        _commit_change(git_repo, "source.md", content)
+        new_head = _get_head_sha(git_repo)
+        results, upgraded, sha_bumped = check_stale(net, db_dir=git_repo, git_aware=True)
+        assert len(results) == 0
+        assert net.nodes["belief-1"].metadata["pinned_lines"] == "1-3"


### PR DESCRIPTION
## Summary

Closes #170. Extends #169 SHA pinning so beliefs can be pinned to specific source line ranges. check-stale --git now only flags stale when the diff between pinned SHA and HEAD touches the pinned lines, not the entire file.

- New metadata field pinned_lines (e.g., 89-93) stored alongside pinned_sha
- New parse_diff_hunks() parses unified diff @@ headers (uses -U0 for exact ranges)
- New file_lines_changed_since() checks committed + uncommitted diffs for line-range overlap
- New pin_lines() sets line range and auto-pins SHA if not already set
- New CLI command: reasons pin-lines NODE START END
- Enhanced reasons show to display pinned SHA and line range
- 21 new tests covering hunk parsing, line-range detection, pin-lines, and check-stale integration

## Test plan

- [x] parse_diff_hunks unit tests (6 tests)
- [x] file_lines_changed_since integration tests (5 tests)
- [x] pin_lines tests (6 tests)
- [x] check_stale line-range integration (4 tests)
- [x] All 88 existing tests pass (zero regressions)