### PR TITLE
Add cost/token tracking via --output-format json (#184)

### DIFF
--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1191,6 +1191,8 @@ def _write_derive_report(report_state, status):
 def cmd_derive(args):
     _require_sqlite(args, "derive")
     from datetime import datetime
+    from .llm import reset_cost_tracker, format_cost_summary
+    reset_cost_tracker()
 
     prompt_template = None
     if args.prompt_file:
@@ -1287,6 +1289,10 @@ def cmd_derive(args):
     if report_state is not None:
         _write_derive_report(report_state, "complete")
         print(f"  Report: {report_state['report_path']}")
+
+    cost = format_cost_summary()
+    if cost:
+        print(f"  {cost}", file=sys.stderr)
 
 
 def cmd_accept(args):
@@ -1431,6 +1437,8 @@ def cmd_review_beliefs(args):
     _require_sqlite(args, "review-beliefs")
     import json
     from datetime import datetime
+    from .llm import reset_cost_tracker, format_cost_summary
+    reset_cost_tracker()
 
     model = getattr(args, "model", None) or "claude"
     ts = datetime.now().isoformat(timespec="seconds")
@@ -1552,11 +1560,17 @@ def cmd_review_beliefs(args):
             except Exception as e:
                 print(f"  ERROR retracting {r['id']}: {e}", file=sys.stderr)
 
+    cost = format_cost_summary()
+    if cost:
+        print(f"  {cost}", file=sys.stderr)
+
 
 def cmd_propose_update(args):
     _require_sqlite(args, "propose-update")
     import json as _json
     from datetime import datetime
+    from .llm import reset_cost_tracker, format_cost_summary
+    reset_cost_tracker()
 
     from .propose_update import format_proposals_file
 
@@ -1636,6 +1650,10 @@ def cmd_propose_update(args):
         }, indent=2))
         print(f"  Report: {report_path}")
 
+    cost = format_cost_summary()
+    if cost:
+        print(f"  {cost}", file=sys.stderr)
+
 
 def cmd_repair_smuggled(args):
     _require_sqlite(args, "repair-smuggled")
@@ -1681,6 +1699,8 @@ def cmd_repair_smuggled(args):
 
 def cmd_research(args):
     _require_sqlite(args, "research")
+    from .llm import reset_cost_tracker, format_cost_summary
+    reset_cost_tracker()
 
     model = getattr(args, "model", None) or "claude"
     review_file = getattr(args, "review_file", None)
@@ -1722,6 +1742,10 @@ def cmd_research(args):
     if args.dry_run:
         print("\n  (dry run -- no changes applied)")
 
+    cost = format_cost_summary()
+    if cost:
+        print(f"  {cost}", file=sys.stderr)
+
 
 def cmd_contradictions(args):
     _require_sqlite(args, "detect-contradictions")
@@ -1747,6 +1771,9 @@ def cmd_contradictions(args):
         else:
             print("No nogoods to apply.")
         return
+
+    from .llm import reset_cost_tracker, format_cost_summary
+    reset_cost_tracker()
 
     model = getattr(args, "model", None) or "claude"
     output = args.output
@@ -1787,6 +1814,10 @@ def cmd_contradictions(args):
     elif not args.auto_apply:
         print(f"\nWrote {output} — review, then run:")
         print(f"  reasons contradictions --accept {output}")
+
+    cost = format_cost_summary()
+    if cost:
+        print(f"  {cost}", file=sys.stderr)
 
 
 def cmd_namespaces(args):

--- a/reasons_lib/llm.py
+++ b/reasons_lib/llm.py
@@ -6,8 +6,12 @@ and API-based providers via 'api:<model>' and 'vertex:<model>'.
 
 CLI-based models pipe prompts to stdin and read responses from stdout.
 API-based models use LangChain adapters with optional Langfuse tracing.
+
+Cost tracking: CLI models use --output-format json to capture token
+counts and costs. Use get_cost_summary() to retrieve accumulated stats.
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -35,12 +39,99 @@ except ImportError:
 
 
 MODEL_COMMANDS = {
-    "claude": ["claude", "-p"],
-    "gemini": ["gemini", "--skip-trust", "-p", ""],
+    "claude": ["claude", "-p", "--output-format", "json"],
+    "gemini": ["gemini", "--skip-trust", "-o", "json", "-p", ""],
 }
 
 _langfuse_handler = None
 _langfuse_checked = False
+
+_cost_tracker = {
+    "calls": 0,
+    "input_tokens": 0,
+    "output_tokens": 0,
+    "total_cost_usd": 0.0,
+    "by_model": {},
+}
+
+
+def reset_cost_tracker():
+    """Reset accumulated cost/token stats."""
+    _cost_tracker["calls"] = 0
+    _cost_tracker["input_tokens"] = 0
+    _cost_tracker["output_tokens"] = 0
+    _cost_tracker["total_cost_usd"] = 0.0
+    _cost_tracker["by_model"] = {}
+
+
+def get_cost_summary() -> dict:
+    """Return accumulated cost/token stats across all LLM calls."""
+    return dict(_cost_tracker)
+
+
+def format_cost_summary() -> str:
+    """Format cost summary as a human-readable string."""
+    s = _cost_tracker
+    if s["calls"] == 0:
+        return ""
+    parts = []
+    if s["total_cost_usd"] > 0:
+        parts.append(f"${s['total_cost_usd']:.4f}")
+    parts.append(f"{s['input_tokens']:,} input + {s['output_tokens']:,} output tokens")
+    parts.append(f"{s['calls']} call(s)")
+    return "Cost: " + " | ".join(parts)
+
+
+def _record_cost(model: str, input_tokens: int, output_tokens: int, cost_usd: float):
+    """Record token/cost stats from one LLM call."""
+    _cost_tracker["calls"] += 1
+    _cost_tracker["input_tokens"] += input_tokens
+    _cost_tracker["output_tokens"] += output_tokens
+    _cost_tracker["total_cost_usd"] += cost_usd
+
+    if model not in _cost_tracker["by_model"]:
+        _cost_tracker["by_model"][model] = {
+            "calls": 0, "input_tokens": 0, "output_tokens": 0, "total_cost_usd": 0.0,
+        }
+    m = _cost_tracker["by_model"][model]
+    m["calls"] += 1
+    m["input_tokens"] += input_tokens
+    m["output_tokens"] += output_tokens
+    m["total_cost_usd"] += cost_usd
+
+
+def _parse_cli_json(output: str, model: str) -> str:
+    """Parse JSON output from CLI, extract response text and record costs.
+
+    Falls back to returning raw output if JSON parsing fails.
+    """
+    try:
+        data = json.loads(output)
+    except (json.JSONDecodeError, ValueError):
+        return output
+
+    if not isinstance(data, dict):
+        return output
+
+    if model.startswith("gemini") or model.startswith("gemini:"):
+        text = data.get("response", output)
+        stats = data.get("stats", {})
+        input_tokens = 0
+        output_tokens = 0
+        for model_stats in stats.get("models", {}).values():
+            tokens = model_stats.get("tokens", {})
+            input_tokens += tokens.get("input", 0)
+            output_tokens += tokens.get("candidates", 0)
+        _record_cost(model, input_tokens, output_tokens, 0.0)
+        return text
+
+    text = data.get("result", output)
+    usage = data.get("usage", {})
+    input_tokens = usage.get("input_tokens", 0) + usage.get("cache_creation_input_tokens", 0) + usage.get("cache_read_input_tokens", 0)
+    output_tokens = usage.get("output_tokens", 0)
+    cost_usd = data.get("total_cost_usd", 0.0)
+    _record_cost(model, input_tokens, output_tokens, cost_usd)
+    return text
 
 
 def _get_langfuse_handler():
@@ -71,10 +162,10 @@ def resolve_model_cmd(model: str) -> list[str]:
         return MODEL_COMMANDS[model]
     if model.startswith("claude:"):
         submodel = model.split(":", 1)[1]
-        return ["claude", "-p", "--model", submodel]
+        return ["claude", "-p", "--model", submodel, "--output-format", "json"]
     if model.startswith("gemini:"):
         submodel = model.split(":", 1)[1]
-        return ["gemini", "--skip-trust", "-m", submodel, "-p", ""]
+        return ["gemini", "--skip-trust", "-m", submodel, "-o", "json", "-p", ""]
     if model.startswith("ollama:"):
         ollama_model = model.split(":", 1)[1]
         return ["ollama", "run", ollama_model]
@@ -136,6 +227,9 @@ def _invoke_api(prompt: str, model: str, timeout: int = 300) -> str:
 def invoke_model(prompt: str, model: str = "claude", timeout: int = 300) -> str:
     """Invoke an LLM via CLI subprocess or API. Returns response text.
 
+    For CLI models, uses --output-format json to capture token/cost data.
+    Accumulated stats available via get_cost_summary().
+
     Raises FileNotFoundError if the model binary is not in PATH (CLI models).
     Raises ImportError if API dependencies are not installed (API models).
     Raises RuntimeError if the model exits non-zero or API call fails.
@@ -167,4 +261,6 @@ def invoke_model(prompt: str, model: str = "claude", timeout: int = 300) -> str:
         parts = output.split("...done thinking.\n", 1)
         if len(parts) == 2:
             output = parts[1]
-    return output
+    if model.startswith("ollama:"):
+        return output
+    return _parse_cli_json(output, model)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,5 +1,6 @@
 """Tests for the shared LLM invocation module."""
 
+import json
 import os
 import subprocess
 from unittest.mock import MagicMock, patch
@@ -10,7 +11,12 @@ import reasons_lib.llm as llm_module
 from reasons_lib.llm import (
     _get_langfuse_handler,
     _invoke_api,
+    _parse_cli_json,
+    _record_cost,
+    format_cost_summary,
+    get_cost_summary,
     invoke_model,
+    reset_cost_tracker,
     resolve_model_cmd,
 )
 
@@ -18,19 +24,19 @@ from reasons_lib.llm import (
 class TestResolveModelCmd:
 
     def test_resolve_claude(self):
-        assert resolve_model_cmd("claude") == ["claude", "-p"]
+        assert resolve_model_cmd("claude") == ["claude", "-p", "--output-format", "json"]
 
     def test_resolve_gemini(self):
-        assert resolve_model_cmd("gemini") == ["gemini", "--skip-trust", "-p", ""]
+        assert resolve_model_cmd("gemini") == ["gemini", "--skip-trust", "-o", "json", "-p", ""]
 
     def test_resolve_gemini_submodel(self):
         assert resolve_model_cmd("gemini:gemini-2.5-flash") == [
-            "gemini", "--skip-trust", "-m", "gemini-2.5-flash", "-p", ""
+            "gemini", "--skip-trust", "-m", "gemini-2.5-flash", "-o", "json", "-p", ""
         ]
 
     def test_resolve_gemini_submodel_short(self):
         assert resolve_model_cmd("gemini:flash") == [
-            "gemini", "--skip-trust", "-m", "flash", "-p", ""
+            "gemini", "--skip-trust", "-m", "flash", "-o", "json", "-p", ""
         ]
 
     def test_resolve_ollama_model(self):
@@ -40,10 +46,10 @@ class TestResolveModelCmd:
         assert resolve_model_cmd("ollama:qwen3.5:27b") == ["ollama", "run", "qwen3.5:27b"]
 
     def test_resolve_claude_submodel(self):
-        assert resolve_model_cmd("claude:sonnet") == ["claude", "-p", "--model", "sonnet"]
+        assert resolve_model_cmd("claude:sonnet") == ["claude", "-p", "--model", "sonnet", "--output-format", "json"]
 
     def test_resolve_claude_submodel_full_name(self):
-        assert resolve_model_cmd("claude:claude-sonnet-4-6") == ["claude", "-p", "--model", "claude-sonnet-4-6"]
+        assert resolve_model_cmd("claude:claude-sonnet-4-6") == ["claude", "-p", "--model", "claude-sonnet-4-6", "--output-format", "json"]
 
     def test_resolve_unknown_raises(self):
         with pytest.raises(ValueError, match="Unknown model"):
@@ -58,14 +64,15 @@ class TestInvokeModel:
                 invoke_model("hello", model="claude")
 
     def test_invokes_subprocess(self):
-        mock_result = type("Result", (), {"returncode": 0, "stdout": "response", "stderr": ""})()
+        json_out = json.dumps({"result": "response", "usage": {}, "total_cost_usd": 0.0})
+        mock_result = type("Result", (), {"returncode": 0, "stdout": json_out, "stderr": ""})()
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run", return_value=mock_result) as mock_run:
             result = invoke_model("hello", model="claude", timeout=60)
             assert result == "response"
             mock_run.assert_called_once()
             args = mock_run.call_args
-            assert args[0][0] == ["claude", "-p"]
+            assert args[0][0] == ["claude", "-p", "--output-format", "json"]
             assert args[1]["input"] == "hello"
             assert args[1]["timeout"] == 60
 
@@ -111,14 +118,16 @@ class TestInvokeModel:
 
     def test_claude_does_not_strip_thinking(self):
         output = "Thinking...\nsome reasoning\n...done thinking.\nAnswer."
-        mock_result = type("Result", (), {"returncode": 0, "stdout": output, "stderr": ""})()
+        json_out = json.dumps({"result": output, "usage": {}, "total_cost_usd": 0.0})
+        mock_result = type("Result", (), {"returncode": 0, "stdout": json_out, "stderr": ""})()
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
             result = invoke_model("hello", model="claude")
             assert result == output
 
     def test_strips_claudecode_env(self):
-        mock_result = type("Result", (), {"returncode": 0, "stdout": "ok", "stderr": ""})()
+        json_out = json.dumps({"result": "ok", "usage": {}, "total_cost_usd": 0.0})
+        mock_result = type("Result", (), {"returncode": 0, "stdout": json_out, "stderr": ""})()
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run", return_value=mock_result) as mock_run, \
              patch.dict("os.environ", {"CLAUDECODE": "1", "HOME": "/home/test"}):
@@ -160,7 +169,8 @@ class TestInvokeModelApiDispatch:
             mock.assert_called_once_with("hello", "vertex:claude-sonnet-4-20250514", 60)
 
     def test_claude_still_uses_subprocess(self):
-        mock_result = type("Result", (), {"returncode": 0, "stdout": "cli response", "stderr": ""})()
+        json_out = json.dumps({"result": "cli response", "usage": {}, "total_cost_usd": 0.0})
+        mock_result = type("Result", (), {"returncode": 0, "stdout": json_out, "stderr": ""})()
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
             result = invoke_model("hello", model="claude")
@@ -322,3 +332,138 @@ class TestLangfuseHandler:
         assert result == "traced response"
         call_config = mock_model.invoke.call_args[1]["config"]
         assert call_config["callbacks"] == [mock_handler]
+
+
+class TestParseCliJson:
+
+    def test_claude_json(self):
+        data = {
+            "result": "The answer is 42.",
+            "usage": {"input_tokens": 100, "output_tokens": 50},
+            "total_cost_usd": 0.0021,
+        }
+        reset_cost_tracker()
+        text = _parse_cli_json(json.dumps(data), "claude")
+        assert text == "The answer is 42."
+        s = get_cost_summary()
+        assert s["input_tokens"] == 100
+        assert s["output_tokens"] == 50
+        assert s["total_cost_usd"] == pytest.approx(0.0021)
+        assert s["calls"] == 1
+
+    def test_claude_json_with_cache_tokens(self):
+        data = {
+            "result": "cached",
+            "usage": {
+                "input_tokens": 50,
+                "output_tokens": 30,
+                "cache_creation_input_tokens": 200,
+                "cache_read_input_tokens": 100,
+            },
+            "total_cost_usd": 0.01,
+        }
+        reset_cost_tracker()
+        text = _parse_cli_json(json.dumps(data), "claude:sonnet")
+        assert text == "cached"
+        s = get_cost_summary()
+        assert s["input_tokens"] == 350  # 50 + 200 + 100
+
+    def test_gemini_json(self):
+        data = {
+            "response": "Gemini says hi.",
+            "stats": {
+                "models": {
+                    "gemini-2.5-flash": {
+                        "tokens": {"input": 80, "candidates": 40}
+                    }
+                }
+            },
+        }
+        reset_cost_tracker()
+        text = _parse_cli_json(json.dumps(data), "gemini")
+        assert text == "Gemini says hi."
+        s = get_cost_summary()
+        assert s["input_tokens"] == 80
+        assert s["output_tokens"] == 40
+        assert s["total_cost_usd"] == 0.0
+
+    def test_gemini_submodel_json(self):
+        data = {
+            "response": "Flash response.",
+            "stats": {"models": {"flash": {"tokens": {"input": 10, "candidates": 5}}}},
+        }
+        reset_cost_tracker()
+        text = _parse_cli_json(json.dumps(data), "gemini:flash")
+        assert text == "Flash response."
+        s = get_cost_summary()
+        assert s["input_tokens"] == 10
+        assert s["output_tokens"] == 5
+
+    def test_invalid_json_returns_raw(self):
+        reset_cost_tracker()
+        text = _parse_cli_json("not json at all", "claude")
+        assert text == "not json at all"
+        assert get_cost_summary()["calls"] == 0
+
+    def test_json_missing_result_returns_raw(self):
+        reset_cost_tracker()
+        text = _parse_cli_json(json.dumps({"other": "data"}), "claude")
+        assert text == json.dumps({"other": "data"})
+
+    def test_json_array_returns_raw(self):
+        raw = json.dumps([{"id": "a", "valid": True}])
+        reset_cost_tracker()
+        text = _parse_cli_json(raw, "claude")
+        assert text == raw
+        assert get_cost_summary()["calls"] == 0
+
+
+class TestCostTracker:
+
+    def setup_method(self):
+        reset_cost_tracker()
+
+    def test_reset(self):
+        _record_cost("claude", 100, 50, 0.01)
+        reset_cost_tracker()
+        s = get_cost_summary()
+        assert s["calls"] == 0
+        assert s["input_tokens"] == 0
+        assert s["output_tokens"] == 0
+        assert s["total_cost_usd"] == 0.0
+        assert s["by_model"] == {}
+
+    def test_record_accumulates(self):
+        _record_cost("claude", 100, 50, 0.01)
+        _record_cost("claude", 200, 100, 0.02)
+        s = get_cost_summary()
+        assert s["calls"] == 2
+        assert s["input_tokens"] == 300
+        assert s["output_tokens"] == 150
+        assert s["total_cost_usd"] == pytest.approx(0.03)
+
+    def test_by_model_tracking(self):
+        _record_cost("claude", 100, 50, 0.01)
+        _record_cost("gemini", 80, 40, 0.0)
+        s = get_cost_summary()
+        assert "claude" in s["by_model"]
+        assert "gemini" in s["by_model"]
+        assert s["by_model"]["claude"]["calls"] == 1
+        assert s["by_model"]["gemini"]["input_tokens"] == 80
+
+    def test_format_empty(self):
+        assert format_cost_summary() == ""
+
+    def test_format_with_cost(self):
+        _record_cost("claude", 1000, 500, 0.0123)
+        result = format_cost_summary()
+        assert "$0.0123" in result
+        assert "1,000 input" in result
+        assert "500 output" in result
+        assert "1 call(s)" in result
+
+    def test_format_without_cost(self):
+        _record_cost("gemini", 100, 50, 0.0)
+        result = format_cost_summary()
+        assert "$" not in result
+        assert "100 input" in result


### PR DESCRIPTION
## Summary
- CLI models (claude, gemini) now use --output-format json to capture token counts and costs from wrapper metadata without affecting model responses
- New cost accumulator records per-call and per-model stats across all invoke_model calls
- format_cost_summary() prints a human-readable cost line to stderr after multi-call commands
- JSON parsing handles both Claude and Gemini formats with graceful fallback for non-JSON output

## Test plan
- [x] 51 tests in test_llm.py pass (12 new tests for JSON parsing, cost tracking, and edge cases)
- [x] Full suite: 1328 passed, 0 failed
- [x] Edge case: JSON arrays from mocked responses handled gracefully

Closes #184