### PR TITLE
Add repair-premises and --parallel support (#190)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2626,6 +2626,7 @@ def review_premises(
     visible_to: list[str] | None = None,
     dry_run: bool = False,
     on_batch: Callable | None = None,
+    parallel: int = 0,
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """Review premises against their source material for factual accuracy.
@@ -2702,7 +2703,8 @@ def review_premises(
         review_ids.append(nid)
 
     results = _review(nodes, premise_ids=review_ids, source_contents=source_contents,
-                      model=model, timeout=timeout, on_batch=on_batch)
+                      model=model, timeout=timeout, on_batch=on_batch,
+                      parallel=parallel)
 
     now = datetime.now().isoformat(timespec="seconds")
 
@@ -2732,6 +2734,114 @@ def review_premises(
         "total_premises": total_premises,
         "skipped_no_source": skipped,
         "timestamp": now,
+    }
+
+
+def repair_premises(
+    review_file: str | None = None,
+    belief_ids: list[str] | None = None,
+    model: str = "claude",
+    timeout: int = 300,
+    dry_run: bool = False,
+    parallel: int = 0,
+    on_result: Callable | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Repair inaccurate premises by rewriting from source or retracting.
+
+    Takes review results (from review_file or by re-reviewing belief_ids)
+    and either rewrites premises to match source material or retracts them.
+
+    Returns: {"results": [...], "total_inaccurate": int, "rewritten": int,
+              "retracted": int, "failed": int}
+    """
+    import sys
+    from pathlib import Path
+
+    from .check_stale import resolve_source_path
+    from .repair_premises import repair_premises as _repair
+
+    if review_file:
+        import json as json_mod
+        data = json_mod.loads(Path(review_file).read_text())
+        review_results_list = data.get("results", [])
+    elif belief_ids:
+        review_result = review_premises(
+            belief_ids=belief_ids, model=model, timeout=timeout,
+            dry_run=True, db_path=db_path,
+        )
+        review_results_list = review_result.get("results", [])
+    else:
+        raise ValueError("Either review_file or belief_ids must be provided")
+
+    inaccurate = [r for r in review_results_list if not r.get("accurate", True)]
+    if not inaccurate:
+        return {"results": [], "total_inaccurate": 0, "rewritten": 0,
+                "retracted": 0, "failed": 0}
+
+    review_map = {r["id"]: r for r in inaccurate}
+
+    result = export_network(db_path=db_path)
+    nodes = result.get("nodes", {})
+    repos = result.get("repos", {})
+    repos = {k: Path(v) if isinstance(v, str) else v for k, v in repos.items()}
+    db_dir = Path(db_path).parent if db_path else None
+
+    source_contents = {}
+    repair_ids = []
+
+    for nid in sorted(review_map.keys()):
+        if nid not in nodes:
+            continue
+        source = nodes[nid].get("source", "")
+        if not source:
+            continue
+        if source not in source_contents:
+            agent = nodes[nid].get("metadata", {}).get("agent")
+            path = resolve_source_path(source, repos=repos, db_dir=db_dir, agent=agent)
+            if path and path.exists():
+                try:
+                    source_contents[source] = path.read_text()
+                except (OSError, UnicodeDecodeError):
+                    continue
+            else:
+                print(f"  SKIP {nid}: source not found: {source}", file=sys.stderr)
+                continue
+        repair_ids.append(nid)
+
+    results = _repair(nodes, premise_ids=repair_ids, source_contents=source_contents,
+                      review_results=review_map, model=model, timeout=timeout,
+                      parallel=parallel, on_result=on_result)
+
+    if not dry_run:
+        for r in results:
+            nid = r["id"]
+            action = r.get("action")
+            if action == "rewrite" and r.get("corrected_text"):
+                try:
+                    update_node(nid, text=r["corrected_text"], db_path=db_path)
+                except Exception as e:
+                    print(f"  ERROR updating {nid}: {e}", file=sys.stderr)
+                    r["action"] = "error"
+            elif action == "retract":
+                try:
+                    retract_node(nid,
+                                 reason=f"repair-premises: {r.get('rationale', 'inaccurate')}",
+                                 db_path=db_path)
+                except Exception as e:
+                    print(f"  ERROR retracting {nid}: {e}", file=sys.stderr)
+                    r["action"] = "error"
+
+    rewritten = sum(1 for r in results if r.get("action") == "rewrite")
+    retracted = sum(1 for r in results if r.get("action") == "retract")
+    failed = sum(1 for r in results if r.get("action") == "error")
+
+    return {
+        "results": results,
+        "total_inaccurate": len(inaccurate),
+        "rewritten": rewritten,
+        "retracted": retracted,
+        "failed": failed,
     }
 
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1641,6 +1641,7 @@ def cmd_review_premises(args):
         visible_to=_parse_visible_to(args),
         dry_run=args.dry_run,
         on_batch=on_batch,
+        parallel=getattr(args, "parallel", 0),
         db_path=args.db,
     )
 
@@ -1690,6 +1691,92 @@ def cmd_review_premises(args):
                 print(f"  RETRACTED {r['id']}")
             except Exception as e:
                 print(f"  ERROR retracting {r['id']}: {e}", file=sys.stderr)
+
+    cost = format_cost_summary()
+    if cost:
+        print(f"  {cost}", file=sys.stderr)
+
+
+def cmd_repair_premises(args):
+    _require_sqlite(args, "repair-premises")
+    import json
+    from datetime import datetime
+    from .llm import reset_cost_tracker, format_cost_summary
+    reset_cost_tracker()
+
+    model = getattr(args, "model", None) or "claude"
+    ts = datetime.now().isoformat(timespec="seconds")
+    write_report = not args.no_report
+
+    report_path = None
+    if write_report:
+        report_dir = Path(args.report_dir)
+        report_dir.mkdir(parents=True, exist_ok=True)
+        report_path = report_dir / f"repair-premises-{ts.replace(':', '')}.json"
+
+    review_file = getattr(args, "review_file", None)
+    belief_ids = args.ids or None
+
+    if not review_file and not belief_ids:
+        print("Error: provide premise IDs or --review-file", file=sys.stderr)
+        return
+
+    def _write_report(results, status):
+        if report_path is not None:
+            report = {
+                "timestamp": ts,
+                "status": status,
+                "model": model,
+                "dry_run": args.dry_run,
+                "results": results,
+            }
+            report_path.write_text(json.dumps(report, indent=2))
+
+    on_result = (lambda results: _write_report(results, "partial")) if write_report else None
+
+    result = api.repair_premises(
+        review_file=review_file,
+        belief_ids=belief_ids,
+        model=model,
+        timeout=args.timeout,
+        dry_run=args.dry_run,
+        parallel=getattr(args, "parallel", 0),
+        on_result=on_result,
+        db_path=args.db,
+    )
+
+    repairs = result["results"]
+    if not repairs:
+        print("No inaccurate premises to repair.")
+        cost = format_cost_summary()
+        if cost:
+            print(f"  {cost}", file=sys.stderr)
+        return
+
+    for r in repairs:
+        action = r.get("action", "error")
+        if action == "rewrite":
+            label = "REWRITE"
+        elif action == "retract":
+            label = "RETRACT"
+        else:
+            label = "ERROR"
+        print(f"  [{label}] {r['id']}")
+        if r.get("rationale"):
+            print(f"    {r['rationale']}")
+        if action == "rewrite" and r.get("corrected_text"):
+            text = r["corrected_text"][:100]
+            if len(r["corrected_text"]) > 100:
+                text += "..."
+            print(f"    -> {text}")
+
+    print(f"\nRepaired {len(repairs)} of {result['total_inaccurate']} inaccurate premises")
+    print(f"  Rewritten: {result['rewritten']}  Retracted: {result['retracted']}"
+          f"  Failed: {result['failed']}")
+
+    if report_path is not None:
+        _write_report(repairs, "complete")
+        print(f"  Report: {report_path}")
 
     cost = format_cost_summary()
     if cost:
@@ -2418,6 +2505,26 @@ def main():
                    help="Directory for JSON reports (default: reviews/)")
     p.add_argument("--no-report", action="store_true",
                    help="Skip JSON report generation")
+    p.add_argument("--parallel", type=int, default=0, metavar="N",
+                   help="Number of concurrent workers (0 = sequential)")
+
+    # repair-premises
+    p = sub.add_parser("repair-premises", help="Repair inaccurate premises by rewriting from source or retracting")
+    p.add_argument("ids", nargs="*", help="Premise IDs to repair (requires --review-file or re-reviews these IDs)")
+    p.add_argument("--review-file", default=None,
+                   help="Path to review-premises JSON report")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
+    p.add_argument("--timeout", type=int, default=600,
+                   help="LLM timeout in seconds (default: 600)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report findings without applying changes")
+    p.add_argument("--parallel", type=int, default=0, metavar="N",
+                   help="Number of concurrent workers (0 = sequential)")
+    p.add_argument("--report-dir", default="reviews",
+                   help="Directory for JSON reports (default: reviews/)")
+    p.add_argument("--no-report", action="store_true",
+                   help="Skip JSON report generation")
 
     # propose-update
     p = sub.add_parser("propose-update",
@@ -2569,6 +2676,7 @@ def main():
         "topics": cmd_topics,
         "review-beliefs": cmd_review_beliefs,
         "review-premises": cmd_review_premises,
+        "repair-premises": cmd_repair_premises,
         "propose-update": cmd_propose_update,
         "repair-smuggled": cmd_repair_smuggled,
         "research": cmd_research,

--- a/reasons_lib/repair_premises.py
+++ b/reasons_lib/repair_premises.py
@@ -1,0 +1,175 @@
+"""Repair inaccurate premises by rewriting from source or retracting.
+
+Takes premises flagged by review-premises and either rewrites them to
+accurately reflect the source material, or retracts them if the source
+doesn't support any version of the claim.
+"""
+
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from .llm import invoke_model
+
+REPAIR_PREMISES_PROMPT = """\
+You are repairing inaccurate premises in a Truth Maintenance System (TMS).
+Each premise below was flagged as inaccurate by a prior review step.
+For each premise, the source document and the review comment explaining
+the error are provided.
+
+For each premise, decide:
+- **rewrite**: if the source supports a corrected version of the claim,
+  produce the corrected text that accurately reflects the source.
+- **retract**: if the source does not support any version of the claim,
+  mark it for retraction.
+
+Return ONLY a JSON array. For each premise, one object:
+
+```json
+[
+  {{
+    "id": "premise-id",
+    "action": "rewrite",
+    "corrected_text": "The corrected claim that matches the source.",
+    "rationale": "Brief explanation of what was wrong and how it was fixed."
+  }}
+]
+```
+
+Rules:
+- Return one object per premise, in the same order as presented.
+- "action" must be either "rewrite" or "retract".
+- If action is "rewrite", "corrected_text" must be a complete replacement
+  for the original claim. Keep the same scope and style.
+- If action is "retract", "corrected_text" should be null or omitted.
+- "rationale" should be a single sentence.
+- Only use information from the source document. Do not add external knowledge.
+
+## Premises to repair
+
+{premises}"""
+
+
+def format_premise_for_repair(node_id, nodes, source_content, review_result):
+    """Format one premise with source text and review comment for repair."""
+    node = nodes.get(node_id)
+    if not node:
+        return ""
+
+    lines = [f"### {node_id}"]
+    lines.append(f"Original claim: {node.get('text', '')}")
+
+    error_type = review_result.get("error_type", "inaccurate")
+    comment = review_result.get("comment", "")
+    lines.append(f"Error type: {error_type}")
+    if comment:
+        lines.append(f"Review comment: {comment}")
+
+    source = node.get("source", "")
+    if source:
+        lines.append(f"Source reference: {source}")
+
+    lines.append("")
+    lines.append("Source document content:")
+    lines.append("```")
+    lines.append(source_content)
+    lines.append("```")
+
+    return "\n".join(lines)
+
+
+def parse_repair_response(response):
+    """Extract repair results JSON array from LLM response."""
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(response):
+        if ch != "[":
+            continue
+        try:
+            items, _ = decoder.raw_decode(response, i)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(items, list):
+            continue
+        results = []
+        for item in items:
+            if not isinstance(item, dict) or "id" not in item:
+                continue
+            results.append({
+                "id": item["id"],
+                "action": item.get("action", "retract"),
+                "corrected_text": item.get("corrected_text"),
+                "rationale": item.get("rationale", ""),
+            })
+        if results:
+            return results
+    return []
+
+
+def _repair_one(node_id, nodes, source_contents, review_results, model, timeout):
+    """Repair a single premise. Returns a result dict."""
+    review = review_results.get(node_id, {})
+    source = nodes[node_id].get("source", "")
+    source_text = source_contents.get(source, "(source not available)")
+
+    prompt_text = format_premise_for_repair(node_id, nodes, source_text, review)
+    prompt = REPAIR_PREMISES_PROMPT.format(premises=prompt_text)
+
+    try:
+        response = invoke_model(prompt, model=model, timeout=timeout)
+        parsed = parse_repair_response(response)
+        if parsed:
+            return parsed[0]
+        return {"id": node_id, "action": "retract", "corrected_text": None,
+                "rationale": "Could not parse repair response"}
+    except Exception as e:
+        return {"id": node_id, "action": "error", "corrected_text": None,
+                "rationale": str(e)}
+
+
+def repair_premises(nodes, premise_ids, source_contents, review_results,
+                    model="claude", timeout=300, parallel=0, on_result=None):
+    """Repair inaccurate premises by rewriting or retracting.
+
+    Args:
+        nodes: Dict of node_id -> node data from export_network().
+        premise_ids: List of premise IDs to repair.
+        source_contents: Dict of source_path -> file content string.
+        review_results: Dict of node_id -> review result dict.
+        model: LLM model to use.
+        timeout: LLM timeout in seconds.
+        parallel: Number of concurrent workers (0 = sequential).
+        on_result: Callback(all_results) after each result.
+
+    Returns: list of repair result dicts.
+    """
+    if not premise_ids:
+        return []
+
+    all_results = []
+
+    if parallel > 0:
+        with ThreadPoolExecutor(max_workers=parallel) as executor:
+            futures = {
+                executor.submit(
+                    _repair_one, pid, nodes, source_contents,
+                    review_results, model, timeout
+                ): pid
+                for pid in premise_ids
+            }
+            for i, future in enumerate(as_completed(futures), 1):
+                pid = futures[future]
+                print(f"  Repaired {i}/{len(premise_ids)}: {pid}", file=sys.stderr)
+                result = future.result()
+                all_results.append(result)
+                if on_result is not None:
+                    on_result(all_results)
+    else:
+        for i, pid in enumerate(premise_ids, 1):
+            print(f"  Repairing {i}/{len(premise_ids)}: {pid}...", file=sys.stderr)
+            result = _repair_one(pid, nodes, source_contents,
+                                 review_results, model, timeout)
+            all_results.append(result)
+            if on_result is not None:
+                on_result(all_results)
+
+    return all_results

--- a/reasons_lib/review_premises.py
+++ b/reasons_lib/review_premises.py
@@ -111,8 +111,23 @@ def parse_premise_review_response(response):
     return []
 
 
+def _process_batch(batch, nodes, source_contents, model, timeout):
+    """Process a single review batch. Returns (batch_results, error_or_None)."""
+    premises_text = "\n\n".join(
+        format_premise_for_review(
+            pid, nodes,
+            source_contents.get(nodes[pid].get("source", ""), "(source not available)")
+        )
+        for pid in batch
+    )
+    prompt = REVIEW_PREMISES_PROMPT.format(premises=premises_text)
+    response = invoke_model(prompt, model=model, timeout=timeout)
+    return parse_premise_review_response(response)
+
+
 def review_premises(nodes, premise_ids, source_contents, model="claude",
-                    timeout=300, batch_size=REVIEW_BATCH_SIZE, on_batch=None):
+                    timeout=300, batch_size=REVIEW_BATCH_SIZE, on_batch=None,
+                    parallel=0):
     """Review premises against their source material.
 
     Args:
@@ -123,6 +138,7 @@ def review_premises(nodes, premise_ids, source_contents, model="claude",
         timeout: LLM timeout in seconds.
         batch_size: Number of premises per LLM call.
         on_batch: Callback(all_results) after each batch.
+        parallel: Number of concurrent workers (0 = sequential).
 
     Returns: list of review result dicts.
     """
@@ -144,31 +160,43 @@ def review_premises(nodes, premise_ids, source_contents, model="claude",
     for src_pids in by_source.values():
         ordered_ids.extend(src_pids)
 
-    all_results = []
-    total_batches = (len(ordered_ids) + batch_size - 1) // batch_size
-
+    batches = []
     for i in range(0, len(ordered_ids), batch_size):
-        batch = ordered_ids[i:i + batch_size]
-        batch_num = i // batch_size + 1
-        print(f"  Reviewing batch {batch_num}/{total_batches} "
-              f"({len(batch)} premises)...", file=sys.stderr)
+        batches.append(ordered_ids[i:i + batch_size])
 
-        premises_text = "\n\n".join(
-            format_premise_for_review(
-                pid, nodes,
-                source_contents.get(nodes[pid].get("source", ""), "(source not available)")
-            )
-            for pid in batch
-        )
-        prompt = REVIEW_PREMISES_PROMPT.format(premises=premises_text)
+    all_results = []
+    total_batches = len(batches)
 
-        try:
-            response = invoke_model(prompt, model=model, timeout=timeout)
-            results = parse_premise_review_response(response)
-            all_results.extend(results)
-            if on_batch is not None:
-                on_batch(all_results)
-        except Exception as e:
-            print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
+    if parallel > 0:
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        with ThreadPoolExecutor(max_workers=parallel) as executor:
+            futures = {
+                executor.submit(
+                    _process_batch, batch, nodes, source_contents, model, timeout
+                ): batch_num
+                for batch_num, batch in enumerate(batches, 1)
+            }
+            for future in as_completed(futures):
+                batch_num = futures[future]
+                try:
+                    results = future.result()
+                    all_results.extend(results)
+                    print(f"  Batch {batch_num}/{total_batches} complete "
+                          f"({len(results)} results)", file=sys.stderr)
+                    if on_batch is not None:
+                        on_batch(all_results)
+                except Exception as e:
+                    print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
+    else:
+        for batch_num, batch in enumerate(batches, 1):
+            print(f"  Reviewing batch {batch_num}/{total_batches} "
+                  f"({len(batch)} premises)...", file=sys.stderr)
+            try:
+                results = _process_batch(batch, nodes, source_contents, model, timeout)
+                all_results.extend(results)
+                if on_batch is not None:
+                    on_batch(all_results)
+            except Exception as e:
+                print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
 
     return all_results

--- a/tests/test_repair_premises.py
+++ b/tests/test_repair_premises.py
@@ -1,0 +1,320 @@
+"""Tests for repair-premises command and supporting functions."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib.repair_premises import (
+    format_premise_for_repair,
+    parse_repair_response,
+    repair_premises,
+)
+
+
+class TestFormatPremiseForRepair:
+
+    def test_basic_formatting(self):
+        nodes = {
+            "obs-1": {
+                "text": "Redis is used for session storage",
+                "source": "docs/arch.md",
+            }
+        }
+        review = {"error_type": "misread_source", "comment": "Source says PostgreSQL, not Redis"}
+        result = format_premise_for_repair("obs-1", nodes, "Full source text here.", review)
+        assert "### obs-1" in result
+        assert "Redis is used for session storage" in result
+        assert "misread_source" in result
+        assert "Source says PostgreSQL" in result
+        assert "Full source text here." in result
+
+    def test_missing_node(self):
+        assert format_premise_for_repair("missing", {}, "content", {}) == ""
+
+    def test_no_review_comment(self):
+        nodes = {"obs-1": {"text": "A claim", "source": "doc.md"}}
+        result = format_premise_for_repair("obs-1", nodes, "src", {"error_type": "fabricated"})
+        assert "fabricated" in result
+        assert "Review comment:" not in result
+
+
+class TestParseRepairResponse:
+
+    def test_rewrite_action(self):
+        response = json.dumps([{
+            "id": "obs-1",
+            "action": "rewrite",
+            "corrected_text": "PostgreSQL is used for session storage",
+            "rationale": "Source says PostgreSQL, not Redis",
+        }])
+        results = parse_repair_response(response)
+        assert len(results) == 1
+        assert results[0]["action"] == "rewrite"
+        assert results[0]["corrected_text"] == "PostgreSQL is used for session storage"
+
+    def test_retract_action(self):
+        response = json.dumps([{
+            "id": "obs-1",
+            "action": "retract",
+            "corrected_text": None,
+            "rationale": "Source does not mention this at all",
+        }])
+        results = parse_repair_response(response)
+        assert len(results) == 1
+        assert results[0]["action"] == "retract"
+        assert results[0]["corrected_text"] is None
+
+    def test_json_with_prose(self):
+        response = "Here is my analysis:\n" + json.dumps([{
+            "id": "obs-1", "action": "rewrite",
+            "corrected_text": "Fixed claim", "rationale": "fixed",
+        }]) + "\nDone."
+        results = parse_repair_response(response)
+        assert len(results) == 1
+
+    def test_malformed_json(self):
+        assert parse_repair_response("not json") == []
+
+    def test_defaults(self):
+        response = json.dumps([{"id": "obs-1"}])
+        results = parse_repair_response(response)
+        assert results[0]["action"] == "retract"
+        assert results[0]["corrected_text"] is None
+        assert results[0]["rationale"] == ""
+
+
+class TestRepairPremisesLoop:
+
+    def _mock_result(self, response_text):
+        return type("R", (), {"returncode": 0, "stdout": response_text, "stderr": ""})()
+
+    def test_sequential_repair(self):
+        nodes = {"obs-1": {"text": "Wrong claim", "source": "doc.md", "truth_value": "IN"}}
+        source_contents = {"doc.md": "Correct information here."}
+        review_results = {"obs-1": {"error_type": "misread_source", "comment": "wrong"}}
+
+        llm_resp = json.dumps([{
+            "id": "obs-1", "action": "rewrite",
+            "corrected_text": "Correct claim", "rationale": "fixed",
+        }])
+        mock = self._mock_result(llm_resp)
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock):
+            results = repair_premises(nodes, ["obs-1"], source_contents, review_results)
+        assert len(results) == 1
+        assert results[0]["action"] == "rewrite"
+
+    def test_parallel_repair(self):
+        nodes = {
+            "obs-1": {"text": "Wrong A", "source": "a.md", "truth_value": "IN"},
+            "obs-2": {"text": "Wrong B", "source": "b.md", "truth_value": "IN"},
+        }
+        source_contents = {"a.md": "Correct A.", "b.md": "Correct B."}
+        review_results = {
+            "obs-1": {"error_type": "misread_source", "comment": "wrong A"},
+            "obs-2": {"error_type": "fabricated", "comment": "made up B"},
+        }
+
+        def mock_run(*args, **kwargs):
+            prompt = kwargs.get("input", "")
+            if "obs-1" in prompt:
+                resp = json.dumps([{"id": "obs-1", "action": "rewrite",
+                                    "corrected_text": "Fixed A", "rationale": "ok"}])
+            else:
+                resp = json.dumps([{"id": "obs-2", "action": "retract",
+                                    "corrected_text": None, "rationale": "no support"}])
+            return type("R", (), {"returncode": 0, "stdout": resp, "stderr": ""})()
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=mock_run):
+            results = repair_premises(nodes, ["obs-1", "obs-2"], source_contents,
+                                     review_results, parallel=2)
+        assert len(results) == 2
+        actions = {r["id"]: r["action"] for r in results}
+        assert actions["obs-1"] == "rewrite"
+        assert actions["obs-2"] == "retract"
+
+    def test_empty_ids(self):
+        assert repair_premises({}, [], {}, {}) == []
+
+    def test_on_result_callback(self):
+        nodes = {"obs-1": {"text": "Claim", "source": "doc.md", "truth_value": "IN"}}
+        source_contents = {"doc.md": "Content."}
+        review_results = {"obs-1": {"error_type": "fabricated", "comment": "made up"}}
+
+        llm_resp = json.dumps([{"id": "obs-1", "action": "retract",
+                                "corrected_text": None, "rationale": "gone"}])
+        mock = self._mock_result(llm_resp)
+        callbacks = []
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock):
+            repair_premises(nodes, ["obs-1"], source_contents, review_results,
+                           on_result=lambda r: callbacks.append(len(r)))
+        assert callbacks == [1]
+
+    def test_llm_failure_returns_error(self):
+        nodes = {"obs-1": {"text": "Claim", "source": "doc.md", "truth_value": "IN"}}
+        source_contents = {"doc.md": "Content."}
+        review_results = {"obs-1": {"error_type": "fabricated", "comment": "bad"}}
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=Exception("LLM down")):
+            results = repair_premises(nodes, ["obs-1"], source_contents, review_results)
+        assert len(results) == 1
+        assert results[0]["action"] == "error"
+
+
+class TestApiRepairPremises:
+
+    @pytest.fixture
+    def db_with_reviewed(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "entry.md"
+        source_file.write_text("The system uses PostgreSQL for storage.")
+
+        api.init_db(db_path=db)
+        api.add_node("obs-1", "Redis is used for storage",
+                     source=str(source_file), db_path=db)
+        api.add_node("obs-2", "Memcached handles caching",
+                     source=str(source_file), db_path=db)
+
+        review_report = {
+            "results": [
+                {"id": "obs-1", "accurate": False, "well_scoped": True,
+                 "error_type": "misread_source", "comment": "Source says PostgreSQL"},
+                {"id": "obs-2", "accurate": False, "well_scoped": True,
+                 "error_type": "fabricated", "comment": "Source never mentions caching"},
+            ]
+        }
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps(review_report))
+        return db, str(review_file)
+
+    def test_repair_from_review_file(self, db_with_reviewed):
+        db, review_file = db_with_reviewed
+        llm_resp = json.dumps([
+            {"id": "obs-1", "action": "rewrite",
+             "corrected_text": "PostgreSQL is used for storage", "rationale": "fixed"},
+        ])
+        mock = type("R", (), {"returncode": 0, "stdout": llm_resp, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock):
+            result = api.repair_premises(review_file=review_file, dry_run=True, db_path=db)
+        assert result["total_inaccurate"] == 2
+
+    def test_rewrite_updates_node(self, db_with_reviewed):
+        db, review_file = db_with_reviewed
+
+        def mock_run(*args, **kwargs):
+            prompt = kwargs.get("input", "")
+            if "obs-1" in prompt:
+                resp = json.dumps([{"id": "obs-1", "action": "rewrite",
+                                    "corrected_text": "PostgreSQL is used", "rationale": "ok"}])
+            else:
+                resp = json.dumps([{"id": "obs-2", "action": "retract",
+                                    "corrected_text": None, "rationale": "no support"}])
+            return type("R", (), {"returncode": 0, "stdout": resp, "stderr": ""})()
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=mock_run):
+            result = api.repair_premises(review_file=review_file, db_path=db)
+
+        assert result["rewritten"] >= 1
+        net = api.export_network(db_path=db)
+        if "obs-1" in net["nodes"]:
+            assert net["nodes"]["obs-1"]["text"] == "PostgreSQL is used"
+
+    def test_retract_removes_node(self, db_with_reviewed):
+        db, review_file = db_with_reviewed
+
+        def mock_run(*args, **kwargs):
+            prompt = kwargs.get("input", "")
+            if "obs-2" in prompt:
+                resp = json.dumps([{"id": "obs-2", "action": "retract",
+                                    "corrected_text": None, "rationale": "unsupported"}])
+            else:
+                resp = json.dumps([{"id": "obs-1", "action": "rewrite",
+                                    "corrected_text": "Fixed", "rationale": "ok"}])
+            return type("R", (), {"returncode": 0, "stdout": resp, "stderr": ""})()
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=mock_run):
+            result = api.repair_premises(review_file=review_file, db_path=db)
+
+        assert result["retracted"] >= 1
+        net = api.export_network(db_path=db)
+        if "obs-2" in net["nodes"]:
+            assert net["nodes"]["obs-2"]["truth_value"] == "OUT"
+
+    def test_dry_run_no_changes(self, db_with_reviewed):
+        db, review_file = db_with_reviewed
+        llm_resp = json.dumps([
+            {"id": "obs-1", "action": "rewrite",
+             "corrected_text": "Fixed", "rationale": "ok"},
+        ])
+        mock = type("R", (), {"returncode": 0, "stdout": llm_resp, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock):
+            api.repair_premises(review_file=review_file, dry_run=True, db_path=db)
+
+        net = api.export_network(db_path=db)
+        assert net["nodes"]["obs-1"]["text"] == "Redis is used for storage"
+
+    def test_no_args_raises(self):
+        with pytest.raises(ValueError, match="Either review_file or belief_ids"):
+            api.repair_premises()
+
+    def test_no_inaccurate_returns_empty(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+        review_report = {"results": [
+            {"id": "obs-1", "accurate": True, "well_scoped": True,
+             "error_type": None, "comment": "ok"},
+        ]}
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps(review_report))
+        result = api.repair_premises(review_file=str(review_file), db_path=db)
+        assert result["total_inaccurate"] == 0
+        assert result["results"] == []
+
+
+class TestCliDispatch:
+
+    def test_repair_premises_registered(self):
+        from reasons_lib import cli
+        assert hasattr(cli, "cmd_repair_premises")
+        assert callable(cli.cmd_repair_premises)
+
+
+class TestReviewPremisesParallel:
+
+    def test_parallel_batches(self, tmp_path):
+        """Verify parallel=2 processes batches concurrently."""
+        from reasons_lib.review_premises import review_premises
+
+        nodes = {
+            f"obs-{i}": {"text": f"Claim {i}", "source": "doc.md", "truth_value": "IN"}
+            for i in range(10)
+        }
+        source_contents = {"doc.md": "Source content."}
+
+        def mock_run(*args, **kwargs):
+            prompt = kwargs.get("input", "")
+            results = []
+            for i in range(10):
+                if f"obs-{i}" in prompt:
+                    results.append({
+                        "id": f"obs-{i}", "accurate": True,
+                        "well_scoped": True, "error_type": None, "comment": "ok",
+                    })
+            resp = json.dumps(results)
+            return type("R", (), {"returncode": 0, "stdout": resp, "stderr": ""})()
+
+        premise_ids = [f"obs-{i}" for i in range(10)]
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", side_effect=mock_run):
+            results = review_premises(nodes, premise_ids, source_contents,
+                                      parallel=2, batch_size=5)
+        assert len(results) == 10


### PR DESCRIPTION
## Summary
- New `reasons repair-premises` command: takes review results and either rewrites inaccurate premises from source material or retracts unsupported claims
- `--parallel N` added to both `review-premises` and `repair-premises` for concurrent LLM calls via ThreadPoolExecutor
- Repair uses `--review-file` (JSON from review-premises) or re-reviews specific `belief_ids` inline
- Follows same patterns as existing review/repair pipeline: JSON reports, `--dry-run`, cost tracking

## Usage
```bash
# Review then repair pipeline
reasons review-premises --sample 50 --parallel 3
reasons repair-premises --review-file reviews/review-premises-*.json --parallel 3

# Direct repair by IDs
reasons repair-premises obs-1 obs-2 --dry-run

# Parallel review
reasons review-premises --parallel 4
```

## Test plan
- [x] 21 tests for repair-premises (module, API, CLI, parallel)
- [x] 21 tests for review-premises (existing + parallel batch test)
- [x] Full suite: 1382 passed, 0 failed

Closes #190