### PR TITLE
Add review-premises command for source-material verification (#190)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2618,6 +2618,123 @@ def review_beliefs(
     }
 
 
+def review_premises(
+    belief_ids: list[str] | None = None,
+    model: str = "claude",
+    timeout: int = 300,
+    sample: int | None = None,
+    visible_to: list[str] | None = None,
+    dry_run: bool = False,
+    on_batch: Callable | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Review premises against their source material for factual accuracy.
+
+    Uses an LLM to evaluate whether each premise accurately reflects what
+    its source document says. Writes last_premise_reviewed and
+    premise_review_result metadata to each reviewed node (unless dry_run).
+
+    Returns: {"results": [...], "reviewed": int, "inaccurate": int,
+              "overgeneralized": int, "total_premises": int,
+              "skipped_no_source": int}
+    """
+    import sys
+    from datetime import datetime
+    from pathlib import Path
+
+    from .check_stale import resolve_source_path
+    from .review_premises import review_premises as _review
+
+    result = export_network(db_path=db_path)
+    nodes = result.get("nodes", {})
+    repos = result.get("repos", {})
+    repos = {k: Path(v) if isinstance(v, str) else v for k, v in repos.items()}
+
+    db_dir = Path(db_path).parent if db_path else None
+
+    all_premises = {
+        k: v for k, v in nodes.items()
+        if v.get("truth_value") == "IN"
+        and (not v.get("justifications") or len(v["justifications"]) == 0)
+    }
+    total_premises = len(all_premises)
+
+    candidates = dict(all_premises)
+
+    if belief_ids:
+        candidates = {k: v for k, v in candidates.items() if k in belief_ids}
+
+    if visible_to is not None:
+        tags = set(visible_to)
+        candidates = {
+            k: v for k, v in candidates.items()
+            if not v.get("metadata", {}).get("access_tags")
+            or all(t in tags for t in v["metadata"]["access_tags"])
+        }
+
+    if sample is not None and len(candidates) > sample:
+        import random
+        sampled_keys = random.sample(sorted(candidates.keys()), sample)
+        candidates = {k: candidates[k] for k in sampled_keys}
+
+    source_contents = {}
+    review_ids = []
+    skipped = 0
+
+    for nid in sorted(candidates.keys()):
+        source = candidates[nid].get("source", "")
+        if not source:
+            skipped += 1
+            continue
+        if source not in source_contents:
+            agent = candidates[nid].get("metadata", {}).get("agent")
+            path = resolve_source_path(source, repos=repos, db_dir=db_dir, agent=agent)
+            if path and path.exists():
+                try:
+                    source_contents[source] = path.read_text()
+                except (OSError, UnicodeDecodeError):
+                    skipped += 1
+                    continue
+            else:
+                print(f"  SKIP {nid}: source not found: {source}", file=sys.stderr)
+                skipped += 1
+                continue
+        review_ids.append(nid)
+
+    results = _review(nodes, premise_ids=review_ids, source_contents=source_contents,
+                      model=model, timeout=timeout, on_batch=on_batch)
+
+    now = datetime.now().isoformat(timespec="seconds")
+
+    if not dry_run and results:
+        result_map = {r["id"]: r for r in results}
+        with _with_network(db_path, write=True) as net:
+            for nid in review_ids:
+                if nid in net.nodes and nid in result_map:
+                    r = result_map[nid]
+                    net.nodes[nid].metadata["last_premise_reviewed"] = now
+                    if r.get("accurate", True) and r.get("well_scoped", True):
+                        net.nodes[nid].metadata["premise_review_result"] = "pass"
+                    elif not r.get("accurate", True):
+                        net.nodes[nid].metadata["premise_review_result"] = r.get("error_type", "inaccurate")
+                    else:
+                        net.nodes[nid].metadata["premise_review_result"] = "overgeneralized"
+
+    inaccurate = sum(1 for r in results if not r.get("accurate", True))
+    overgeneralized = sum(1 for r in results
+                         if r.get("accurate", True) and not r.get("well_scoped", True))
+
+    return {
+        "results": results,
+        "reviewed": len(review_ids),
+        "inaccurate": inaccurate,
+        "overgeneralized": overgeneralized,
+        "total_premises": total_premises,
+        "skipped_no_source": skipped,
+        "timestamp": now,
+    }
+
+
 def propose_update(
     belief_ids: list[str] | None = None,
     model: str = "claude",

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1585,6 +1585,117 @@ def cmd_review_beliefs(args):
         print(f"  {cost}", file=sys.stderr)
 
 
+def cmd_review_premises(args):
+    _require_sqlite(args, "review-premises")
+    import json
+    from datetime import datetime
+    from .llm import reset_cost_tracker, format_cost_summary
+    reset_cost_tracker()
+
+    model = getattr(args, "model", None) or "claude"
+    ts = datetime.now().isoformat(timespec="seconds")
+    write_report = not args.no_report
+
+    report_path = None
+    if write_report:
+        report_dir = Path(args.report_dir)
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_path = report_dir / f"review-premises-{ts.replace(':', '')}.json"
+
+    def _build_report(results, status, total_premises=None, skipped=0):
+        inaccurate = sum(1 for r in results if not r.get("accurate", True))
+        overgeneralized = sum(1 for r in results
+                             if r.get("accurate", True) and not r.get("well_scoped", True))
+        return {
+            "timestamp": ts,
+            "status": status,
+            "model": model,
+            "timeout": args.timeout,
+            "dry_run": args.dry_run,
+            "filters": {
+                "belief_ids": args.ids or None,
+                "sample": args.sample,
+                "visible_to": _parse_visible_to(args),
+            },
+            "reviewed": len(results),
+            "total_premises": total_premises,
+            "skipped_no_source": skipped,
+            "summary": {
+                "inaccurate": inaccurate,
+                "overgeneralized": overgeneralized,
+            },
+            "results": results,
+        }
+
+    def _write_report(results, status):
+        if report_path is not None:
+            report_path.write_text(json.dumps(_build_report(results, status), indent=2))
+
+    on_batch = (lambda results: _write_report(results, "partial")) if write_report else None
+
+    result = api.review_premises(
+        belief_ids=args.ids or None,
+        model=model,
+        timeout=args.timeout,
+        sample=args.sample,
+        visible_to=_parse_visible_to(args),
+        dry_run=args.dry_run,
+        on_batch=on_batch,
+        db_path=args.db,
+    )
+
+    reviews = result["results"]
+    if not reviews:
+        print("No premises to review (no premises with resolvable sources found).")
+        cost = format_cost_summary()
+        if cost:
+            print(f"  {cost}", file=sys.stderr)
+        return
+
+    inaccurate = [r for r in reviews if not r.get("accurate", True)]
+    overgeneralized = [r for r in reviews
+                       if r.get("accurate", True) and not r.get("well_scoped", True)]
+
+    for r in reviews:
+        flags = []
+        if not r.get("accurate", True):
+            err = r.get("error_type", "inaccurate")
+            flags.append(f"INACCURATE({err})")
+        if not r.get("well_scoped", True):
+            flags.append("OVERGENERALIZED")
+
+        if flags:
+            print(f"  [{' | '.join(flags)}] {r['id']}")
+            if r.get("comment"):
+                print(f"    {r['comment']}")
+
+    print(f"\nReviewed {result['reviewed']} of {result['total_premises']} premises"
+          f" ({result['skipped_no_source']} skipped, no source)")
+    print(f"  Inaccurate: {result['inaccurate']}  Overgeneralized: {result['overgeneralized']}")
+
+    if report_path is not None:
+        report = _build_report(reviews, "complete",
+                               total_premises=result["total_premises"],
+                               skipped=result["skipped_no_source"])
+        report_path.write_text(json.dumps(report, indent=2))
+        print(f"  Report: {report_path}")
+
+    if args.auto_retract and not args.dry_run and inaccurate:
+        print(f"\nRetracting {len(inaccurate)} inaccurate premise(s)...")
+        for r in inaccurate:
+            try:
+                api.retract_node(r["id"],
+                                 reason=f"review-premises: {r.get('error_type', 'inaccurate')}: {r.get('comment', '')}",
+                                 db_path=args.db)
+                print(f"  RETRACTED {r['id']}")
+            except Exception as e:
+                print(f"  ERROR retracting {r['id']}: {e}", file=sys.stderr)
+
+    cost = format_cost_summary()
+    if cost:
+        print(f"  {cost}", file=sys.stderr)
+
+
 def cmd_propose_update(args):
     _require_sqlite(args, "propose-update")
     import json as _json
@@ -2288,6 +2399,26 @@ def main():
     p.add_argument("--no-report", action="store_true",
                    help="Skip JSON report generation")
 
+    # review-premises
+    p = sub.add_parser("review-premises", help="Review premises against source material for factual accuracy")
+    p.add_argument("ids", nargs="*", help="Specific premise IDs to review (default: all IN premises)")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
+    p.add_argument("--timeout", type=int, default=600,
+                   help="LLM timeout in seconds (default: 600)")
+    p.add_argument("--sample", type=int, default=None,
+                   help="Randomly sample N premises to review")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report findings without taking action")
+    p.add_argument("--auto-retract", action="store_true",
+                   help="Retract premises found inaccurate")
+    p.add_argument("--visible-to", metavar="TAG,TAG",
+                   help="Only review nodes whose access_tags are a subset of these tags")
+    p.add_argument("--report-dir", default="reviews",
+                   help="Directory for JSON reports (default: reviews/)")
+    p.add_argument("--no-report", action="store_true",
+                   help="Skip JSON report generation")
+
     # propose-update
     p = sub.add_parser("propose-update",
         help="Propose structured updates or retractions for beliefs (LLM-driven)")
@@ -2437,6 +2568,7 @@ def main():
         "list-negative": cmd_list_negative,
         "topics": cmd_topics,
         "review-beliefs": cmd_review_beliefs,
+        "review-premises": cmd_review_premises,
         "propose-update": cmd_propose_update,
         "repair-smuggled": cmd_repair_smuggled,
         "research": cmd_research,

--- a/reasons_lib/review_premises.py
+++ b/reasons_lib/review_premises.py
@@ -1,0 +1,174 @@
+"""Review premises against their source material for factual accuracy.
+
+Premises are taken as ground truth in the TMS — they have no antecedents
+to validate against. This module checks whether premises accurately reflect
+what their source documents actually say, catching fabricated details,
+overgeneralizations, and unsupported claims.
+"""
+
+import json
+import sys
+
+from .llm import invoke_model
+
+REVIEW_BATCH_SIZE = 5
+
+REVIEW_PREMISES_PROMPT = """\
+You are auditing premises in a Truth Maintenance System (TMS).
+Each premise below was extracted from a source document by an earlier LLM pass.
+The system stored the claim but did not verify whether the source actually
+says what the premise claims.
+
+For each premise, the source document text is provided. Evaluate two axes:
+
+1. **Accurate**: Does the source material actually state or clearly imply
+   this claim? Watch for:
+   - Details added that the source never mentions (misread_source)
+   - Claims that go beyond what the source supports (overgeneralized)
+   - Information fabricated with no basis in the source (fabricated)
+   - Claims the source does not address at all (unsupported)
+
+2. **Well-scoped**: Is the claim appropriately scoped? A premise that says
+   "X always does Y" when the source says "X sometimes does Y" is
+   overgeneralized even if the core idea is present.
+
+Return ONLY a JSON array. For each premise, one object:
+
+```json
+[
+  {{
+    "id": "premise-id",
+    "accurate": true,
+    "well_scoped": true,
+    "error_type": null,
+    "comment": "brief explanation"
+  }}
+]
+```
+
+Rules:
+- Return one object per premise reviewed, in the same order as presented.
+- "error_type" must be one of: "misread_source", "overgeneralized",
+  "fabricated", "unsupported", or null if the premise is accurate.
+- "comment" should be a single sentence explaining the most important finding.
+- If accurate is false, error_type MUST be set (not null).
+- If accurate is true, error_type MUST be null.
+- Be rigorous: a claim that sounds reasonable but isn't in the source is NOT accurate.
+- Focus on what the source document says, not on general knowledge.
+
+## Premises to review
+
+{premises}"""
+
+
+def format_premise_for_review(node_id, nodes, source_content):
+    """Format one premise with its source text for LLM review."""
+    node = nodes.get(node_id)
+    if not node:
+        return ""
+
+    lines = [f"### {node_id}"]
+    lines.append(f"Claim: {node.get('text', '')}")
+
+    source = node.get("source", "")
+    if source:
+        lines.append(f"Source reference: {source}")
+
+    lines.append("")
+    lines.append("Source document content:")
+    lines.append("```")
+    lines.append(source_content)
+    lines.append("```")
+
+    return "\n".join(lines)
+
+
+def parse_premise_review_response(response):
+    """Extract premise review results JSON array from LLM response."""
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(response):
+        if ch != "[":
+            continue
+        try:
+            items, _ = decoder.raw_decode(response, i)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(items, list):
+            continue
+        results = []
+        for item in items:
+            if not isinstance(item, dict) or "id" not in item:
+                continue
+            results.append({
+                "id": item["id"],
+                "accurate": item.get("accurate", True),
+                "well_scoped": item.get("well_scoped", True),
+                "error_type": item.get("error_type"),
+                "comment": item.get("comment", ""),
+            })
+        if results:
+            return results
+    return []
+
+
+def review_premises(nodes, premise_ids, source_contents, model="claude",
+                    timeout=300, batch_size=REVIEW_BATCH_SIZE, on_batch=None):
+    """Review premises against their source material.
+
+    Args:
+        nodes: Dict of node_id -> node data from export_network().
+        premise_ids: List of premise IDs to review.
+        source_contents: Dict of source_path -> file content string.
+        model: LLM model to use for review.
+        timeout: LLM timeout in seconds.
+        batch_size: Number of premises per LLM call.
+        on_batch: Callback(all_results) after each batch.
+
+    Returns: list of review result dicts.
+    """
+    if not premise_ids:
+        return []
+
+    source_for_premise = {}
+    for pid in premise_ids:
+        node = nodes.get(pid)
+        if node:
+            source_for_premise[pid] = node.get("source", "")
+
+    by_source = {}
+    for pid in premise_ids:
+        src = source_for_premise.get(pid, "")
+        by_source.setdefault(src, []).append(pid)
+
+    ordered_ids = []
+    for src_pids in by_source.values():
+        ordered_ids.extend(src_pids)
+
+    all_results = []
+    total_batches = (len(ordered_ids) + batch_size - 1) // batch_size
+
+    for i in range(0, len(ordered_ids), batch_size):
+        batch = ordered_ids[i:i + batch_size]
+        batch_num = i // batch_size + 1
+        print(f"  Reviewing batch {batch_num}/{total_batches} "
+              f"({len(batch)} premises)...", file=sys.stderr)
+
+        premises_text = "\n\n".join(
+            format_premise_for_review(
+                pid, nodes,
+                source_contents.get(nodes[pid].get("source", ""), "(source not available)")
+            )
+            for pid in batch
+        )
+        prompt = REVIEW_PREMISES_PROMPT.format(premises=premises_text)
+
+        try:
+            response = invoke_model(prompt, model=model, timeout=timeout)
+            results = parse_premise_review_response(response)
+            all_results.extend(results)
+            if on_batch is not None:
+                on_batch(all_results)
+        except Exception as e:
+            print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
+
+    return all_results

--- a/tests/test_review_premises.py
+++ b/tests/test_review_premises.py
@@ -1,0 +1,258 @@
+"""Tests for review-premises command and supporting functions."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib.review_premises import (
+    format_premise_for_review,
+    parse_premise_review_response,
+    review_premises,
+)
+
+
+class TestFormatPremiseForReview:
+
+    def test_basic_formatting(self):
+        nodes = {
+            "obs-1": {
+                "text": "Redis is used for session storage",
+                "source": "docs/architecture.md",
+            }
+        }
+        result = format_premise_for_review("obs-1", nodes, "Session data is stored in PostgreSQL.")
+        assert "### obs-1" in result
+        assert "Redis is used for session storage" in result
+        assert "docs/architecture.md" in result
+        assert "Session data is stored in PostgreSQL." in result
+
+    def test_missing_node(self):
+        assert format_premise_for_review("missing", {}, "content") == ""
+
+    def test_no_source_field(self):
+        nodes = {"obs-1": {"text": "A claim"}}
+        result = format_premise_for_review("obs-1", nodes, "source text")
+        assert "### obs-1" in result
+        assert "A claim" in result
+        assert "Source reference:" not in result
+
+
+class TestParsePremiseReviewResponse:
+
+    def test_valid_json(self):
+        response = json.dumps([{
+            "id": "obs-1",
+            "accurate": False,
+            "well_scoped": True,
+            "error_type": "misread_source",
+            "comment": "Source says PostgreSQL, not Redis",
+        }])
+        results = parse_premise_review_response(response)
+        assert len(results) == 1
+        assert results[0]["id"] == "obs-1"
+        assert results[0]["accurate"] is False
+        assert results[0]["error_type"] == "misread_source"
+
+    def test_json_with_prose(self):
+        response = "Here are my findings:\n" + json.dumps([{
+            "id": "obs-1", "accurate": True, "well_scoped": True,
+            "error_type": None, "comment": "Matches source",
+        }]) + "\n\nHope this helps!"
+        results = parse_premise_review_response(response)
+        assert len(results) == 1
+        assert results[0]["accurate"] is True
+
+    def test_malformed_json(self):
+        assert parse_premise_review_response("not json at all") == []
+
+    def test_defaults_for_missing_fields(self):
+        response = json.dumps([{"id": "obs-1"}])
+        results = parse_premise_review_response(response)
+        assert results[0]["accurate"] is True
+        assert results[0]["well_scoped"] is True
+        assert results[0]["error_type"] is None
+        assert results[0]["comment"] == ""
+
+    def test_multiple_results(self):
+        response = json.dumps([
+            {"id": "obs-1", "accurate": True, "well_scoped": True, "error_type": None, "comment": "ok"},
+            {"id": "obs-2", "accurate": False, "well_scoped": False, "error_type": "fabricated", "comment": "made up"},
+        ])
+        results = parse_premise_review_response(response)
+        assert len(results) == 2
+        assert results[0]["id"] == "obs-1"
+        assert results[1]["id"] == "obs-2"
+
+
+class TestReviewPremisesBatchLoop:
+
+    def test_calls_llm_and_parses(self):
+        nodes = {
+            "obs-1": {"text": "Claim A", "source": "doc.md", "truth_value": "IN"},
+        }
+        source_contents = {"doc.md": "Source content for doc."}
+        llm_response = json.dumps([{
+            "id": "obs-1", "accurate": True, "well_scoped": True,
+            "error_type": None, "comment": "matches",
+        }])
+        mock_result = type("R", (), {"returncode": 0, "stdout": llm_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            results = review_premises(nodes, ["obs-1"], source_contents, model="claude")
+        assert len(results) == 1
+        assert results[0]["accurate"] is True
+
+    def test_empty_ids_returns_empty(self):
+        assert review_premises({}, [], {}) == []
+
+    def test_on_batch_callback(self):
+        nodes = {
+            "obs-1": {"text": "Claim", "source": "doc.md", "truth_value": "IN"},
+        }
+        source_contents = {"doc.md": "Content."}
+        llm_response = json.dumps([{
+            "id": "obs-1", "accurate": True, "well_scoped": True,
+            "error_type": None, "comment": "ok",
+        }])
+        mock_result = type("R", (), {"returncode": 0, "stdout": llm_response, "stderr": ""})()
+        batches = []
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            review_premises(nodes, ["obs-1"], source_contents,
+                           on_batch=lambda r: batches.append(len(r)))
+        assert batches == [1]
+
+    def test_failed_batch_continues(self):
+        nodes = {
+            "obs-1": {"text": "A", "source": "a.md", "truth_value": "IN"},
+        }
+        source_contents = {"a.md": "Content."}
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=Exception("LLM down")):
+            results = review_premises(nodes, ["obs-1"], source_contents)
+        assert results == []
+
+
+class TestApiReviewPremises:
+
+    @pytest.fixture
+    def db_with_premises(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "entry.md"
+        source_file.write_text("The system uses PostgreSQL for storage.")
+
+        api.init_db(db_path=db)
+        api.add_node("obs-1", "PostgreSQL is used for storage",
+                     source=str(source_file), db_path=db)
+        api.add_node("obs-2", "Redis is used for caching",
+                     source=str(source_file), db_path=db)
+        api.add_node("derived-1", "Storage is reliable",
+                     sl="obs-1", db_path=db)
+        return db
+
+    def test_filters_premises_only(self, db_with_premises):
+        llm_response = json.dumps([
+            {"id": "obs-1", "accurate": True, "well_scoped": True, "error_type": None, "comment": "ok"},
+            {"id": "obs-2", "accurate": True, "well_scoped": True, "error_type": None, "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": llm_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_premises(dry_run=True, db_path=db_with_premises)
+        reviewed_ids = {r["id"] for r in result["results"]}
+        assert "derived-1" not in reviewed_ids
+        assert result["total_premises"] == 2
+
+    def test_skips_premises_without_source(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        api.add_node("no-src", "A claim with no source", db_path=db)
+        result = api.review_premises(dry_run=True, db_path=db)
+        assert result["skipped_no_source"] == 1
+        assert result["reviewed"] == 0
+
+    def test_specific_belief_ids(self, db_with_premises):
+        llm_response = json.dumps([
+            {"id": "obs-1", "accurate": True, "well_scoped": True, "error_type": None, "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": llm_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_premises(belief_ids=["obs-1"], dry_run=True,
+                                         db_path=db_with_premises)
+        assert result["reviewed"] == 1
+
+    def test_sample_limits(self, db_with_premises):
+        llm_response = json.dumps([
+            {"id": "obs-1", "accurate": True, "well_scoped": True, "error_type": None, "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": llm_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_premises(sample=1, dry_run=True,
+                                         db_path=db_with_premises)
+        assert result["reviewed"] == 1
+
+    def test_stores_metadata(self, db_with_premises):
+        llm_response = json.dumps([
+            {"id": "obs-1", "accurate": False, "well_scoped": True,
+             "error_type": "misread_source", "comment": "wrong"},
+            {"id": "obs-2", "accurate": True, "well_scoped": True,
+             "error_type": None, "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": llm_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            api.review_premises(db_path=db_with_premises)
+
+        net = api.export_network(db_path=db_with_premises)
+        obs1 = net["nodes"]["obs-1"]
+        obs2 = net["nodes"]["obs-2"]
+        assert obs1["metadata"]["premise_review_result"] == "misread_source"
+        assert obs2["metadata"]["premise_review_result"] == "pass"
+        assert "last_premise_reviewed" in obs1["metadata"]
+
+    def test_dry_run_no_metadata(self, db_with_premises):
+        llm_response = json.dumps([
+            {"id": "obs-1", "accurate": False, "well_scoped": True,
+             "error_type": "fabricated", "comment": "made up"},
+            {"id": "obs-2", "accurate": True, "well_scoped": True,
+             "error_type": None, "comment": "ok"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": llm_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            api.review_premises(dry_run=True, db_path=db_with_premises)
+
+        net = api.export_network(db_path=db_with_premises)
+        assert "premise_review_result" not in net["nodes"]["obs-1"].get("metadata", {})
+
+    def test_return_counts(self, db_with_premises):
+        llm_response = json.dumps([
+            {"id": "obs-1", "accurate": False, "well_scoped": True,
+             "error_type": "misread_source", "comment": "wrong"},
+            {"id": "obs-2", "accurate": True, "well_scoped": False,
+             "error_type": None, "comment": "too broad"},
+        ])
+        mock_result = type("R", (), {"returncode": 0, "stdout": llm_response, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock_result):
+            result = api.review_premises(dry_run=True, db_path=db_with_premises)
+        assert result["inaccurate"] == 1
+        assert result["overgeneralized"] == 1
+        assert result["reviewed"] == 2
+
+
+class TestCliDispatch:
+
+    def test_review_premises_registered(self):
+        from reasons_lib import cli
+        assert hasattr(cli, "cmd_review_premises")
+
+    def test_dispatch_table(self):
+        from reasons_lib.cli import main
+        import argparse
+        from reasons_lib import cli
+        assert callable(cli.cmd_review_premises)


### PR DESCRIPTION
## Summary
- New `reasons review-premises` command checks whether premises accurately reflect their source documents
- Evaluates two axes: **accuracy** (does the source actually say this?) and **scope** (is the claim appropriately scoped?)
- Classifies errors as: `misread_source`, `overgeneralized`, `fabricated`, or `unsupported`
- Resolves source file paths using existing `check_stale.resolve_source_path()` infrastructure
- Groups premises by source file for efficient batching (smaller batch size of 5 since source text inflates prompts)
- Follows same patterns as `review-beliefs`: JSON reports, `--dry-run`, `--auto-retract`, `--sample`, cost tracking

## Usage
```bash
reasons review-premises                           # review all IN premises with sources
reasons review-premises obs-1 obs-2               # review specific premises
reasons review-premises --sample 50 --dry-run     # sample 50, report only
reasons review-premises --auto-retract            # retract inaccurate premises
reasons review-premises -m api:claude-sonnet-4-20250514  # use API model
```

## Motivation
The propose-beliefs accuracy experiment found 8% of premises contain fabricated details that pass all downstream checks. `review-beliefs` only validates logical consistency of derived beliefs — it cannot catch wrong premises. This command fills that gap.

## Test plan
- [x] 21 tests in test_review_premises.py (module, API, CLI levels)
- [x] Full suite: 1361 passed, 0 failed

Closes #190