### PR TITLE
Rename reasons research to reasons repair (#188)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2990,7 +2990,7 @@ def repair_smuggled(
     }
 
 
-def research(
+def repair(
     review_file: str | None = None,
     belief_ids: list[str] | None = None,
     model: str = "claude",
@@ -3054,6 +3054,9 @@ def research(
                         "soften_failed", "extraction_failed")),
         "errors": sum(1 for r in results if r["status"] == "error"),
     }
+
+
+research = repair
 
 
 def detect_contradictions(

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2998,11 +2998,11 @@ def repair(
     dry_run: bool = False,
     db_path: str = DEFAULT_DB,
 ) -> dict:
-    """Research flagged beliefs: triage into search-and-link, soften, or abandon.
+    """Repair flagged beliefs: triage into search-and-link, soften, or abandon.
 
     Two input modes:
         review_file: path to a review-beliefs JSON report
-        belief_ids: re-review these beliefs inline, then research invalids
+        belief_ids: re-review these beliefs inline, then repair invalids
 
     Returns dict with results list and summary counts.
     """

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -3006,7 +3006,7 @@ def repair(
 
     Returns dict with results list and summary counts.
     """
-    from .repair import research_beliefs
+    from .repair import repair_beliefs
 
     if review_file:
         import json as _json
@@ -3038,7 +3038,7 @@ def repair(
     net = export_network(db_path=db_path)
     nodes = net.get("nodes", {})
 
-    results = research_beliefs(
+    results = repair_beliefs(
         invalid, nodes, model=model, timeout=timeout,
         db_path=db_path, dry_run=dry_run,
     )

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1915,8 +1915,8 @@ def cmd_repair_smuggled(args):
         print("\n  (dry run -- no changes applied)")
 
 
-def cmd_research(args):
-    _require_sqlite(args, "research")
+def cmd_repair(args):
+    _require_sqlite(args, "repair")
     from .llm import reset_cost_tracker, format_cost_summary
     reset_cost_tracker()
 
@@ -1928,7 +1928,7 @@ def cmd_research(args):
         print("Error: provide either --review-file or belief IDs", file=sys.stderr)
         sys.exit(1)
 
-    result = api.research(
+    result = api.repair(
         review_file=review_file,
         belief_ids=belief_ids,
         model=model,
@@ -2562,10 +2562,22 @@ def main():
     p.add_argument("--dry-run", action="store_true",
                    help="Report findings without applying repairs")
 
-    # research
-    p = sub.add_parser("research",
-        help="Research flagged beliefs: search-and-link, soften, or abandon")
-    p.add_argument("ids", nargs="*", help="Belief IDs to research")
+    # repair (formerly research)
+    p = sub.add_parser("repair",
+        help="Repair flagged beliefs: search-and-link, soften, or abandon")
+    p.add_argument("ids", nargs="*", help="Belief IDs to repair")
+    p.add_argument("--review-file", default=None,
+                   help="Path to review-beliefs JSON report")
+    p.add_argument("-m", "--model", default=None,
+                   help="Model to use (default: claude)")
+    p.add_argument("--timeout", type=int, default=600,
+                   help="LLM timeout in seconds (default: 600)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Report findings without applying changes")
+
+    # research (backward-compatible alias for repair)
+    p = sub.add_parser("research", help="Alias for 'repair' (deprecated)")
+    p.add_argument("ids", nargs="*", help="Belief IDs to repair")
     p.add_argument("--review-file", default=None,
                    help="Path to review-beliefs JSON report")
     p.add_argument("-m", "--model", default=None,
@@ -2679,7 +2691,8 @@ def main():
         "repair-premises": cmd_repair_premises,
         "propose-update": cmd_propose_update,
         "repair-smuggled": cmd_repair_smuggled,
-        "research": cmd_research,
+        "repair": cmd_repair,
+        "research": cmd_repair,
         "contradictions": cmd_contradictions,
         "namespaces": cmd_namespaces,
     }

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -6,7 +6,7 @@ Three patterns for resolving beliefs flagged invalid by review-beliefs:
 2. Soften — belief overstates the evidence; weaken text to match antecedents
 3. Abandon — dependency tree too broken to repair; retract
 
-The `research_beliefs` orchestrator triages each invalid belief via LLM,
+The `repair_beliefs` orchestrator triages each invalid belief via LLM,
 then executes the appropriate pattern.
 """
 
@@ -351,7 +351,7 @@ def _do_search_and_link(belief_id, node, nodes, comment, model, timeout,
     return "linked", claim, matched_ids, match.get("rationale", "")
 
 
-def research_beliefs(review_results, nodes, model="claude",
+def repair_beliefs(review_results, nodes, model="claude",
                      timeout=300, db_path=None, dry_run=False,
                      search_fn=None):
     """Orchestrate triage and repair for invalid beliefs.
@@ -465,6 +465,9 @@ def research_beliefs(review_results, nodes, model="claude",
         results.append(result)
 
     return results
+
+
+research_beliefs = repair_beliefs
 
 
 def repair_smuggled_beliefs(review_results, nodes, model="claude",

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -344,7 +344,7 @@ def _do_search_and_link(belief_id, node, nodes, comment, model, timeout,
             belief_id,
             sl=",".join(new_ants),
             unless=",".join(original_outlist) if original_outlist else "",
-            label=f"research: linked {claim[:50]}",
+            label=f"repair: linked {claim[:50]}",
             db_path=db_path,
         )
 
@@ -359,7 +359,7 @@ def research_beliefs(review_results, nodes, model="claude",
     Triages each invalid belief into search_and_link, soften, or abandon,
     then executes the appropriate pattern.
 
-    Returns list of research result dicts.
+    Returns list of repair result dicts.
     """
     from . import api
 
@@ -454,7 +454,7 @@ def research_beliefs(review_results, nodes, model="claude",
                 if not dry_run:
                     api.retract_node(
                         belief_id,
-                        reason=f"research: abandoned — {triage.get('rationale', '')}",
+                        reason=f"repair: abandoned — {triage.get('rationale', '')}",
                         db_path=db_path,
                     )
                 result["status"] = "abandoned"

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -12,6 +12,7 @@ from reasons_lib.repair import (
     parse_soften_response,
     triage_belief,
     soften_belief,
+    repair_beliefs,
     research_beliefs,
     _compute_depth,
 )
@@ -192,7 +193,7 @@ class TestSoftenBelief:
         assert result["softened_text"] == "weaker"
 
 
-# --- research_beliefs ---
+# --- repair_beliefs ---
 
 class TestResearchBeliefs:
     def test_search_and_link(self):
@@ -215,7 +216,7 @@ class TestResearchBeliefs:
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp, extract_resp, match_resp]), \
              patch("reasons_lib.api.add_justification"):
-            results = research_beliefs(
+            results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search(search_results),
             )
@@ -239,7 +240,7 @@ class TestResearchBeliefs:
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp, soften_resp]), \
              patch("reasons_lib.api.update_node") as mock_update:
-            results = research_beliefs(
+            results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),
             )
@@ -262,7 +263,7 @@ class TestResearchBeliefs:
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp]), \
              patch("reasons_lib.api.retract_node") as mock_retract:
-            results = research_beliefs(
+            results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),
             )
@@ -282,7 +283,7 @@ class TestResearchBeliefs:
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp]):
-            results = research_beliefs(
+            results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),
             )
@@ -300,7 +301,7 @@ class TestResearchBeliefs:
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp, soften_resp]):
-            results = research_beliefs(
+            results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),
             )
@@ -323,7 +324,7 @@ class TestResearchBeliefs:
              patch("reasons_lib.api.update_node") as mock_update, \
              patch("reasons_lib.api.retract_node") as mock_retract, \
              patch("reasons_lib.api.add_justification") as mock_add:
-            results = research_beliefs(
+            results = repair_beliefs(
                 review_results, nodes, db_path="test.db", dry_run=True,
                 search_fn=_mock_search([]),
             )
@@ -361,7 +362,7 @@ class TestResearchBeliefs:
                    side_effect=[triage1, soften1, triage2]), \
              patch("reasons_lib.api.update_node"), \
              patch("reasons_lib.api.retract_node"):
-            results = research_beliefs(
+            results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),
             )
@@ -376,7 +377,7 @@ class TestResearchBeliefs:
             "id": "nonexistent", "valid": False, "comment": "x",
         }]
 
-        results = research_beliefs(
+        results = repair_beliefs(
             review_results, nodes, db_path="test.db",
             search_fn=_mock_search([]),
         )
@@ -396,7 +397,7 @@ class TestResearchBeliefs:
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp, extract_resp]):
-            results = research_beliefs(
+            results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),
             )
@@ -410,7 +411,7 @@ class TestResearchBeliefs:
             {"id": "derived-boil", "valid": True, "comment": "fine"},
         ]
 
-        results = research_beliefs(
+        results = repair_beliefs(
             review_results, nodes, db_path="test.db",
             search_fn=_mock_search([]),
         )
@@ -580,3 +581,49 @@ class TestCmdResearch:
 
         node = api.show_node("derived-a", db_path=db)
         assert node["truth_value"] == "IN"
+
+
+class TestBackwardCompatAlias:
+    def test_research_beliefs_alias(self):
+        assert research_beliefs is repair_beliefs
+
+    def test_api_research_alias(self):
+        assert api.research is api.repair
+
+
+class TestCmdRepair:
+    def test_help(self):
+        stdout, stderr, code = run_cli("repair", "--help")
+        assert code == 0
+        assert "repair" in stdout.lower()
+
+    def test_from_review_file(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("premise-a", "A is true", db_path=db)
+        api.add_node("derived-a", "A extended", sl="premise-a", db_path=db)
+
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps({
+            "results": [{
+                "id": "derived-a",
+                "valid": False,
+                "comment": "overstated",
+            }],
+        }))
+
+        triage_resp = _mock_result('{"pattern": "soften", "rationale": "x"}')
+        soften_resp = _mock_result(
+            '{"softened_text": "A weakly extended", "rationale": "weakened"}'
+        )
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp, soften_resp]):
+            stdout, stderr, code = run_cli(
+                "repair",
+                "--review-file", str(review_file),
+                db_path=db,
+            )
+
+        assert code == 0
+        assert "SOFTENED" in stdout


### PR DESCRIPTION
## Summary
- Renames the `research` command to `repair` throughout: function definition (`cmd_repair`), API function (`api.repair()`), subparser, and dispatch table
- Keeps `research` as a backward-compatible deprecated alias at both the CLI and API layers
- All 1382 tests pass, including existing `test_research.py` which exercises the alias path

## Test plan
- [x] `uv run pytest tests/test_research.py -v` — 34/34 pass (uses `api.research()` alias)
- [x] `uv run pytest tests/ -x` — 1382 passed, 166 skipped
- [ ] Verify `reasons repair --help` shows the new command
- [ ] Verify `reasons research --help` still works as alias

Closes #188

Generated with [Claude Code](https://claude.com/claude-code)