### PR TITLE
Add search-sources command for standalone FTS5 chunk queries (#186)

### DIFF
--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -216,53 +216,10 @@ def _strip_belief_metadata(beliefs_context):
     return result
 
 
-def _search_source_chunks(question, sources_db, top_k=10):
-    """Search FTS5 index of source document chunks."""
-    from .api import _STOP_WORDS
-
-    raw_words = re.findall(r'\w+', question)
-    words = [w for w in raw_words if w.lower() not in _STOP_WORDS and len(w) > 1]
-    if not words:
-        words = [w for w in raw_words if len(w) > 1]
-    if not words:
-        return ""
-    fts_query = " OR ".join(f'"{w}"' for w in words)
-
-    try:
-        conn = sqlite3.connect(sources_db)
-        try:
-            conn.row_factory = sqlite3.Row
-            cur = conn.cursor()
-            cur.execute("""
-                SELECT c.text, c.cluster, c.filename, c.section
-                FROM chunks_fts
-                JOIN chunks c ON c.id = chunks_fts.rowid
-                WHERE chunks_fts MATCH ?
-                ORDER BY chunks_fts.rank
-                LIMIT ?
-            """, (fts_query, top_k))
-            rows = cur.fetchall()
-        finally:
-            conn.close()
-    except (sqlite3.OperationalError, sqlite3.DatabaseError):
-        return ""
-
-    if not rows:
-        return ""
-
-    parts = []
-    for i, row in enumerate(rows, 1):
-        header = f"[{i}] {row['filename']}"
-        if row["section"]:
-            header += f" > {row['section']}"
-        parts.append(f"### {header}\n\n{row['text']}")
-    return "\n\n---\n\n".join(parts)
-
-
 def search_source_chunks(query, sources_db, top_k=10):
     """Search FTS5 index and return structured results.
 
-    Returns list of dicts with keys: filename, section, text.
+    Returns list of dicts with keys: filename, section, text, cluster.
     """
     from .api import _STOP_WORDS
 
@@ -289,6 +246,23 @@ def search_source_chunks(query, sources_db, top_k=10):
         return [dict(row) for row in cur.fetchall()]
     finally:
         conn.close()
+
+
+def _search_source_chunks(question, sources_db, top_k=10):
+    """Search FTS5 index of source document chunks. Returns formatted text."""
+    try:
+        rows = search_source_chunks(question, sources_db, top_k)
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+        return ""
+    if not rows:
+        return ""
+    parts = []
+    for i, row in enumerate(rows, 1):
+        header = f"[{i}] {row['filename']}"
+        if row["section"]:
+            header += f" > {row['section']}"
+        parts.append(f"### {header}\n\n{row['text']}")
+    return "\n\n---\n\n".join(parts)
 
 
 FTS_RAG_PROMPT = """\

--- a/reasons_lib/ask.py
+++ b/reasons_lib/ask.py
@@ -259,6 +259,38 @@ def _search_source_chunks(question, sources_db, top_k=10):
     return "\n\n---\n\n".join(parts)
 
 
+def search_source_chunks(query, sources_db, top_k=10):
+    """Search FTS5 index and return structured results.
+
+    Returns list of dicts with keys: filename, section, text.
+    """
+    from .api import _STOP_WORDS
+
+    raw_words = re.findall(r'\w+', query)
+    words = [w for w in raw_words if w.lower() not in _STOP_WORDS and len(w) > 1]
+    if not words:
+        words = [w for w in raw_words if len(w) > 1]
+    if not words:
+        return []
+    fts_query = " OR ".join(f'"{w}"' for w in words)
+
+    conn = sqlite3.connect(sources_db)
+    try:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        cur.execute("""
+            SELECT c.text, c.cluster, c.filename, c.section
+            FROM chunks_fts
+            JOIN chunks c ON c.id = chunks_fts.rowid
+            WHERE chunks_fts MATCH ?
+            ORDER BY chunks_fts.rank
+            LIMIT ?
+        """, (fts_query, top_k))
+        return [dict(row) for row in cur.fetchall()]
+    finally:
+        conn.close()
+
+
 FTS_RAG_PROMPT = """\
 You are answering questions using retrieved document excerpts.
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -879,6 +879,26 @@ def cmd_lookup(args):
     print(result)
 
 
+def cmd_search_sources(args):
+    from .ask import search_source_chunks
+    results = search_source_chunks(args.query, args.db, top_k=args.top_k)
+    if not results:
+        print("No matching chunks found.")
+        return
+    fmt = getattr(args, "format", "text")
+    if fmt == "json":
+        print(json.dumps(results, indent=2))
+        return
+    for i, row in enumerate(results, 1):
+        header = f"[{i}] {row['filename']}"
+        if row.get("section"):
+            header += f" > {row['section']}"
+        print(f"### {header}\n")
+        print(row["text"])
+        if i < len(results):
+            print("\n---\n")
+
+
 def cmd_ask(args):
     _require_sqlite(args, "ask")
     from .ask import ask
@@ -2184,6 +2204,16 @@ def main():
     p.add_argument("--mcp", action="append", default=None,
                    help="MCP server command as data source (repeatable, e.g. --mcp snowflake-mcp)")
 
+    # search-sources
+    p = sub.add_parser("search-sources", help="Search source document chunks from an FTS5 index (no LLM)")
+    p.add_argument("query", help="Search query")
+    p.add_argument("--db", required=True, metavar="FTS_DB",
+                   help="Path to FTS5 chunks database (e.g. rag_fts.db)")
+    p.add_argument("--top-k", type=int, default=10,
+                   help="Number of results to return (default: 10)")
+    p.add_argument("--format", choices=["text", "json"], default="text",
+                   help="Output format (default: text)")
+
     # deduplicate
     p = sub.add_parser("deduplicate", help="Find and optionally retract duplicate IN beliefs")
     p.add_argument("--threshold", type=float, default=0.5,
@@ -2399,6 +2429,7 @@ def main():
         "search": cmd_search,
         "lookup": cmd_lookup,
         "ask": cmd_ask,
+        "search-sources": cmd_search_sources,
         "deduplicate": cmd_deduplicate,
         "cluster-list": cmd_cluster_list,
         "list": cmd_list,

--- a/tests/test_search_sources.py
+++ b/tests/test_search_sources.py
@@ -1,0 +1,150 @@
+"""Tests for search-sources command and search_source_chunks function."""
+
+import json
+import sqlite3
+
+import pytest
+
+from reasons_lib.ask import search_source_chunks
+
+
+def _create_fts_db(path):
+    """Create a minimal FTS5 chunks database for testing."""
+    conn = sqlite3.connect(str(path))
+    conn.execute("""
+        CREATE TABLE chunks (
+            id INTEGER PRIMARY KEY,
+            text TEXT,
+            cluster TEXT,
+            filename TEXT,
+            section TEXT
+        )
+    """)
+    conn.execute("CREATE VIRTUAL TABLE chunks_fts USING fts5(text, content=chunks, content_rowid=id)")
+    conn.execute("""
+        INSERT INTO chunks (id, text, cluster, filename, section)
+        VALUES (1, 'Retraction cascades propagate through the dependency graph',
+                'tms', 'architecture.md', 'Retraction')
+    """)
+    conn.execute("""
+        INSERT INTO chunks (id, text, cluster, filename, section)
+        VALUES (2, 'Nodes are justified by SL justifications with support lists',
+                'tms', 'architecture.md', 'Justifications')
+    """)
+    conn.execute("""
+        INSERT INTO chunks (id, text, cluster, filename, section)
+        VALUES (3, 'The belief network can be exported as JSON or Markdown',
+                'export', 'usage.md', '')
+    """)
+    conn.execute("""
+        INSERT INTO chunks_fts (rowid, text)
+        VALUES (1, 'Retraction cascades propagate through the dependency graph')
+    """)
+    conn.execute("""
+        INSERT INTO chunks_fts (rowid, text)
+        VALUES (2, 'Nodes are justified by SL justifications with support lists')
+    """)
+    conn.execute("""
+        INSERT INTO chunks_fts (rowid, text)
+        VALUES (3, 'The belief network can be exported as JSON or Markdown')
+    """)
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+class TestSearchSourceChunks:
+
+    def test_basic_search(self, tmp_path):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        results = search_source_chunks("retraction", db)
+        assert len(results) >= 1
+        assert results[0]["filename"] == "architecture.md"
+        assert "Retraction" in results[0]["text"]
+
+    def test_returns_list_of_dicts(self, tmp_path):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        results = search_source_chunks("justifications", db)
+        assert isinstance(results, list)
+        assert all(isinstance(r, dict) for r in results)
+        assert all(k in results[0] for k in ("text", "filename", "section"))
+
+    def test_no_matches(self, tmp_path):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        results = search_source_chunks("xyznonexistent", db)
+        assert results == []
+
+    def test_top_k_limits(self, tmp_path):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        results = search_source_chunks("network belief retraction", db, top_k=1)
+        assert len(results) <= 1
+
+    def test_empty_query(self, tmp_path):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        results = search_source_chunks("", db)
+        assert results == []
+
+    def test_stop_words_fallback_still_searches(self, tmp_path):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        results = search_source_chunks("the a an", db)
+        assert isinstance(results, list)
+
+    def test_section_included(self, tmp_path):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        results = search_source_chunks("retraction", db)
+        assert results[0]["section"] == "Retraction"
+
+    def test_empty_section(self, tmp_path):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        results = search_source_chunks("exported JSON", db)
+        assert len(results) >= 1
+        assert results[0]["section"] == ""
+
+    def test_bad_db_raises(self, tmp_path):
+        with pytest.raises(sqlite3.OperationalError):
+            search_source_chunks("test", str(tmp_path / "nonexistent.db"))
+
+
+class TestSearchSourcesCli:
+
+    def test_text_output(self, tmp_path, capsys):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        from reasons_lib.cli import cmd_search_sources
+        args = type("Args", (), {
+            "query": "retraction",
+            "db": db,
+            "top_k": 10,
+            "format": "text",
+        })()
+        cmd_search_sources(args)
+        out = capsys.readouterr().out
+        assert "architecture.md" in out
+        assert "Retraction" in out
+
+    def test_json_output(self, tmp_path, capsys):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        from reasons_lib.cli import cmd_search_sources
+        args = type("Args", (), {
+            "query": "retraction",
+            "db": db,
+            "top_k": 10,
+            "format": "json",
+        })()
+        cmd_search_sources(args)
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert data[0]["filename"] == "architecture.md"
+
+    def test_no_results_message(self, tmp_path, capsys):
+        db = _create_fts_db(tmp_path / "chunks.db")
+        from reasons_lib.cli import cmd_search_sources
+        args = type("Args", (), {
+            "query": "xyznonexistent",
+            "db": db,
+            "top_k": 10,
+            "format": "text",
+        })()
+        cmd_search_sources(args)
+        out = capsys.readouterr().out
+        assert "No matching chunks" in out


### PR DESCRIPTION
## Summary
- New `reasons search-sources` command queries FTS5 chunk databases directly without LLM calls
- New public `search_source_chunks()` function in `ask.py` returns structured results (list of dicts)
- Supports `--format text` (default, markdown-style) and `--format json` output
- Configurable `--top-k` for result count

## Usage
```bash
reasons search-sources "retraction cascade" --db rag_fts.db
reasons search-sources "retraction cascade" --db rag_fts.db --top-k 20 --format json
```

## Test plan
- [x] 12 tests in test_search_sources.py (function + CLI, both formats, edge cases)
- [x] Full suite: 1340 passed, 0 failed

Closes #186