### PR TITLE
Add source type metadata to beliefs

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -160,6 +160,9 @@ def list_namespaces(db_path: str = DEFAULT_DB,
         return {"namespaces": namespaces}
 
 
+SOURCE_TYPES = {"code", "document", "self-description", "derived"}
+
+
 def add_node(
     node_id: str,
     text: str,
@@ -173,6 +176,7 @@ def add_node(
     any_mode: bool = False,
     access_tags: list[str] | None = None,
     example: str | None = None,
+    source_type: str = "",
     db_path: str = DEFAULT_DB,
     pg_conninfo=None, project_id=None,
 ) -> dict:
@@ -251,11 +255,19 @@ def add_node(
                 j.antecedents = [_resolve_namespace(a, namespace) for a in j.antecedents]
                 j.outlist = [_resolve_namespace(o, namespace) for o in j.outlist]
 
+        if source_type and source_type not in SOURCE_TYPES:
+            raise ValueError(
+                f"Invalid source_type '{source_type}'. "
+                f"Must be one of: {', '.join(sorted(SOURCE_TYPES))}"
+            )
+
         metadata = {}
         if access_tags:
             metadata["access_tags"] = sorted(set(access_tags))
         if example is not None:
             metadata["example"] = example
+        if source_type:
+            metadata["source_type"] = source_type
 
         node = net.add_node(
             id=node_id,
@@ -2218,6 +2230,7 @@ def list_nodes(
                 "challenges": node.metadata.get("challenges", []),
                 "last_reviewed": node.metadata.get("last_reviewed"),
                 "review_result": node.metadata.get("review_result"),
+                "source_type": node.metadata.get("source_type", ""),
             })
         if by_impact:
             nodes.sort(key=lambda n: -n["dependent_count"])

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -57,6 +57,7 @@ def cmd_add(args):
             any_mode=getattr(args, "any", False),
             access_tags=access_tags,
             example=getattr(args, "example", None),
+            source_type=getattr(args, "source_type", None) or "",
             **_backend_kwargs(args),
         )
         print(f"Added {result['node_id']} [{result['truth_value']}] ({result['type']})")
@@ -262,6 +263,8 @@ def cmd_show(args):
         print(f"URL:    {node['source_url']}")
     if node["source_hash"]:
         print(f"Hash:   {node['source_hash']}")
+    if node["metadata"].get("source_type"):
+        print(f"Source type: {node['metadata']['source_type']}")
     if node["metadata"].get("pinned_sha"):
         sha = node["metadata"]["pinned_sha"][:12]
         lines = node["metadata"].get("pinned_lines", "")
@@ -1329,13 +1332,14 @@ def cmd_list(args):
         marker = "+" if node["truth_value"] == "IN" else "-"
         jinfo = f"  ({node['justification_count']} justification{'s' if node['justification_count'] != 1 else ''})" if node["justification_count"] else "  (premise)"
         deps = f"  [{node['dependent_count']} dependents]" if node["dependent_count"] else ""
+        stype = f"  <{node['source_type']}>" if node.get("source_type") else ""
         review_info = ""
         if show_review:
             if node.get("last_reviewed"):
                 review_info = f"  (reviewed: {node['last_reviewed']}, {node.get('review_result', '?')})"
             elif node.get("justification_count", 0) > 0:
                 review_info = "  (never reviewed)"
-        print(f"  [{marker}] {node['id']}{jinfo}{deps}{review_info}")
+        print(f"  [{marker}] {node['id']}{jinfo}{deps}{stype}{review_info}")
 
     print(f"\n{result['count']} node{'s' if result['count'] != 1 else ''}")
 
@@ -1799,6 +1803,8 @@ def main():
     p.add_argument("-n", "--namespace", help="Namespace prefix (auto-creates ns:active premise)")
     p.add_argument("--access-tags", metavar="TAG,TAG", help="Data source provenance tags (comma-separated)")
     p.add_argument("--example", default=None, help="Code example demonstrating the belief")
+    p.add_argument("--source-type", choices=["code", "document", "self-description", "derived"],
+                   help="Epistemic source type (code, document, self-description, derived)")
 
     # add-justification
     p = sub.add_parser("add-justification", help="Add a justification to an existing node")

--- a/reasons_lib/derive.py
+++ b/reasons_lib/derive.py
@@ -636,6 +636,7 @@ def apply_proposals(valid, db_path="reasons.db"):
                 sl=sl,
                 unless=unless,
                 label=p["label"],
+                source_type="derived",
                 db_path=db_path,
             )
             results.append((p, result))

--- a/reasons_lib/export_markdown.py
+++ b/reasons_lib/export_markdown.py
@@ -64,6 +64,8 @@ def export_markdown(network: Network, repos: dict[str, str] | None = None) -> st
 
         if node.source:
             lines.append(f"- Source: {node.source}")
+        if node.metadata.get("source_type"):
+            lines.append(f"- Source type: {node.metadata['source_type']}")
         if node.source_hash:
             lines.append(f"- Source hash: {node.source_hash}")
         if node.date:

--- a/reasons_lib/import_beliefs.py
+++ b/reasons_lib/import_beliefs.py
@@ -82,6 +82,7 @@ def parse_beliefs(text: str) -> list[dict]:
                 "type": m.group(3).strip(),
                 "text": "",
                 "source": "",
+                "source_type": "",
                 "source_hash": "",
                 "date": "",
                 "depends_on": [],
@@ -106,6 +107,8 @@ def parse_beliefs(text: str) -> list[dict]:
         elif line.startswith("- Unless: "):
             unless = line[len("- Unless: "):].strip()
             current["unless"] = [u.strip() for u in unless.split(",") if u.strip()]
+        elif line.startswith("- Source type: "):
+            current["source_type"] = line[len("- Source type: "):].strip()
         elif line.lower().startswith("- stale reason: "):
             current["stale_reason"] = line[line.index(": ") + 2:].strip()
         elif line.lower().startswith("- superseded by: "):
@@ -237,6 +240,8 @@ def import_into_network(
         metadata = {}
         if claim["type"]:
             metadata["beliefs_type"] = claim["type"]
+        if claim.get("source_type"):
+            metadata["source_type"] = claim["source_type"]
         if claim["stale_reason"]:
             metadata["stale_reason"] = claim["stale_reason"]
         if claim["superseded_by"]:

--- a/tests/test_source_type.py
+++ b/tests/test_source_type.py
@@ -1,0 +1,188 @@
+"""Tests for source_type metadata field."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib.export_markdown import export_markdown
+from reasons_lib.import_beliefs import parse_beliefs, import_into_network
+from reasons_lib.network import Network
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    api.init_db(db_path=db_path)
+    return db_path
+
+
+class TestAddNodeSourceType:
+    def test_stores_source_type(self, db):
+        api.add_node("n1", "A code observation.", source_type="code", db_path=db)
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["source_type"] == "code"
+
+    def test_all_valid_types(self, db):
+        for i, st in enumerate(["code", "document", "self-description", "derived"]):
+            api.add_node(f"n{i}", f"Type {st}.", source_type=st, db_path=db)
+            node = api.show_node(f"n{i}", db_path=db)
+            assert node["metadata"]["source_type"] == st
+
+    def test_invalid_type_raises(self, db):
+        with pytest.raises(ValueError, match="Invalid source_type"):
+            api.add_node("bad", "Bad type.", source_type="unknown", db_path=db)
+
+    def test_empty_type_not_stored(self, db):
+        api.add_node("n1", "No type.", db_path=db)
+        node = api.show_node("n1", db_path=db)
+        assert "source_type" not in node["metadata"]
+
+    def test_source_type_persists(self, db):
+        api.add_node("n1", "Code obs.", source_type="code", db_path=db)
+        node = api.show_node("n1", db_path=db)
+        assert node["metadata"]["source_type"] == "code"
+        result = api.export_network(db_path=db)
+        assert result["nodes"]["n1"]["metadata"]["source_type"] == "code"
+
+
+class TestShowSourceType:
+    def test_show_displays_source_type(self, db, capsys):
+        api.add_node("n1", "Code obs.", source_type="code", db_path=db)
+        from reasons_lib.cli import cmd_show
+        import argparse
+        args = argparse.Namespace(
+            node_id="n1", db=db, visible_to=None,
+            pg_conninfo=None, pg_project=None,
+        )
+        cmd_show(args)
+        captured = capsys.readouterr()
+        assert "Source type: code" in captured.out
+
+    def test_show_omits_when_absent(self, db, capsys):
+        api.add_node("n1", "No type.", db_path=db)
+        from reasons_lib.cli import cmd_show
+        import argparse
+        args = argparse.Namespace(
+            node_id="n1", db=db, visible_to=None,
+            pg_conninfo=None, pg_project=None,
+        )
+        cmd_show(args)
+        captured = capsys.readouterr()
+        assert "Source type" not in captured.out
+
+
+class TestListSourceType:
+    def test_list_shows_source_type(self, db):
+        api.add_node("n1", "Code obs.", source_type="code", db_path=db)
+        result = api.list_nodes(db_path=db)
+        node = result["nodes"][0]
+        assert node["source_type"] == "code"
+
+    def test_list_empty_when_absent(self, db):
+        api.add_node("n1", "No type.", db_path=db)
+        result = api.list_nodes(db_path=db)
+        node = result["nodes"][0]
+        assert node["source_type"] == ""
+
+
+class TestExportMarkdown:
+    def test_exports_source_type(self, db):
+        api.add_node("n1", "Code obs.", source="repo/file.py",
+                      source_type="code", db_path=db)
+        from reasons_lib.storage import Storage
+        storage = Storage(db)
+        net = storage.load()
+        storage.close()
+        md = export_markdown(net)
+        assert "- Source type: code" in md
+
+    def test_omits_when_absent(self, db):
+        api.add_node("n1", "No type.", source="repo/file.py", db_path=db)
+        from reasons_lib.storage import Storage
+        storage = Storage(db)
+        net = storage.load()
+        storage.close()
+        md = export_markdown(net)
+        assert "Source type" not in md
+
+
+class TestImportBeliefs:
+    def test_parses_source_type(self):
+        text = """\
+## Claims
+
+### obs-1 [IN] OBSERVATION
+The API uses REST endpoints.
+- Source: repo/api.py
+- Source type: code
+- Date: 2026-06-04
+"""
+        claims = parse_beliefs(text)
+        assert len(claims) == 1
+        assert claims[0]["source_type"] == "code"
+
+    def test_missing_source_type(self):
+        text = """\
+## Claims
+
+### obs-1 [IN] OBSERVATION
+The API uses REST endpoints.
+- Source: repo/api.py
+- Date: 2026-06-04
+"""
+        claims = parse_beliefs(text)
+        assert claims[0]["source_type"] == ""
+
+    def test_import_stores_source_type(self):
+        net = Network()
+        text = """\
+## Claims
+
+### obs-1 [IN] OBSERVATION
+The API uses REST endpoints.
+- Source: repo/api.py
+- Source type: document
+"""
+        result = import_into_network(net, text)
+        assert result["claims_imported"] == 1
+        node = net.nodes["obs-1"]
+        assert node.metadata.get("source_type") == "document"
+
+    def test_roundtrip_export_import(self, db):
+        api.add_node("n1", "Code obs.", source="repo/file.py",
+                      source_type="code", db_path=db)
+        from reasons_lib.storage import Storage
+        storage = Storage(db)
+        net = storage.load()
+        storage.close()
+        md = export_markdown(net)
+
+        net2 = Network()
+        result = import_into_network(net2, md)
+        assert result["claims_imported"] == 1
+        assert net2.nodes["n1"].metadata.get("source_type") == "code"
+
+
+class TestDeriveAutoSourceType:
+    def test_derive_sets_derived_type(self, db):
+        api.add_node("p1", "Premise one.", db_path=db)
+        api.add_node("p2", "Premise two.", db_path=db)
+
+        from reasons_lib.derive import apply_proposals
+        proposals = [{
+            "id": "d1",
+            "text": "Derived from p1 and p2.",
+            "antecedents": ["p1", "p2"],
+            "unless": [],
+            "label": "test derivation",
+        }]
+        results = apply_proposals(proposals, db_path=db)
+        assert len(results) == 1
+        _, result = results[0]
+        assert isinstance(result, dict)
+
+        node = api.show_node("d1", db_path=db)
+        assert node["metadata"].get("source_type") == "derived"


### PR DESCRIPTION
## Summary

- Adds `source_type` metadata field to beliefs: `code`, `document`, `self-description`, `derived`
- `reasons add --source-type code` sets the type on creation
- `reasons show` displays source type when present
- `reasons list` shows `<code>` indicator in listings
- `export-markdown` writes `- Source type: code` field; `import-beliefs` parses it back
- `derive` command auto-sets `source_type: "derived"` on new derived beliefs
- Invalid source types rejected with clear error message

Closes #172

## Test plan

- [x] 16 unit tests covering add, show, list, export, import, derive, validation, roundtrip
- [ ] Manual: `reasons add test-node "test" --source-type code && reasons show test-node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)