### PR TITLE
Add propose-update command for structured belief amendments

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2540,7 +2540,7 @@ def review_beliefs(
 def propose_update(
     belief_ids: list[str] | None = None,
     model: str = "claude",
-    timeout: int = 300,
+    timeout: int = 600,
     stale_only: bool = False,
     namespace: str | None = None,
     sample: int | None = None,

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2537,6 +2537,78 @@ def review_beliefs(
     }
 
 
+def propose_update(
+    belief_ids: list[str] | None = None,
+    model: str = "claude",
+    timeout: int = 300,
+    stale_only: bool = False,
+    namespace: str | None = None,
+    sample: int | None = None,
+    on_batch: Callable | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Propose structured updates or retractions for beliefs.
+
+    Sends beliefs to an LLM for evaluation, classifying each by failure
+    mode and update basis. Computes cascade impact for retract proposals.
+
+    Returns: {"proposals": [...], "reviewed": int, "timestamp": str}
+    """
+    from datetime import datetime
+
+    from .propose_update import propose_updates as _propose
+
+    result = export_network(db_path=db_path)
+    nodes = result.get("nodes", {})
+
+    candidates = {
+        k: v for k, v in nodes.items()
+        if v.get("truth_value") == "IN"
+    }
+
+    if belief_ids:
+        candidates = {k: v for k, v in candidates.items() if k in belief_ids}
+
+    if stale_only:
+        candidates = {
+            k: v for k, v in candidates.items()
+            if (v.get("metadata") or {}).get("stale_reason")
+        }
+
+    if namespace is not None:
+        if namespace == "":
+            candidates = {k: v for k, v in candidates.items() if ":" not in k}
+        else:
+            candidates = {
+                k: v for k, v in candidates.items()
+                if k.startswith(f"{namespace}:")
+            }
+
+    if sample is not None and len(candidates) > sample:
+        import random
+        sampled_keys = random.sample(sorted(candidates.keys()), sample)
+        candidates = {k: candidates[k] for k in sampled_keys}
+
+    review_ids = sorted(candidates.keys())
+    proposals = _propose(nodes, belief_ids=review_ids, model=model,
+                         timeout=timeout, on_batch=on_batch)
+
+    cascades = {}
+    for p in proposals:
+        try:
+            cascades[p["id"]] = what_if_retract(p["id"], db_path=db_path)
+        except KeyError:
+            pass
+
+    now = datetime.now().isoformat(timespec="seconds")
+    return {
+        "proposals": proposals,
+        "cascades": cascades,
+        "reviewed": len(review_ids),
+        "timestamp": now,
+    }
+
+
 def repair_smuggled(
     review_file: str | None = None,
     belief_ids: list[str] | None = None,

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2590,11 +2590,20 @@ def propose_update(
         candidates = {k: candidates[k] for k in sampled_keys}
 
     review_ids = sorted(candidates.keys())
+
+    # Enrich nodes with dependents (export_network doesn't include them)
+    with _with_network(db_path) as net:
+        for nid in nodes:
+            if nid in net.nodes:
+                nodes[nid]["dependents"] = sorted(net.nodes[nid].dependents)
+
     proposals = _propose(nodes, belief_ids=review_ids, model=model,
                          timeout=timeout, on_batch=on_batch)
 
     cascades = {}
     for p in proposals:
+        if p["id"] not in nodes:
+            continue
         try:
             cascades[p["id"]] = what_if_retract(p["id"], db_path=db_path)
         except KeyError:

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1575,20 +1575,15 @@ def cmd_propose_update(args):
 
     print(f"\nReviewed {result['reviewed']} beliefs, {len(proposals)} update(s) proposed")
 
-    nodes = None
-    if output_format == "markdown" or args.output:
+    if output_format == "markdown":
         net_result = api.export_network(db_path=args.db)
         nodes = net_result.get("nodes", {})
-
-    output_file = args.output or "proposed-updates.md"
-    if output_format == "json":
-        output_file = args.output or "proposed-updates.json"
-
-    if output_format == "markdown":
+        output_file = args.output or "proposed-updates.md"
         content = format_proposals_file(proposals, nodes=nodes, cascades=cascades)
         Path(output_file).write_text(content)
         print(f"\nWrote proposals to {output_file}")
     else:
+        output_file = args.output or "proposed-updates.json"
         Path(output_file).write_text(_json.dumps({
             "timestamp": ts,
             "model": model,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1520,6 +1520,95 @@ def cmd_review_beliefs(args):
                 print(f"  ERROR retracting {r['id']}: {e}", file=sys.stderr)
 
 
+def cmd_propose_update(args):
+    _require_sqlite(args, "propose-update")
+    import json as _json
+    from datetime import datetime
+
+    from .propose_update import format_proposals_file
+
+    model = getattr(args, "model", None) or "claude"
+    ts = datetime.now().isoformat(timespec="seconds")
+    write_report = not args.no_report
+    output_format = getattr(args, "format", "markdown") or "markdown"
+
+    report_path = None
+    if write_report:
+        report_dir = Path(args.report_dir)
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_path = report_dir / f"propose-update-{ts.replace(':', '')}.json"
+
+    def on_batch(results):
+        if report_path is not None:
+            report_path.write_text(_json.dumps({
+                "timestamp": ts,
+                "status": "partial",
+                "model": model,
+                "proposals": results,
+            }, indent=2))
+
+    result = api.propose_update(
+        belief_ids=args.ids or None,
+        model=model,
+        timeout=args.timeout,
+        stale_only=args.stale_only,
+        namespace=args.namespace,
+        sample=args.sample,
+        on_batch=on_batch,
+        db_path=args.db,
+    )
+
+    proposals = result["proposals"]
+    cascades = result.get("cascades", {})
+
+    if not proposals:
+        print("No updates proposed.")
+        return
+
+    for p in proposals:
+        action = p["action"].upper()
+        basis = p.get("basis", "")
+        fm = p.get("failure_mode", "")
+        print(f"  [{action}] {p['id']}  ({fm}, {basis})")
+        if p.get("comment"):
+            print(f"    {p['comment']}")
+
+    print(f"\nReviewed {result['reviewed']} beliefs, {len(proposals)} update(s) proposed")
+
+    nodes = None
+    if output_format == "markdown" or args.output:
+        net_result = api.export_network(db_path=args.db)
+        nodes = net_result.get("nodes", {})
+
+    output_file = args.output or "proposed-updates.md"
+    if output_format == "json":
+        output_file = args.output or "proposed-updates.json"
+
+    if output_format == "markdown":
+        content = format_proposals_file(proposals, nodes=nodes, cascades=cascades)
+        Path(output_file).write_text(content)
+        print(f"\nWrote proposals to {output_file}")
+    else:
+        Path(output_file).write_text(_json.dumps({
+            "timestamp": ts,
+            "model": model,
+            "reviewed": result["reviewed"],
+            "proposals": proposals,
+            "cascades": {k: v for k, v in cascades.items()},
+        }, indent=2))
+        print(f"\nWrote proposals to {output_file}")
+
+    if write_report and report_path is not None:
+        report_path.write_text(_json.dumps({
+            "timestamp": ts,
+            "status": "complete",
+            "model": model,
+            "reviewed": result["reviewed"],
+            "proposals": proposals,
+        }, indent=2))
+        print(f"  Report: {report_path}")
+
+
 def cmd_repair_smuggled(args):
     _require_sqlite(args, "repair-smuggled")
 
@@ -2088,6 +2177,29 @@ def main():
     p.add_argument("--no-report", action="store_true",
                    help="Skip JSON report generation")
 
+    # propose-update
+    p = sub.add_parser("propose-update",
+        help="Propose structured updates or retractions for beliefs (LLM-driven)")
+    p.add_argument("ids", nargs="*", help="Specific belief IDs to evaluate (default: all IN)")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
+    p.add_argument("--timeout", type=int, default=600,
+                   help="LLM timeout in seconds (default: 600)")
+    p.add_argument("--stale-only", action="store_true",
+                   help="Only evaluate beliefs flagged as stale")
+    p.add_argument("-n", "--namespace", default=None,
+                   help="Filter by agent namespace (use empty string '' for local beliefs only)")
+    p.add_argument("--sample", type=int, default=None,
+                   help="Randomly sample N beliefs to evaluate")
+    p.add_argument("-o", "--output", default=None,
+                   help="Output file path (default: proposed-updates.md or .json)")
+    p.add_argument("--format", choices=["markdown", "json"], default="markdown",
+                   help="Output format (default: markdown)")
+    p.add_argument("--report-dir", default="reviews",
+                   help="Directory for JSON reports (default: reviews/)")
+    p.add_argument("--no-report", action="store_true",
+                   help="Skip JSON report generation")
+
     # repair-smuggled
     p = sub.add_parser("repair-smuggled",
         help="Repair smuggled premises by finding and linking existing premises")
@@ -2211,6 +2323,7 @@ def main():
         "list-negative": cmd_list_negative,
         "topics": cmd_topics,
         "review-beliefs": cmd_review_beliefs,
+        "propose-update": cmd_propose_update,
         "repair-smuggled": cmd_repair_smuggled,
         "research": cmd_research,
         "contradictions": cmd_contradictions,

--- a/reasons_lib/propose_update.py
+++ b/reasons_lib/propose_update.py
@@ -185,6 +185,8 @@ def parse_update_proposals(response):
             if action not in ("update", "retract"):
                 action = "update"
             failure_mode = item.get("failure_mode", "")
+            if failure_mode not in FAILURE_MODES:
+                failure_mode = ""
             basis = item.get("basis", "prior-knowledge")
             if basis not in BASES:
                 basis = "prior-knowledge"

--- a/reasons_lib/propose_update.py
+++ b/reasons_lib/propose_update.py
@@ -231,13 +231,22 @@ def format_proposal_markdown(proposal, nodes=None, cascade=None):
         restored = cascade.get("restored", [])
         total = cascade.get("total_affected", 0)
         if total > 0:
-            lines.append(f"\n**Cascade impact:** {total} dependent(s) affected")
-            for item in retracted:
-                text = item.get("text", "")[:80]
-                lines.append(f"- {item['id']}: \"{text}\" — will go OUT")
-            for item in restored:
-                text = item.get("text", "")[:80]
-                lines.append(f"- {item['id']}: \"{text}\" — will go IN")
+            if action == "RETRACT":
+                lines.append(f"\n**Cascade impact:** {total} dependent(s) affected")
+                for item in retracted:
+                    text = item.get("text", "")[:80]
+                    lines.append(f"- {item['id']}: \"{text}\" — will go OUT")
+                for item in restored:
+                    text = item.get("text", "")[:80]
+                    lines.append(f"- {item['id']}: \"{text}\" — will go IN")
+            else:
+                lines.append(f"\n**Cascade impact:** {total} dependent(s) need re-review")
+                for item in retracted:
+                    text = item.get("text", "")[:80]
+                    lines.append(f"- {item['id']}: \"{text}\"")
+                for item in restored:
+                    text = item.get("text", "")[:80]
+                    lines.append(f"- {item['id']}: \"{text}\"")
         else:
             lines.append("\n**Cascade impact:** none")
     else:

--- a/reasons_lib/propose_update.py
+++ b/reasons_lib/propose_update.py
@@ -1,0 +1,320 @@
+"""Propose structured updates to existing beliefs.
+
+Feeds beliefs to an LLM with their justification chains, source info,
+and dependents. Returns structured proposals with failure mode taxonomy,
+update basis, evidence, and cascade impact predictions.
+"""
+
+import json
+import sys
+
+from .llm import invoke_model
+
+PROPOSE_UPDATE_BATCH_SIZE = 10
+
+FAILURE_MODES = {
+    "smuggled-premise",
+    "unsupported-superlative",
+    "false-causal-link",
+    "domain-conflation",
+    "contradicted-by-source",
+    "stale",
+}
+
+BASES = {
+    "source-divergence",
+    "detected-contradiction",
+    "prior-knowledge",
+}
+
+PROPOSE_UPDATE_PROMPT = """\
+You are auditing beliefs in a Truth Maintenance System (TMS).
+Each belief below may need updating or retracting based on its current
+text, source material, justification chain, and dependents.
+
+For each belief, decide: does it need an update, a retraction, or is it fine?
+Only propose changes for beliefs that genuinely need them. If a belief is
+accurate and well-supported, skip it (do not include it in the output).
+
+For each belief that needs a change, classify:
+
+1. **action**: "update" (amend the text) or "retract" (remove the belief)
+
+2. **failure_mode**: one of these categories:
+   - smuggled-premise: unstated assumption baked into the claim
+   - unsupported-superlative: "always", "never", "all" without evidence
+   - false-causal-link: correlation presented as causation
+   - domain-conflation: mixing concepts from different domains
+   - contradicted-by-source: source material disagrees with the claim
+   - stale: source material has changed, belief is outdated
+
+3. **basis**: why this update is being proposed:
+   - source-divergence: the source file/URL changed (mechanically verifiable, cheap to accept)
+   - detected-contradiction: conflicts with another belief (nogood)
+   - prior-knowledge: your own assessment (needs scrutiny — reviewer may share your blind spot)
+
+4. **proposed_text**: the corrected text (null if retracting)
+
+5. **evidence**: explanation with URLs where available
+
+6. **comment**: one-sentence summary of the most important finding
+
+Return ONLY a JSON array. For each belief that needs a change, one object:
+
+```json
+[
+  {{
+    "id": "belief-id",
+    "action": "update",
+    "proposed_text": "The corrected belief text.",
+    "failure_mode": "smuggled-premise",
+    "basis": "prior-knowledge",
+    "evidence": "The original claim assumes X, but the source shows Y.",
+    "comment": "Removes unstated assumption about X."
+  }}
+]
+```
+
+If no beliefs need changes, return an empty array: []
+
+Rules:
+- Only propose changes for beliefs that genuinely need them.
+- Be conservative: when in doubt, don't propose a change.
+- For "update" actions, proposed_text must be meaningfully different from current text.
+- For "retract" actions, set proposed_text to null.
+- Use the failure_mode and basis taxonomies exactly as defined above.
+- Include source URLs in evidence when the belief has a source_url.
+
+## Beliefs to review
+
+{beliefs}"""
+
+
+def format_belief_for_update(node_id, nodes):
+    """Format one belief with source info and dependents for LLM review."""
+    node = nodes.get(node_id)
+    if not node:
+        return ""
+
+    lines = [f"### {node_id}"]
+    lines.append(f"Text: {node.get('text', '')}")
+    lines.append(f"Status: {node.get('truth_value', 'unknown')}")
+
+    source = node.get("source", "")
+    if source:
+        lines.append(f"Source: {source}")
+
+    source_url = node.get("source_url", "")
+    if source_url:
+        lines.append(f"Source URL: {source_url}")
+
+    meta = node.get("metadata", {}) or {}
+    if meta.get("stale_reason"):
+        lines.append(f"Stale reason: {meta['stale_reason']}")
+
+    justs = node.get("justifications", [])
+    if justs:
+        for ji, j in enumerate(justs):
+            antecedents = j.get("antecedents", [])
+            outlist = j.get("outlist", [])
+            label = j.get("label", "")
+
+            if len(justs) > 1:
+                lines.append(f"Justification {ji + 1}/{len(justs)}:")
+
+            if antecedents:
+                lines.append("Antecedents:")
+                for ant_id in antecedents:
+                    ant_node = nodes.get(ant_id)
+                    if ant_node:
+                        lines.append(f"- {ant_id}: {ant_node.get('text', '')}")
+                    else:
+                        lines.append(f"- {ant_id}: (not found)")
+
+            if outlist:
+                lines.append("Unless (must be OUT):")
+                for out_id in outlist:
+                    out_node = nodes.get(out_id)
+                    if out_node:
+                        lines.append(f"- {out_id}: {out_node.get('text', '')}")
+                    else:
+                        lines.append(f"- {out_id}: (not found)")
+
+            if label:
+                lines.append(f"Label: {label}")
+    else:
+        lines.append("Type: premise (no justifications)")
+
+    dependents = node.get("dependents", [])
+    if dependents:
+        dep_summaries = []
+        for dep_id in sorted(dependents) if isinstance(dependents, (set, list)) else []:
+            dep_node = nodes.get(dep_id)
+            if dep_node:
+                dep_summaries.append(f"- {dep_id}: {dep_node.get('text', '')}")
+            else:
+                dep_summaries.append(f"- {dep_id}: (not found)")
+        if dep_summaries:
+            lines.append(f"Dependents ({len(dep_summaries)}):")
+            lines.extend(dep_summaries)
+
+    return "\n".join(lines)
+
+
+def parse_update_proposals(response):
+    """Extract update proposals JSON array from LLM response.
+
+    Uses json.JSONDecoder.raw_decode at each '[' position to handle
+    prose around the JSON array.
+    """
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(response):
+        if ch != "[":
+            continue
+        try:
+            items, _ = decoder.raw_decode(response, i)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(items, list):
+            continue
+        results = []
+        for item in items:
+            if not isinstance(item, dict) or "id" not in item:
+                continue
+            action = item.get("action", "update")
+            if action not in ("update", "retract"):
+                action = "update"
+            failure_mode = item.get("failure_mode", "")
+            basis = item.get("basis", "prior-knowledge")
+            if basis not in BASES:
+                basis = "prior-knowledge"
+            results.append({
+                "id": item["id"],
+                "action": action,
+                "proposed_text": item.get("proposed_text"),
+                "failure_mode": failure_mode,
+                "basis": basis,
+                "evidence": item.get("evidence", ""),
+                "comment": item.get("comment", ""),
+            })
+        if results:
+            return results
+    return []
+
+
+def format_proposal_markdown(proposal, nodes=None, cascade=None):
+    """Render one proposal as a markdown section."""
+    nid = proposal["id"]
+    action = proposal["action"].upper()
+    lines = [f"## {action}: {nid}", ""]
+
+    current_text = ""
+    if nodes:
+        node = nodes.get(nid, {})
+        current_text = node.get("text", "")
+    lines.append(f"**Current text:** {current_text}")
+
+    if action == "UPDATE" and proposal.get("proposed_text"):
+        lines.append(f"\n**Proposed text:** {proposal['proposed_text']}")
+
+    lines.append(f"\n**Failure mode:** {proposal.get('failure_mode', 'unknown')}")
+    lines.append(f"**Basis:** {proposal.get('basis', 'unknown')}")
+
+    evidence = proposal.get("evidence", "")
+    if evidence:
+        lines.append(f"**Evidence:** {evidence}")
+
+    if cascade:
+        retracted = cascade.get("retracted", [])
+        restored = cascade.get("restored", [])
+        total = cascade.get("total_affected", 0)
+        if total > 0:
+            lines.append(f"\n**Cascade impact:** {total} dependent(s) affected")
+            for item in retracted:
+                text = item.get("text", "")[:80]
+                lines.append(f"- {item['id']}: \"{text}\" — will go OUT")
+            for item in restored:
+                text = item.get("text", "")[:80]
+                lines.append(f"- {item['id']}: \"{text}\" — will go IN")
+        else:
+            lines.append("\n**Cascade impact:** none")
+    else:
+        lines.append("\n**Cascade impact:** not computed")
+
+    if action == "UPDATE" and proposal.get("proposed_text"):
+        escaped = proposal["proposed_text"].replace('"', '\\"')
+        lines.append(f"\n**Command:** `reasons update {nid} \"{escaped}\"`")
+    elif action == "RETRACT":
+        fm = proposal.get("failure_mode", "unknown")
+        lines.append(
+            f"\n**Command:** `reasons retract {nid} "
+            f"--reason \"{fm}: {proposal.get('comment', '')}\"`"
+        )
+
+    return "\n".join(lines)
+
+
+def format_proposals_file(proposals, nodes=None, cascades=None):
+    """Render all proposals as a markdown document."""
+    lines = [
+        "# Proposed Updates",
+        "",
+        "Review each proposal below. Accept by running the suggested command.",
+        "",
+    ]
+    if not proposals:
+        lines.append("No updates proposed.")
+        return "\n".join(lines)
+
+    for proposal in proposals:
+        nid = proposal["id"]
+        cascade = cascades.get(nid) if cascades else None
+        lines.append("---")
+        lines.append("")
+        lines.append(format_proposal_markdown(proposal, nodes, cascade))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def propose_updates(nodes, belief_ids=None, model="claude", timeout=300,
+                    batch_size=PROPOSE_UPDATE_BATCH_SIZE, on_batch=None):
+    """Propose updates for beliefs by sending them to an LLM in batches.
+
+    Returns list of proposal dicts.
+    """
+    if belief_ids is None:
+        belief_ids = [
+            nid for nid, node in sorted(nodes.items())
+            if node.get("truth_value") == "IN"
+        ]
+    else:
+        belief_ids = [nid for nid in belief_ids if nid in nodes]
+
+    if not belief_ids:
+        return []
+
+    all_results = []
+    total_batches = (len(belief_ids) + batch_size - 1) // batch_size
+
+    for i in range(0, len(belief_ids), batch_size):
+        batch = belief_ids[i:i + batch_size]
+        batch_num = i // batch_size + 1
+        print(f"  Reviewing batch {batch_num}/{total_batches} "
+              f"({len(batch)} beliefs)...", file=sys.stderr)
+
+        beliefs_text = "\n\n".join(
+            format_belief_for_update(nid, nodes) for nid in batch
+        )
+        prompt = PROPOSE_UPDATE_PROMPT.format(beliefs=beliefs_text)
+
+        try:
+            response = invoke_model(prompt, model=model, timeout=timeout)
+            results = parse_update_proposals(response)
+            all_results.extend(results)
+            if on_batch is not None:
+                on_batch(all_results)
+        except Exception as e:
+            print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
+
+    return all_results

--- a/tests/test_propose_update.py
+++ b/tests/test_propose_update.py
@@ -112,6 +112,31 @@ class TestFormatBeliefForUpdate:
         result = format_belief_for_update("derived-c", sample_nodes)
         assert "Dependents" not in result
 
+    def test_multiple_justifications(self):
+        nodes = {
+            "multi-just": {
+                "text": "Has two justifications.",
+                "truth_value": "IN",
+                "source": "",
+                "source_url": "",
+                "justifications": [
+                    {"antecedents": ["a"], "outlist": [], "label": "first"},
+                    {"antecedents": ["b"], "outlist": [], "label": "second"},
+                ],
+                "dependents": [],
+                "metadata": {},
+            },
+            "a": {"text": "Ant A.", "truth_value": "IN", "justifications": [],
+                   "source": "", "source_url": "", "dependents": [], "metadata": {}},
+            "b": {"text": "Ant B.", "truth_value": "IN", "justifications": [],
+                   "source": "", "source_url": "", "dependents": [], "metadata": {}},
+        }
+        result = format_belief_for_update("multi-just", nodes)
+        assert "Justification 1/2:" in result
+        assert "Justification 2/2:" in result
+        assert "Label: first" in result
+        assert "Label: second" in result
+
 
 class TestParseUpdateProposals:
     def test_valid_json(self):
@@ -183,6 +208,15 @@ class TestParseUpdateProposals:
         }])
         results = parse_update_proposals(response)
         assert results[0]["basis"] == "prior-knowledge"
+
+    def test_invalid_failure_mode_defaults(self):
+        response = json.dumps([{
+            "id": "x", "action": "update", "proposed_text": "new",
+            "failure_mode": "made-up-mode", "basis": "source-divergence",
+            "evidence": "", "comment": "",
+        }])
+        results = parse_update_proposals(response)
+        assert results[0]["failure_mode"] == ""
 
     def test_invalid_action_defaults(self):
         response = json.dumps([{

--- a/tests/test_propose_update.py
+++ b/tests/test_propose_update.py
@@ -305,6 +305,27 @@ class TestFormatProposalMarkdown:
         assert "**Cascade impact:** 1 dependent(s) affected" in result
         assert 'derived-b: "Blue skies indicate clear weather." — will go OUT' in result
 
+    def test_update_cascade_says_re_review(self, sample_nodes):
+        proposal = {
+            "id": "premise-a",
+            "action": "update",
+            "proposed_text": "Updated sky claim.",
+            "failure_mode": "smuggled-premise",
+            "basis": "prior-knowledge",
+            "evidence": "",
+            "comment": "",
+        }
+        cascade = {
+            "retracted": [
+                {"id": "derived-b", "text": "Blue skies indicate clear weather.", "depth": 1, "dependents": 1},
+            ],
+            "restored": [],
+            "total_affected": 1,
+        }
+        result = format_proposal_markdown(proposal, nodes=sample_nodes, cascade=cascade)
+        assert "need re-review" in result
+        assert "will go OUT" not in result
+
     def test_no_cascade(self, sample_nodes):
         proposal = {
             "id": "premise-a",

--- a/tests/test_propose_update.py
+++ b/tests/test_propose_update.py
@@ -1,0 +1,404 @@
+"""Tests for propose-update command."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib.propose_update import (
+    format_belief_for_update,
+    format_proposal_markdown,
+    format_proposals_file,
+    parse_update_proposals,
+    propose_updates,
+)
+
+
+@pytest.fixture
+def sample_nodes():
+    return {
+        "premise-a": {
+            "text": "The sky is blue.",
+            "truth_value": "IN",
+            "source": "observations/sky.md",
+            "source_url": "https://example.com/sky.md",
+            "justifications": [],
+            "dependents": ["derived-b"],
+            "metadata": {},
+        },
+        "premise-stale": {
+            "text": "The API uses REST.",
+            "truth_value": "IN",
+            "source": "docs/api.md",
+            "source_url": "https://example.com/api.md",
+            "justifications": [],
+            "dependents": [],
+            "metadata": {"stale_reason": "content_changed"},
+        },
+        "derived-b": {
+            "text": "Blue skies indicate clear weather.",
+            "truth_value": "IN",
+            "source": "",
+            "source_url": "",
+            "justifications": [
+                {
+                    "antecedents": ["premise-a"],
+                    "outlist": [],
+                    "label": "weather inference",
+                }
+            ],
+            "dependents": ["derived-c"],
+            "metadata": {},
+        },
+        "derived-c": {
+            "text": "Clear weather is good for flying.",
+            "truth_value": "IN",
+            "source": "",
+            "source_url": "",
+            "justifications": [
+                {
+                    "antecedents": ["derived-b"],
+                    "outlist": ["bad-weather-warning"],
+                    "label": "aviation safety",
+                }
+            ],
+            "dependents": [],
+            "metadata": {},
+        },
+        "bad-weather-warning": {
+            "text": "Storm warning issued.",
+            "truth_value": "OUT",
+            "source": "",
+            "source_url": "",
+            "justifications": [],
+            "dependents": ["derived-c"],
+            "metadata": {},
+        },
+    }
+
+
+class TestFormatBeliefForUpdate:
+    def test_premise_with_source(self, sample_nodes):
+        result = format_belief_for_update("premise-a", sample_nodes)
+        assert "### premise-a" in result
+        assert "Text: The sky is blue." in result
+        assert "Source: observations/sky.md" in result
+        assert "Source URL: https://example.com/sky.md" in result
+        assert "Type: premise" in result
+        assert "Dependents (1):" in result
+        assert "derived-b" in result
+
+    def test_derived_with_justification(self, sample_nodes):
+        result = format_belief_for_update("derived-b", sample_nodes)
+        assert "### derived-b" in result
+        assert "Antecedents:" in result
+        assert "premise-a: The sky is blue." in result
+        assert "Label: weather inference" in result
+
+    def test_derived_with_outlist(self, sample_nodes):
+        result = format_belief_for_update("derived-c", sample_nodes)
+        assert "Unless (must be OUT):" in result
+        assert "bad-weather-warning" in result
+
+    def test_stale_node(self, sample_nodes):
+        result = format_belief_for_update("premise-stale", sample_nodes)
+        assert "Stale reason: content_changed" in result
+
+    def test_missing_node(self, sample_nodes):
+        result = format_belief_for_update("nonexistent", sample_nodes)
+        assert result == ""
+
+    def test_no_dependents(self, sample_nodes):
+        result = format_belief_for_update("derived-c", sample_nodes)
+        assert "Dependents" not in result
+
+
+class TestParseUpdateProposals:
+    def test_valid_json(self):
+        response = """Here are my proposals:
+
+```json
+[
+  {
+    "id": "premise-a",
+    "action": "update",
+    "proposed_text": "The sky appears blue due to Rayleigh scattering.",
+    "failure_mode": "smuggled-premise",
+    "basis": "prior-knowledge",
+    "evidence": "The original claim is simplistic.",
+    "comment": "Adds mechanistic explanation."
+  }
+]
+```"""
+        results = parse_update_proposals(response)
+        assert len(results) == 1
+        assert results[0]["id"] == "premise-a"
+        assert results[0]["action"] == "update"
+        assert "Rayleigh" in results[0]["proposed_text"]
+        assert results[0]["failure_mode"] == "smuggled-premise"
+        assert results[0]["basis"] == "prior-knowledge"
+
+    def test_retract_proposal(self):
+        response = json.dumps([{
+            "id": "bad-belief",
+            "action": "retract",
+            "proposed_text": None,
+            "failure_mode": "contradicted-by-source",
+            "basis": "source-divergence",
+            "evidence": "Source changed.",
+            "comment": "No longer supported.",
+        }])
+        results = parse_update_proposals(response)
+        assert len(results) == 1
+        assert results[0]["action"] == "retract"
+        assert results[0]["proposed_text"] is None
+
+    def test_multiple_proposals(self):
+        response = json.dumps([
+            {"id": "a", "action": "update", "proposed_text": "new a",
+             "failure_mode": "stale", "basis": "source-divergence",
+             "evidence": "", "comment": "stale"},
+            {"id": "b", "action": "retract", "proposed_text": None,
+             "failure_mode": "contradicted-by-source", "basis": "detected-contradiction",
+             "evidence": "", "comment": "wrong"},
+        ])
+        results = parse_update_proposals(response)
+        assert len(results) == 2
+        assert results[0]["id"] == "a"
+        assert results[1]["id"] == "b"
+
+    def test_empty_array(self):
+        results = parse_update_proposals("[]")
+        assert results == []
+
+    def test_malformed_json(self):
+        results = parse_update_proposals("not json at all")
+        assert results == []
+
+    def test_invalid_basis_defaults(self):
+        response = json.dumps([{
+            "id": "x", "action": "update", "proposed_text": "new",
+            "failure_mode": "stale", "basis": "invalid-basis",
+            "evidence": "", "comment": "",
+        }])
+        results = parse_update_proposals(response)
+        assert results[0]["basis"] == "prior-knowledge"
+
+    def test_invalid_action_defaults(self):
+        response = json.dumps([{
+            "id": "x", "action": "invalid",
+            "proposed_text": "new", "failure_mode": "stale",
+            "basis": "source-divergence", "evidence": "", "comment": "",
+        }])
+        results = parse_update_proposals(response)
+        assert results[0]["action"] == "update"
+
+    def test_prose_around_json(self):
+        response = "I found issues with these beliefs:\n" + json.dumps([{
+            "id": "x", "action": "retract", "proposed_text": None,
+            "failure_mode": "stale", "basis": "source-divergence",
+            "evidence": "", "comment": "stale",
+        }]) + "\n\nThat's all I found."
+        results = parse_update_proposals(response)
+        assert len(results) == 1
+        assert results[0]["id"] == "x"
+
+    def test_skips_items_without_id(self):
+        response = json.dumps([
+            {"action": "update", "proposed_text": "missing id"},
+            {"id": "x", "action": "update", "proposed_text": "has id",
+             "failure_mode": "stale", "basis": "source-divergence",
+             "evidence": "", "comment": ""},
+        ])
+        results = parse_update_proposals(response)
+        assert len(results) == 1
+        assert results[0]["id"] == "x"
+
+
+class TestFormatProposalMarkdown:
+    def test_update_proposal(self, sample_nodes):
+        proposal = {
+            "id": "premise-a",
+            "action": "update",
+            "proposed_text": "The sky appears blue.",
+            "failure_mode": "smuggled-premise",
+            "basis": "prior-knowledge",
+            "evidence": "Simplistic claim.",
+            "comment": "More precise.",
+        }
+        result = format_proposal_markdown(proposal, nodes=sample_nodes)
+        assert "## UPDATE: premise-a" in result
+        assert "**Current text:** The sky is blue." in result
+        assert "**Proposed text:** The sky appears blue." in result
+        assert "**Failure mode:** smuggled-premise" in result
+        assert "**Basis:** prior-knowledge" in result
+        assert "**Evidence:** Simplistic claim." in result
+        assert "reasons update premise-a" in result
+
+    def test_retract_proposal(self, sample_nodes):
+        proposal = {
+            "id": "premise-a",
+            "action": "retract",
+            "proposed_text": None,
+            "failure_mode": "contradicted-by-source",
+            "basis": "source-divergence",
+            "evidence": "Source changed.",
+            "comment": "No longer valid.",
+        }
+        result = format_proposal_markdown(proposal, nodes=sample_nodes)
+        assert "## RETRACT: premise-a" in result
+        assert "reasons retract premise-a" in result
+        assert "Proposed text" not in result
+
+    def test_with_cascade(self, sample_nodes):
+        proposal = {
+            "id": "premise-a",
+            "action": "retract",
+            "proposed_text": None,
+            "failure_mode": "stale",
+            "basis": "source-divergence",
+            "evidence": "",
+            "comment": "Stale.",
+        }
+        cascade = {
+            "retracted": [
+                {"id": "derived-b", "text": "Blue skies indicate clear weather.", "depth": 1, "dependents": 1},
+            ],
+            "restored": [],
+            "total_affected": 1,
+        }
+        result = format_proposal_markdown(proposal, nodes=sample_nodes, cascade=cascade)
+        assert "**Cascade impact:** 1 dependent(s) affected" in result
+        assert 'derived-b: "Blue skies indicate clear weather." — will go OUT' in result
+
+    def test_no_cascade(self, sample_nodes):
+        proposal = {
+            "id": "premise-a",
+            "action": "update",
+            "proposed_text": "Updated.",
+            "failure_mode": "stale",
+            "basis": "source-divergence",
+            "evidence": "",
+            "comment": "",
+        }
+        result = format_proposal_markdown(proposal, nodes=sample_nodes)
+        assert "**Cascade impact:** not computed" in result
+
+    def test_empty_cascade(self, sample_nodes):
+        proposal = {
+            "id": "derived-c",
+            "action": "update",
+            "proposed_text": "Updated.",
+            "failure_mode": "stale",
+            "basis": "source-divergence",
+            "evidence": "",
+            "comment": "",
+        }
+        cascade = {"retracted": [], "restored": [], "total_affected": 0}
+        result = format_proposal_markdown(proposal, nodes=sample_nodes, cascade=cascade)
+        assert "**Cascade impact:** none" in result
+
+
+class TestFormatProposalsFile:
+    def test_no_proposals(self):
+        result = format_proposals_file([], nodes={})
+        assert "No updates proposed." in result
+
+    def test_with_proposals(self, sample_nodes):
+        proposals = [
+            {
+                "id": "premise-a",
+                "action": "update",
+                "proposed_text": "Updated.",
+                "failure_mode": "stale",
+                "basis": "source-divergence",
+                "evidence": "",
+                "comment": "",
+            }
+        ]
+        result = format_proposals_file(proposals, nodes=sample_nodes)
+        assert "# Proposed Updates" in result
+        assert "## UPDATE: premise-a" in result
+        assert "---" in result
+
+
+class TestProposeUpdates:
+    @patch("reasons_lib.propose_update.invoke_model")
+    def test_basic_flow(self, mock_invoke, sample_nodes):
+        mock_invoke.return_value = json.dumps([{
+            "id": "premise-a",
+            "action": "update",
+            "proposed_text": "Updated sky claim.",
+            "failure_mode": "smuggled-premise",
+            "basis": "prior-knowledge",
+            "evidence": "Too simple.",
+            "comment": "Improved.",
+        }])
+        results = propose_updates(
+            sample_nodes,
+            belief_ids=["premise-a"],
+            model="claude",
+            timeout=300,
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "premise-a"
+        mock_invoke.assert_called_once()
+
+    @patch("reasons_lib.propose_update.invoke_model")
+    def test_no_proposals_returned(self, mock_invoke, sample_nodes):
+        mock_invoke.return_value = "[]"
+        results = propose_updates(
+            sample_nodes,
+            belief_ids=["premise-a"],
+        )
+        assert results == []
+
+    @patch("reasons_lib.propose_update.invoke_model")
+    def test_batching(self, mock_invoke, sample_nodes):
+        mock_invoke.return_value = "[]"
+        propose_updates(
+            sample_nodes,
+            belief_ids=["premise-a", "derived-b", "derived-c"],
+            batch_size=2,
+        )
+        assert mock_invoke.call_count == 2
+
+    @patch("reasons_lib.propose_update.invoke_model")
+    def test_default_all_in_beliefs(self, mock_invoke, sample_nodes):
+        mock_invoke.return_value = "[]"
+        propose_updates(sample_nodes)
+        call_prompt = mock_invoke.call_args[0][0]
+        assert "premise-a" in call_prompt
+        assert "derived-b" in call_prompt
+
+    @patch("reasons_lib.propose_update.invoke_model")
+    def test_handles_llm_error(self, mock_invoke, sample_nodes):
+        mock_invoke.side_effect = RuntimeError("model failed")
+        results = propose_updates(
+            sample_nodes,
+            belief_ids=["premise-a"],
+        )
+        assert results == []
+
+    @patch("reasons_lib.propose_update.invoke_model")
+    def test_on_batch_callback(self, mock_invoke, sample_nodes):
+        mock_invoke.return_value = json.dumps([{
+            "id": "premise-a", "action": "update",
+            "proposed_text": "new", "failure_mode": "stale",
+            "basis": "source-divergence", "evidence": "", "comment": "",
+        }])
+        batches_seen = []
+        propose_updates(
+            sample_nodes,
+            belief_ids=["premise-a"],
+            on_batch=lambda results: batches_seen.append(len(results)),
+        )
+        assert batches_seen == [1]
+
+    def test_empty_belief_ids(self, sample_nodes):
+        results = propose_updates(sample_nodes, belief_ids=[])
+        assert results == []
+
+    def test_nonexistent_belief_ids(self, sample_nodes):
+        results = propose_updates(sample_nodes, belief_ids=["nonexistent"])
+        assert results == []


### PR DESCRIPTION
## Summary

- Adds `reasons propose-update` command that sends beliefs to an LLM for evaluation and generates structured markdown proposals for updates or retractions
- Proposals include failure mode taxonomy (smuggled-premise, unsupported-superlative, false-causal-link, domain-conflation, contradicted-by-source, stale) and update basis (source-divergence, detected-contradiction, prior-knowledge) for reviewer triage
- Cascade impact computed via existing `what_if_retract()` infrastructure

Closes #171

## Test plan

- [x] 30 unit tests covering format, parse, markdown rendering, batching, error handling
- [ ] Integration test with live LLM: `uv run reasons propose-update --stale-only`
- [ ] Verify cascade section matches `reasons what-if retract` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)