### PR TITLE
EEM-Hub default org, publish and pull commands (#174)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1394,9 +1394,7 @@ def publish_hf(
         export_network(visible_to=visible_to, **backend), indent=2
     )
 
-    from .export_markdown import export_markdown as _export_md
-    with _with_network(db_path) as net:
-        beliefs_md = _export_md(net, repos=net.repos)
+    beliefs_md = export_markdown(visible_to=visible_to, **backend)
 
     card_md = export_card(
         visible_to=visible_to, domain=domain, license=license,

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1353,6 +1353,73 @@ def import_hf(repo_id: str, init: bool = False, token: str | None = None,
     return result
 
 
+def publish_hf(
+    repo_id: str,
+    token: str | None = None,
+    private: bool = False,
+    visible_to: list[str] | None = None,
+    domain: list[str] | None = None,
+    license: str = "mit",
+    base_network: str | None = None,
+    source_repos: list[str] | None = None,
+    db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
+) -> dict:
+    """Export and publish network to a HuggingFace repo.
+
+    Uploads network.json, beliefs.md, and README.md (EEM card).
+
+    Args:
+        repo_id: HuggingFace repo ID (bare name, user/repo, or URL)
+        token: HuggingFace auth token (falls back to HF_TOKEN env or cached)
+        private: Create a private repo
+        visible_to: Access tag filter for exported nodes
+
+    Returns: {"repo_id": str, "url": str, "files_uploaded": list}
+    """
+    from .hf import _resolve_token, create_repo, resolve_repo_id, upload_file
+
+    resolved_token = _resolve_token(token)
+    if not resolved_token:
+        raise RuntimeError(
+            "HuggingFace token required for publishing. "
+            "Run 'huggingface-cli login', set HF_TOKEN, or pass --token."
+        )
+
+    parsed_id = resolve_repo_id(repo_id)
+    create_repo(parsed_id, token=resolved_token, private=private)
+
+    backend = dict(db_path=db_path, pg_conninfo=pg_conninfo, project_id=project_id)
+    network_json = json.dumps(
+        export_network(visible_to=visible_to, **backend), indent=2
+    )
+
+    from .export_markdown import export_markdown as _export_md
+    with _with_network(db_path) as net:
+        beliefs_md = _export_md(net, repos=net.repos)
+
+    card_md = export_card(
+        visible_to=visible_to, domain=domain, license=license,
+        base_network=base_network, source_repos=source_repos,
+        **backend,
+    )
+
+    files = []
+    for filename, content in [
+        ("network.json", network_json),
+        ("beliefs.md", beliefs_md),
+        ("README.md", card_md),
+    ]:
+        upload_file(parsed_id, filename, content.encode("utf-8"), resolved_token)
+        files.append(filename)
+
+    return {
+        "repo_id": parsed_id,
+        "url": f"https://huggingface.co/{parsed_id}",
+        "files_uploaded": files,
+    }
+
+
 def import_api(url: str | None = None, agent_id: str | None = None,
                api_key: str | None = None, init: bool = False,
                db_path: str = DEFAULT_DB,

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -623,6 +623,7 @@ def cmd_publish(args):
             repo_id=args.repo_id,
             token=args.token,
             private=getattr(args, "private", False),
+            visible_to=_parse_visible_to(args),
             domain=getattr(args, "domain", None),
             license=getattr(args, "license", "mit"),
             base_network=getattr(args, "base_network", None),
@@ -2045,6 +2046,7 @@ def main():
     p.add_argument("--license", default="mit", help="License identifier (default: mit)")
     p.add_argument("--base-network", help="Parent EEM this was derived from")
     p.add_argument("--source-repos", nargs="*", help="Source repository identifiers")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only publish nodes whose access_tags are a subset of these tags")
 
     # import-api
     p = sub.add_parser("import-api", help="Import beliefs from agentic-mind-service")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -613,6 +613,31 @@ def cmd_import_hf(args):
         print(f"Imported {result['nogoods_imported']} nogoods")
 
 
+def cmd_pull(args):
+    cmd_import_hf(args)
+
+
+def cmd_publish(args):
+    try:
+        result = api.publish_hf(
+            repo_id=args.repo_id,
+            token=args.token,
+            private=getattr(args, "private", False),
+            domain=getattr(args, "domain", None),
+            license=getattr(args, "license", "mit"),
+            base_network=getattr(args, "base_network", None),
+            source_repos=getattr(args, "source_repos", None),
+            **_backend_kwargs(args),
+        )
+    except RuntimeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Published to {result['url']}")
+    for f in result["files_uploaded"]:
+        print(f"  uploaded {f}")
+
+
 def cmd_import_api(args):
     try:
         result = api.import_api(
@@ -1999,10 +2024,27 @@ def main():
 
     # import-hf
     p = sub.add_parser("import-hf", help="Import network from HuggingFace repo")
-    p.add_argument("repo_id", help="HuggingFace repo (user/repo or URL)")
+    p.add_argument("repo_id", help="HuggingFace repo (bare name, user/repo, or URL)")
     p.add_argument("--init", action="store_true",
                    help="Initialize reasons.db if it doesn't exist")
     p.add_argument("--token", help="HuggingFace token (default: from HF_TOKEN or ~/.cache/huggingface/token)")
+
+    # pull (alias for import-hf with default org)
+    p = sub.add_parser("pull", help="Pull EEM from HuggingFace (default org: EEM-Hub)")
+    p.add_argument("repo_id", help="EEM name (bare name defaults to EEM-Hub/name)")
+    p.add_argument("--init", action="store_true",
+                   help="Initialize reasons.db if it doesn't exist")
+    p.add_argument("--token", help="HuggingFace token (default: from HF_TOKEN or ~/.cache/huggingface/token)")
+
+    # publish
+    p = sub.add_parser("publish", help="Publish EEM to HuggingFace (default org: EEM-Hub)")
+    p.add_argument("repo_id", help="EEM name (bare name defaults to EEM-Hub/name)")
+    p.add_argument("--token", help="HuggingFace token (default: from HF_TOKEN or ~/.cache/huggingface/token)")
+    p.add_argument("--private", action="store_true", help="Create a private repo")
+    p.add_argument("--domain", nargs="*", help="Domain tags (e.g. kubernetes devops)")
+    p.add_argument("--license", default="mit", help="License identifier (default: mit)")
+    p.add_argument("--base-network", help="Parent EEM this was derived from")
+    p.add_argument("--source-repos", nargs="*", help="Source repository identifiers")
 
     # import-api
     p = sub.add_parser("import-api", help="Import beliefs from agentic-mind-service")
@@ -2300,6 +2342,8 @@ def main():
         "import-beliefs": cmd_import_beliefs,
         "import-json": cmd_import_json,
         "import-hf": cmd_import_hf,
+        "pull": cmd_pull,
+        "publish": cmd_publish,
         "import-api": cmd_import_api,
         "export-api": cmd_export_api,
         "export": cmd_export,

--- a/reasons_lib/hf.py
+++ b/reasons_lib/hf.py
@@ -1,5 +1,6 @@
-"""Download belief networks from HuggingFace repos."""
+"""Download and publish belief networks on HuggingFace."""
 
+import json
 import os
 from pathlib import Path
 from urllib.error import HTTPError
@@ -7,6 +8,7 @@ from urllib.request import Request, urlopen
 
 
 HF_BASE = "https://huggingface.co"
+DEFAULT_HF_ORG = "EEM-Hub"
 
 
 def _resolve_token(token: str | None = None) -> str | None:
@@ -22,23 +24,41 @@ def _resolve_token(token: str | None = None) -> str | None:
     return None
 
 
-def _parse_repo_id(repo_id: str) -> str:
-    """Extract user/repo from a repo ID or HuggingFace URL."""
-    repo_id = repo_id.rstrip("/")
+def resolve_repo_id(repo_id: str) -> str:
+    """Resolve a repo identifier, prepending the default org if needed.
+
+    - ``ddia-expert`` → ``EEM-Hub/ddia-expert`` (default org)
+    - ``myuser/my-eem`` → ``myuser/my-eem`` (explicit org)
+    - ``https://huggingface.co/org/repo`` → ``org/repo`` (URL)
+
+    The default org is ``EEM-Hub`` unless overridden by the
+    ``REASONS_HF_ORG`` environment variable.
+    """
+    repo_id = repo_id.strip().rstrip("/")
     if repo_id.startswith(("http://", "https://")):
-        # https://huggingface.co/user/repo -> user/repo
         parts = repo_id.split("huggingface.co/", 1)
         if len(parts) == 2:
             return parts[1]
         raise ValueError(f"Not a HuggingFace URL: {repo_id}")
-    return repo_id
+    if "/" in repo_id:
+        return repo_id
+    default_org = os.environ.get("REASONS_HF_ORG", DEFAULT_HF_ORG)
+    return f"{default_org}/{repo_id}"
+
+
+def _parse_repo_id(repo_id: str) -> str:
+    """Extract user/repo from a repo ID or HuggingFace URL.
+
+    Delegates to resolve_repo_id for default org handling.
+    """
+    return resolve_repo_id(repo_id)
 
 
 def download_network(repo_id: str, token: str | None = None) -> str:
     """Download network.json from a HuggingFace repo.
 
     Args:
-        repo_id: HuggingFace repo ID (user/repo) or full URL
+        repo_id: HuggingFace repo ID (user/repo, bare name, or full URL)
         token: Optional auth token (falls back to HF_TOKEN env or cached token)
 
     Returns:
@@ -67,3 +87,80 @@ def download_network(repo_id: str, token: str | None = None) -> str:
                 f"Repository or file not found: {parsed_id}/network.json"
             ) from e
         raise
+
+
+def create_repo(repo_id: str, token: str, private: bool = False) -> str:
+    """Create a HuggingFace repo if it doesn't exist.
+
+    Returns the resolved repo_id. Silently succeeds if the repo already exists.
+    """
+    parsed_id = resolve_repo_id(repo_id)
+    org, name = parsed_id.split("/", 1)
+
+    payload = json.dumps({
+        "name": name,
+        "organization": org,
+        "private": private,
+        "type": "model",
+    }).encode()
+
+    req = Request(
+        f"{HF_BASE}/api/repos/create",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(req, timeout=30) as resp:
+            resp.read()
+    except HTTPError as e:
+        if e.code == 409:
+            pass  # repo already exists
+        elif e.code == 401:
+            raise RuntimeError(
+                "Authentication failed. Run 'huggingface-cli login' or pass --token."
+            ) from e
+        else:
+            raise RuntimeError(
+                f"Failed to create repo {parsed_id}: HTTP {e.code}"
+            ) from e
+
+    return parsed_id
+
+
+def upload_file(
+    repo_id: str,
+    path_in_repo: str,
+    content: bytes,
+    token: str,
+) -> None:
+    """Upload a file to a HuggingFace repo.
+
+    Uses the HuggingFace Hub upload API (single-file upload via PUT).
+    """
+    parsed_id = resolve_repo_id(repo_id)
+    url = f"{HF_BASE}/api/models/{parsed_id}/upload/main/{path_in_repo}"
+
+    req = Request(
+        url,
+        data=content,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/octet-stream",
+        },
+        method="PUT",
+    )
+    try:
+        with urlopen(req, timeout=60) as resp:
+            resp.read()
+    except HTTPError as e:
+        if e.code == 401:
+            raise RuntimeError(
+                "Authentication failed. Run 'huggingface-cli login' or pass --token."
+            ) from e
+        raise RuntimeError(
+            f"Failed to upload {path_in_repo} to {parsed_id}: HTTP {e.code}"
+        ) from e

--- a/tests/test_hf_default_org.py
+++ b/tests/test_hf_default_org.py
@@ -1,0 +1,234 @@
+"""Tests for EEM-Hub default org, publish, and pull commands."""
+
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, call, patch
+from urllib.error import HTTPError
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib.hf import (
+    DEFAULT_HF_ORG,
+    create_repo,
+    resolve_repo_id,
+    upload_file,
+)
+
+
+SAMPLE_NETWORK = {
+    "meta": {"schema_version": "1.0", "project_name": "test-eem"},
+    "nodes": {
+        "a": {"text": "Node A", "truth_value": "IN", "justifications": [],
+               "source": "", "source_hash": "", "date": "", "metadata": {}},
+    },
+    "nogoods": [],
+    "repos": {},
+}
+
+
+def _mock_response(data=None):
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(data or {}).encode("utf-8")
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+class TestResolveRepoId:
+    def test_bare_name_gets_default_org(self):
+        assert resolve_repo_id("ddia-expert") == "EEM-Hub/ddia-expert"
+
+    def test_explicit_org_unchanged(self):
+        assert resolve_repo_id("myuser/my-eem") == "myuser/my-eem"
+
+    def test_url_parsed(self):
+        assert resolve_repo_id("https://huggingface.co/org/repo") == "org/repo"
+
+    def test_trailing_slash_stripped(self):
+        assert resolve_repo_id("ddia-expert/") == "EEM-Hub/ddia-expert"
+
+    def test_whitespace_stripped(self):
+        assert resolve_repo_id("  ddia-expert  ") == "EEM-Hub/ddia-expert"
+
+    def test_env_var_override(self, monkeypatch):
+        monkeypatch.setenv("REASONS_HF_ORG", "my-company")
+        assert resolve_repo_id("internal-eem") == "my-company/internal-eem"
+
+    def test_env_var_does_not_affect_explicit_org(self, monkeypatch):
+        monkeypatch.setenv("REASONS_HF_ORG", "my-company")
+        assert resolve_repo_id("other/repo") == "other/repo"
+
+    def test_non_hf_url_raises(self):
+        with pytest.raises(ValueError, match="Not a HuggingFace URL"):
+            resolve_repo_id("https://github.com/org/repo")
+
+    def test_default_org_constant(self):
+        assert DEFAULT_HF_ORG == "EEM-Hub"
+
+
+class TestCreateRepo:
+    @patch("reasons_lib.hf.urlopen")
+    def test_creates_repo(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response()
+        result = create_repo("test-eem", token="tok")
+        assert result == "EEM-Hub/test-eem"
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://huggingface.co/api/repos/create"
+        body = json.loads(req.data)
+        assert body["name"] == "test-eem"
+        assert body["organization"] == "EEM-Hub"
+        assert body["private"] is False
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_private_repo(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response()
+        create_repo("org/repo", token="tok", private=True)
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data)
+        assert body["private"] is True
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_already_exists_ignored(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError("url", 409, "Conflict", {}, BytesIO(b""))
+        result = create_repo("org/repo", token="tok")
+        assert result == "org/repo"
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_auth_failure_raises(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError("url", 401, "Unauthorized", {}, BytesIO(b""))
+        with pytest.raises(RuntimeError, match="Authentication failed"):
+            create_repo("org/repo", token="bad-tok")
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_other_error_raises(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError("url", 500, "Server Error", {}, BytesIO(b""))
+        with pytest.raises(RuntimeError, match="HTTP 500"):
+            create_repo("org/repo", token="tok")
+
+
+class TestUploadFile:
+    @patch("reasons_lib.hf.urlopen")
+    def test_uploads_to_correct_url(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response()
+        upload_file("EEM-Hub/test-eem", "network.json", b'{"nodes":{}}', "tok")
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://huggingface.co/api/models/EEM-Hub/test-eem/upload/main/network.json"
+        assert req.get_method() == "PUT"
+        assert req.data == b'{"nodes":{}}'
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_auth_header(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_response()
+        upload_file("org/repo", "file.txt", b"data", "my-token")
+        req = mock_urlopen.call_args[0][0]
+        assert req.get_header("Authorization") == "Bearer my-token"
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_auth_failure_raises(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError("url", 401, "Unauthorized", {}, BytesIO(b""))
+        with pytest.raises(RuntimeError, match="Authentication failed"):
+            upload_file("org/repo", "file.txt", b"data", "bad-tok")
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_upload_failure_raises(self, mock_urlopen):
+        mock_urlopen.side_effect = HTTPError("url", 500, "Error", {}, BytesIO(b""))
+        with pytest.raises(RuntimeError, match="Failed to upload"):
+            upload_file("org/repo", "file.txt", b"data", "tok")
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    api.init_db(db_path=db_path)
+    api.add_node("n1", "Test belief.", db_path=db_path)
+    return db_path
+
+
+class TestPublishHf:
+    @patch("reasons_lib.hf.urlopen")
+    def test_publishes_three_files(self, mock_urlopen, db):
+        mock_urlopen.return_value = _mock_response()
+        result = api.publish_hf("test-eem", token="tok", db_path=db)
+        assert result["repo_id"] == "EEM-Hub/test-eem"
+        assert result["url"] == "https://huggingface.co/EEM-Hub/test-eem"
+        assert set(result["files_uploaded"]) == {"network.json", "beliefs.md", "README.md"}
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_upload_calls(self, mock_urlopen, db):
+        mock_urlopen.return_value = _mock_response()
+        api.publish_hf("test-eem", token="tok", db_path=db)
+        # 1 create_repo + 3 upload_file = 4 calls
+        assert mock_urlopen.call_count == 4
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_explicit_org(self, mock_urlopen, db):
+        mock_urlopen.return_value = _mock_response()
+        result = api.publish_hf("myuser/my-eem", token="tok", db_path=db)
+        assert result["repo_id"] == "myuser/my-eem"
+        assert result["url"] == "https://huggingface.co/myuser/my-eem"
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_private_repo(self, mock_urlopen, db):
+        mock_urlopen.return_value = _mock_response()
+        api.publish_hf("test-eem", token="tok", private=True, db_path=db)
+        create_req = mock_urlopen.call_args_list[0][0][0]
+        body = json.loads(create_req.data)
+        assert body["private"] is True
+
+    def test_no_token_raises(self, db, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        with patch("reasons_lib.hf.Path.home", return_value=pytest.importorskip("pathlib").Path("/nonexistent")):
+            with pytest.raises(RuntimeError, match="token required"):
+                api.publish_hf("test-eem", db_path=db)
+
+
+class TestPullCommand:
+    @patch("reasons_lib.hf.urlopen")
+    def test_pull_with_bare_name(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        db = str(tmp_path / "test.db")
+        result = api.import_hf("ddia-expert", init=True, token="tok", db_path=db)
+        assert result["repo_id"] == "EEM-Hub/ddia-expert"
+        assert result["nodes_imported"] == 1
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_pull_with_explicit_org(self, mock_urlopen, tmp_path):
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        db = str(tmp_path / "test.db")
+        result = api.import_hf("myuser/my-eem", init=True, token="tok", db_path=db)
+        assert result["repo_id"] == "myuser/my-eem"
+
+    @patch("reasons_lib.hf.urlopen")
+    def test_import_hf_bare_name_resolves(self, mock_urlopen, tmp_path):
+        """Existing import-hf command also gets default org resolution."""
+        mock_urlopen.return_value = _mock_response(SAMPLE_NETWORK)
+        db = str(tmp_path / "test.db")
+        api.import_hf("test-eem", init=True, token="tok", db_path=db)
+        req = mock_urlopen.call_args[0][0]
+        assert "EEM-Hub/test-eem" in req.full_url
+
+
+class TestCLIDispatch:
+    def test_pull_dispatches(self):
+        from reasons_lib.cli import cmd_pull, cmd_import_hf
+        # cmd_pull delegates to cmd_import_hf — verify it's callable
+        assert callable(cmd_pull)
+
+    def test_publish_dispatches(self):
+        from reasons_lib.cli import cmd_publish
+        assert callable(cmd_publish)
+
+    def test_commands_registered(self):
+        """pull and publish are in the CLI dispatch table."""
+        import argparse
+        from reasons_lib.cli import main
+        # Just verify the subparser accepts the commands
+        from reasons_lib import cli
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        # Smoke test: the commands exist by checking the dispatch dict
+        # We access it indirectly by verifying the module defines the handlers
+        assert hasattr(cli, "cmd_pull")
+        assert hasattr(cli, "cmd_publish")


### PR DESCRIPTION
## Summary

- **Default org resolution**: bare names like `ddia-expert` resolve to `EEM-Hub/ddia-expert`, configurable via `REASONS_HF_ORG` env var
- **`reasons publish`**: exports and uploads `network.json`, `beliefs.md`, and `README.md` (EEM card) to HuggingFace — zero new dependencies (stdlib `urllib` only)
- **`reasons pull`**: friendlier alias for `import-hf` with default org resolution
- Existing `import-hf` also gains default org resolution

## Usage

```bash
# Pull (download + import)
reasons pull ddia-expert              # from EEM-Hub/ddia-expert
reasons pull myuser/my-eem            # explicit org

# Publish (export + upload)
reasons publish ddia-expert           # to EEM-Hub/ddia-expert
reasons publish myuser/my-eem --private

# Custom default org
REASONS_HF_ORG=my-company reasons pull internal-eem
```

## Changes

| File | Change |
|------|--------|
| `reasons_lib/hf.py` | `DEFAULT_HF_ORG`, `resolve_repo_id()`, `create_repo()`, `upload_file()` |
| `reasons_lib/api.py` | `publish_hf()` function |
| `reasons_lib/cli.py` | `pull` and `publish` subparsers + handlers |
| `tests/test_hf_default_org.py` | 29 tests for resolve, create, upload, publish, pull |

Closes #174.

## Test plan

- [x] 29 new tests pass (resolve_repo_id, create_repo, upload_file, publish_hf, pull, CLI dispatch)
- [x] 22 existing HF import tests still pass
- [x] Full suite: 1315 passed, 166 skipped, 0 failed
- [ ] Code review with multi-model consensus

🤖 Generated with [Claude Code](https://claude.com/claude-code)