### PR TITLE
Add local stdio MCP server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ llm = ["langchain-anthropic>=0.3", "langchain-google-vertexai>=2.0", "langfuse>=
 
 [project.scripts]
 reasons = "reasons_lib.cli:main"
+reasons-mcp = "reasons_lib.mcp_server:main"
 
 [tool.setuptools]
 packages = ["reasons_lib"]

--- a/reasons_lib/mcp_server.py
+++ b/reasons_lib/mcp_server.py
@@ -121,8 +121,11 @@ def add(node_id: str, text: str, sl: str = "", unless: str = "", label: str = ""
         unless: Comma-separated outlist node IDs (must be OUT for justification to hold)
         label: Optional justification label
     """
-    result = api.add_node(node_id, text, sl=sl, unless=unless, label=label, db_path=_get_db())
-    return json.dumps(result, indent=2)
+    try:
+        result = api.add_node(node_id, text, sl=sl, unless=unless, label=label, db_path=_get_db())
+        return json.dumps(result, indent=2)
+    except (ValueError, KeyError) as e:
+        return json.dumps({"error": str(e)})
 
 
 @mcp.tool()
@@ -159,11 +162,14 @@ def what_if(node_id: str, action: str = "retract") -> str:
         node_id: The belief to simulate
         action: "retract" or "assert"
     """
-    if action == "assert":
-        result = api.what_if_assert(node_id, db_path=_get_db())
-    else:
-        result = api.what_if_retract(node_id, db_path=_get_db())
-    return json.dumps(result, indent=2)
+    try:
+        if action == "assert":
+            result = api.what_if_assert(node_id, db_path=_get_db())
+        else:
+            result = api.what_if_retract(node_id, db_path=_get_db())
+        return json.dumps(result, indent=2)
+    except KeyError:
+        return json.dumps({"error": f"Node '{node_id}' not found"})
 
 
 @mcp.tool()
@@ -178,8 +184,11 @@ def add_justification(node_id: str, sl: str = "", unless: str = "", label: str =
         unless: Comma-separated outlist node IDs
         label: Optional justification label
     """
-    result = api.add_justification(node_id, sl=sl, unless=unless, label=label, db_path=_get_db())
-    return json.dumps(result, indent=2)
+    try:
+        result = api.add_justification(node_id, sl=sl, unless=unless, label=label, db_path=_get_db())
+        return json.dumps(result, indent=2)
+    except (ValueError, KeyError) as e:
+        return json.dumps({"error": str(e)})
 
 
 @mcp.tool()

--- a/reasons_lib/mcp_server.py
+++ b/reasons_lib/mcp_server.py
@@ -1,0 +1,238 @@
+"""MCP server for ftl-reasons — exposes belief network tools over stdio.
+
+Usage:
+    reasons-mcp                              # auto-discover reasons.db
+    REASONS_DB=/path/to/reasons.db reasons-mcp  # explicit path
+
+Add to Claude Code:
+    claude mcp add reasons -- reasons-mcp
+    claude mcp add reasons -e REASONS_DB=/path/to/reasons.db -- reasons-mcp
+"""
+
+import json
+import os
+
+from mcp.server.fastmcp import FastMCP
+
+from reasons_lib import api
+
+mcp = FastMCP("reasons")
+
+_db: str = os.environ.get("REASONS_DB", api.DEFAULT_DB)
+
+
+def _find_db() -> str:
+    """Walk up from cwd looking for reasons.db, matching CLI behavior."""
+    if os.environ.get("REASONS_DB"):
+        return os.environ["REASONS_DB"]
+    d = os.getcwd()
+    while True:
+        candidate = os.path.join(d, "reasons.db")
+        if os.path.exists(candidate):
+            return candidate
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    return api.DEFAULT_DB
+
+
+# --- Tier 1: Core ---
+
+
+@mcp.tool()
+def search(query: str, format: str = "markdown", depth: int = 1) -> str:
+    """Search beliefs by text with neighbor expansion.
+
+    Args:
+        query: Search terms (matches all terms in any order)
+        format: Output format — "markdown", "json", or "minimal"
+        depth: Hops to expand along justification chains (default 1)
+    """
+    return api.search(query, db_path=_db, format=format, depth=depth)
+
+
+@mcp.tool()
+def show(node_id: str) -> str:
+    """Get full details for a belief: text, truth value, justifications, and dependents.
+
+    Args:
+        node_id: The belief identifier (e.g. "ansible-is-declarative")
+    """
+    return json.dumps(api.show_node(node_id, db_path=_db), indent=2)
+
+
+@mcp.tool()
+def explain(node_id: str) -> str:
+    """Trace why a belief is IN or OUT by walking its justification chain.
+
+    Args:
+        node_id: The belief identifier to explain
+    """
+    return json.dumps(api.explain_node(node_id, db_path=_db), indent=2)
+
+
+@mcp.tool()
+def list_beliefs(status: str = "", premises_only: bool = False, namespace: str = "") -> str:
+    """List beliefs in the network with optional filters.
+
+    Args:
+        status: Filter by truth value — "IN", "OUT", or empty for all
+        premises_only: Only show premise nodes (no derived beliefs)
+        namespace: Filter by namespace prefix
+    """
+    result = api.list_nodes(
+        status=status or None,
+        premises_only=premises_only,
+        namespace=namespace or None,
+        db_path=_db,
+    )
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def add(node_id: str, text: str, sl: str = "", unless: str = "", label: str = "") -> str:
+    """Add a belief to the network. Without sl, adds as a premise. With sl, adds as derived.
+
+    Args:
+        node_id: Identifier for the new belief (e.g. "ansible-is-declarative")
+        text: The belief text
+        sl: Comma-separated antecedent node IDs for SL justification (empty = premise)
+        unless: Comma-separated outlist node IDs (must be OUT for justification to hold)
+        label: Optional justification label
+    """
+    result = api.add_node(node_id, text, sl=sl, unless=unless, label=label, db_path=_db)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def retract(node_id: str, reason: str = "") -> str:
+    """Retract a belief, cascading OUT to all dependents.
+
+    Args:
+        node_id: The belief to retract
+        reason: Why this belief is being retracted
+    """
+    return json.dumps(api.retract_node(node_id, reason=reason, db_path=_db), indent=2)
+
+
+@mcp.tool()
+def assert_belief(node_id: str) -> str:
+    """Assert a retracted belief back to IN, cascading restoration to dependents.
+
+    Args:
+        node_id: The belief to assert
+    """
+    return json.dumps(api.assert_node(node_id, db_path=_db), indent=2)
+
+
+# --- Tier 2: Reasoning ---
+
+
+@mcp.tool()
+def what_if(node_id: str, action: str = "retract") -> str:
+    """Simulate retracting or asserting a belief without modifying the database.
+
+    Shows the cascade: which beliefs would change truth values.
+
+    Args:
+        node_id: The belief to simulate
+        action: "retract" or "assert"
+    """
+    if action == "assert":
+        result = api.what_if_assert(node_id, db_path=_db)
+    else:
+        result = api.what_if_retract(node_id, db_path=_db)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def add_justification(node_id: str, sl: str = "", unless: str = "", label: str = "") -> str:
+    """Add an additional justification to an existing belief.
+
+    Can bring an OUT belief back to IN if the new justification is satisfied.
+
+    Args:
+        node_id: The belief to add a justification to
+        sl: Comma-separated antecedent node IDs
+        unless: Comma-separated outlist node IDs
+        label: Optional justification label
+    """
+    result = api.add_justification(node_id, sl=sl, unless=unless, label=label, db_path=_db)
+    return json.dumps(result, indent=2)
+
+
+@mcp.tool()
+def nogood(node_ids: list[str]) -> str:
+    """Record a contradiction between beliefs and trigger backtracking.
+
+    The TMS will retract the weakest premise to resolve the contradiction.
+
+    Args:
+        node_ids: List of belief IDs that form a contradiction
+    """
+    return json.dumps(api.add_nogood(node_ids, db_path=_db), indent=2)
+
+
+@mcp.tool()
+def trace(node_id: str) -> str:
+    """Find all root premises a belief ultimately depends on.
+
+    Args:
+        node_id: The belief to trace
+    """
+    return json.dumps(api.trace_assumptions(node_id, db_path=_db), indent=2)
+
+
+@mcp.tool()
+def compact(budget: int = 500) -> str:
+    """Get a token-budgeted summary of the entire belief network.
+
+    Args:
+        budget: Maximum token budget for the summary
+    """
+    return api.compact(budget=budget, db_path=_db)
+
+
+# --- Tier 3: Data management ---
+
+
+@mcp.tool()
+def status() -> str:
+    """Get a network overview: all nodes with truth values and counts."""
+    return json.dumps(api.get_status(db_path=_db), indent=2)
+
+
+@mcp.tool()
+def list_gated() -> str:
+    """Find OUT beliefs that are blocked by active outlist gates.
+
+    These are beliefs that would come IN if their blocker was retracted.
+    """
+    return json.dumps(api.list_gated(db_path=_db), indent=2)
+
+
+@mcp.tool()
+def export_markdown() -> str:
+    """Export the entire belief network as markdown (beliefs.md format)."""
+    return api.export_markdown(db_path=_db)
+
+
+@mcp.tool()
+def topics(limit: int = 20) -> str:
+    """Extract topic clusters from belief identifiers.
+
+    Args:
+        limit: Maximum number of topics to return
+    """
+    return json.dumps(api.topics(limit=limit, db_path=_db), indent=2)
+
+
+def main():
+    global _db
+    _db = _find_db()
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/reasons_lib/mcp_server.py
+++ b/reasons_lib/mcp_server.py
@@ -136,7 +136,10 @@ def retract(node_id: str, reason: str = "") -> str:
         node_id: The belief to retract
         reason: Why this belief is being retracted
     """
-    return json.dumps(api.retract_node(node_id, reason=reason, db_path=_get_db()), indent=2)
+    try:
+        return json.dumps(api.retract_node(node_id, reason=reason, db_path=_get_db()), indent=2)
+    except KeyError:
+        return json.dumps({"error": f"Node '{node_id}' not found"})
 
 
 @mcp.tool()
@@ -146,7 +149,10 @@ def assert_belief(node_id: str) -> str:
     Args:
         node_id: The belief to assert
     """
-    return json.dumps(api.assert_node(node_id, db_path=_get_db()), indent=2)
+    try:
+        return json.dumps(api.assert_node(node_id, db_path=_get_db()), indent=2)
+    except KeyError:
+        return json.dumps({"error": f"Node '{node_id}' not found"})
 
 
 # --- Tier 2: Reasoning ---
@@ -200,7 +206,10 @@ def nogood(node_ids: list[str]) -> str:
     Args:
         node_ids: List of belief IDs that form a contradiction
     """
-    return json.dumps(api.add_nogood(node_ids, db_path=_get_db()), indent=2)
+    try:
+        return json.dumps(api.add_nogood(node_ids, db_path=_get_db()), indent=2)
+    except KeyError as e:
+        return json.dumps({"error": str(e)})
 
 
 @mcp.tool()

--- a/reasons_lib/mcp_server.py
+++ b/reasons_lib/mcp_server.py
@@ -12,13 +12,19 @@ Add to Claude Code:
 import json
 import os
 
-from mcp.server.fastmcp import FastMCP
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError:
+    raise ImportError(
+        "The 'mcp' package is required for the MCP server. "
+        "Install with: pip install 'ftl-reasons[mcp]'"
+    )
 
 from reasons_lib import api
 
 mcp = FastMCP("reasons")
 
-_db: str = os.environ.get("REASONS_DB", api.DEFAULT_DB)
+_db: str | None = None
 
 
 def _find_db() -> str:
@@ -37,19 +43,27 @@ def _find_db() -> str:
     return api.DEFAULT_DB
 
 
+def _get_db() -> str:
+    """Return the resolved database path, discovering lazily if needed."""
+    global _db
+    if _db is None:
+        _db = _find_db()
+    return _db
+
+
 # --- Tier 1: Core ---
 
 
 @mcp.tool()
-def search(query: str, format: str = "markdown", depth: int = 1) -> str:
+def search(query: str, output_format: str = "markdown", depth: int = 1) -> str:
     """Search beliefs by text with neighbor expansion.
 
     Args:
         query: Search terms (matches all terms in any order)
-        format: Output format — "markdown", "json", or "minimal"
+        output_format: Output format — "markdown", "json", or "minimal"
         depth: Hops to expand along justification chains (default 1)
     """
-    return api.search(query, db_path=_db, format=format, depth=depth)
+    return api.search(query, db_path=_get_db(), format=output_format, depth=depth)
 
 
 @mcp.tool()
@@ -59,7 +73,10 @@ def show(node_id: str) -> str:
     Args:
         node_id: The belief identifier (e.g. "ansible-is-declarative")
     """
-    return json.dumps(api.show_node(node_id, db_path=_db), indent=2)
+    try:
+        return json.dumps(api.show_node(node_id, db_path=_get_db()), indent=2)
+    except KeyError:
+        return json.dumps({"error": f"Node '{node_id}' not found"})
 
 
 @mcp.tool()
@@ -69,7 +86,10 @@ def explain(node_id: str) -> str:
     Args:
         node_id: The belief identifier to explain
     """
-    return json.dumps(api.explain_node(node_id, db_path=_db), indent=2)
+    try:
+        return json.dumps(api.explain_node(node_id, db_path=_get_db()), indent=2)
+    except KeyError:
+        return json.dumps({"error": f"Node '{node_id}' not found"})
 
 
 @mcp.tool()
@@ -85,7 +105,7 @@ def list_beliefs(status: str = "", premises_only: bool = False, namespace: str =
         status=status or None,
         premises_only=premises_only,
         namespace=namespace or None,
-        db_path=_db,
+        db_path=_get_db(),
     )
     return json.dumps(result, indent=2)
 
@@ -101,7 +121,7 @@ def add(node_id: str, text: str, sl: str = "", unless: str = "", label: str = ""
         unless: Comma-separated outlist node IDs (must be OUT for justification to hold)
         label: Optional justification label
     """
-    result = api.add_node(node_id, text, sl=sl, unless=unless, label=label, db_path=_db)
+    result = api.add_node(node_id, text, sl=sl, unless=unless, label=label, db_path=_get_db())
     return json.dumps(result, indent=2)
 
 
@@ -113,7 +133,7 @@ def retract(node_id: str, reason: str = "") -> str:
         node_id: The belief to retract
         reason: Why this belief is being retracted
     """
-    return json.dumps(api.retract_node(node_id, reason=reason, db_path=_db), indent=2)
+    return json.dumps(api.retract_node(node_id, reason=reason, db_path=_get_db()), indent=2)
 
 
 @mcp.tool()
@@ -123,7 +143,7 @@ def assert_belief(node_id: str) -> str:
     Args:
         node_id: The belief to assert
     """
-    return json.dumps(api.assert_node(node_id, db_path=_db), indent=2)
+    return json.dumps(api.assert_node(node_id, db_path=_get_db()), indent=2)
 
 
 # --- Tier 2: Reasoning ---
@@ -140,9 +160,9 @@ def what_if(node_id: str, action: str = "retract") -> str:
         action: "retract" or "assert"
     """
     if action == "assert":
-        result = api.what_if_assert(node_id, db_path=_db)
+        result = api.what_if_assert(node_id, db_path=_get_db())
     else:
-        result = api.what_if_retract(node_id, db_path=_db)
+        result = api.what_if_retract(node_id, db_path=_get_db())
     return json.dumps(result, indent=2)
 
 
@@ -158,7 +178,7 @@ def add_justification(node_id: str, sl: str = "", unless: str = "", label: str =
         unless: Comma-separated outlist node IDs
         label: Optional justification label
     """
-    result = api.add_justification(node_id, sl=sl, unless=unless, label=label, db_path=_db)
+    result = api.add_justification(node_id, sl=sl, unless=unless, label=label, db_path=_get_db())
     return json.dumps(result, indent=2)
 
 
@@ -171,7 +191,7 @@ def nogood(node_ids: list[str]) -> str:
     Args:
         node_ids: List of belief IDs that form a contradiction
     """
-    return json.dumps(api.add_nogood(node_ids, db_path=_db), indent=2)
+    return json.dumps(api.add_nogood(node_ids, db_path=_get_db()), indent=2)
 
 
 @mcp.tool()
@@ -181,7 +201,10 @@ def trace(node_id: str) -> str:
     Args:
         node_id: The belief to trace
     """
-    return json.dumps(api.trace_assumptions(node_id, db_path=_db), indent=2)
+    try:
+        return json.dumps(api.trace_assumptions(node_id, db_path=_get_db()), indent=2)
+    except KeyError:
+        return json.dumps({"error": f"Node '{node_id}' not found"})
 
 
 @mcp.tool()
@@ -191,7 +214,7 @@ def compact(budget: int = 500) -> str:
     Args:
         budget: Maximum token budget for the summary
     """
-    return api.compact(budget=budget, db_path=_db)
+    return api.compact(budget=budget, db_path=_get_db())
 
 
 # --- Tier 3: Data management ---
@@ -200,7 +223,7 @@ def compact(budget: int = 500) -> str:
 @mcp.tool()
 def status() -> str:
     """Get a network overview: all nodes with truth values and counts."""
-    return json.dumps(api.get_status(db_path=_db), indent=2)
+    return json.dumps(api.get_status(db_path=_get_db()), indent=2)
 
 
 @mcp.tool()
@@ -209,13 +232,13 @@ def list_gated() -> str:
 
     These are beliefs that would come IN if their blocker was retracted.
     """
-    return json.dumps(api.list_gated(db_path=_db), indent=2)
+    return json.dumps(api.list_gated(db_path=_get_db()), indent=2)
 
 
 @mcp.tool()
 def export_markdown() -> str:
     """Export the entire belief network as markdown (beliefs.md format)."""
-    return api.export_markdown(db_path=_db)
+    return api.export_markdown(db_path=_get_db())
 
 
 @mcp.tool()
@@ -225,7 +248,7 @@ def topics(limit: int = 20) -> str:
     Args:
         limit: Maximum number of topics to return
     """
-    return json.dumps(api.topics(limit=limit, db_path=_db), indent=2)
+    return json.dumps(api.topics(limit=limit, db_path=_get_db()), indent=2)
 
 
 def main():

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytest.importorskip("mcp")
+
 from reasons_lib import api
 from reasons_lib import mcp_server
 
@@ -153,6 +155,10 @@ class TestRetractTool:
         node = api.show_node("premise-a", db_path=db)
         assert node["truth_value"] == "OUT"
 
+    def test_retract_missing_returns_error(self, db):
+        result = json.loads(mcp_server.retract("nonexistent"))
+        assert "error" in result
+
 
 class TestAssertBeliefTool:
 
@@ -162,6 +168,10 @@ class TestAssertBeliefTool:
         assert "premise-a" in result["went_in"]
         node = api.show_node("premise-a", db_path=db)
         assert node["truth_value"] == "IN"
+
+    def test_assert_missing_returns_error(self, db):
+        result = json.loads(mcp_server.assert_belief("nonexistent"))
+        assert "error" in result
 
 
 class TestWhatIfTool:
@@ -201,6 +211,10 @@ class TestNogoodTool:
     def test_nogood(self, db):
         result = json.loads(mcp_server.nogood(["premise-a", "premise-b"]))
         assert "nogood_id" in result
+
+    def test_nogood_missing_returns_error(self, db):
+        result = json.loads(mcp_server.nogood(["nonexistent-x", "nonexistent-y"]))
+        assert "error" in result
 
 
 class TestTraceTool:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -138,6 +138,12 @@ class TestAddTool:
                                            sl="premise-a"))
         assert result["node_id"] == "new-derived"
 
+    def test_add_with_missing_sl_creates_out(self, db):
+        result = json.loads(mcp_server.add("bad-derived", "Bad",
+                                           sl="nonexistent-node"))
+        assert result["node_id"] == "bad-derived"
+        assert result["truth_value"] == "OUT"
+
 
 class TestRetractTool:
 
@@ -162,12 +168,19 @@ class TestWhatIfTool:
 
     def test_what_if_retract(self, db):
         result = json.loads(mcp_server.what_if("premise-a", action="retract"))
-        assert "affected" in result or "would_change" in result or isinstance(result, dict)
+        assert result["node_id"] == "premise-a"
+        assert "retracted" in result
+        assert "total_affected" in result
 
     def test_what_if_assert(self, db):
         api.retract_node("premise-a", db_path=db)
         result = json.loads(mcp_server.what_if("premise-a", action="assert"))
-        assert isinstance(result, dict)
+        assert result["node_id"] == "premise-a"
+        assert "restored" in result
+
+    def test_what_if_missing_returns_error(self, db):
+        result = json.loads(mcp_server.what_if("nonexistent"))
+        assert "error" in result
 
 
 class TestAddJustificationTool:
@@ -175,21 +188,27 @@ class TestAddJustificationTool:
     def test_add_justification(self, db):
         result = json.loads(mcp_server.add_justification(
             "derived-c", sl="premise-a", label="extra"))
-        assert isinstance(result, dict)
+        assert result["node_id"] == "derived-c"
+
+    def test_add_justification_missing_sl(self, db):
+        result = json.loads(mcp_server.add_justification(
+            "derived-c", sl="nonexistent"))
+        assert result["node_id"] == "derived-c"
 
 
 class TestNogoodTool:
 
     def test_nogood(self, db):
         result = json.loads(mcp_server.nogood(["premise-a", "premise-b"]))
-        assert isinstance(result, dict)
+        assert "nogood_id" in result
 
 
 class TestTraceTool:
 
     def test_trace_derived(self, db):
         result = json.loads(mcp_server.trace("derived-c"))
-        assert isinstance(result, (dict, list))
+        assert result["node_id"] == "derived-c"
+        assert "premises" in result
 
     def test_trace_missing_returns_error(self, db):
         result = json.loads(mcp_server.trace("nonexistent"))
@@ -208,14 +227,16 @@ class TestStatusTool:
 
     def test_status(self, db):
         result = json.loads(mcp_server.status())
-        assert "nodes" in result or "total" in result or isinstance(result, dict)
+        assert "nodes" in result
+        assert "in_count" in result
+        assert "total" in result
 
 
 class TestListGatedTool:
 
     def test_list_gated(self, db):
         result = json.loads(mcp_server.list_gated())
-        assert isinstance(result, (dict, list))
+        assert "gated_count" in result
 
 
 class TestExportMarkdownTool:
@@ -230,4 +251,4 @@ class TestTopicsTool:
 
     def test_topics(self, db):
         result = json.loads(mcp_server.topics(limit=10))
-        assert isinstance(result, (dict, list))
+        assert "topics" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,233 @@
+"""Tests for the MCP server tool functions."""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib import mcp_server
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    api.init_db(db_path=db_path)
+    api.add_node("premise-a", "A is true", db_path=db_path)
+    api.add_node("premise-b", "B is true", db_path=db_path)
+    api.add_node("derived-c", "C follows from A and B",
+                 sl="premise-a,premise-b", db_path=db_path)
+    mcp_server._db = db_path
+    yield db_path
+    mcp_server._db = None
+
+
+class TestFindDb:
+
+    def test_env_var_takes_precedence(self, tmp_path):
+        custom = str(tmp_path / "custom.db")
+        with patch.dict(os.environ, {"REASONS_DB": custom}):
+            assert mcp_server._find_db() == custom
+
+    def test_walks_up_from_cwd(self, tmp_path):
+        db_path = tmp_path / "reasons.db"
+        db_path.touch()
+        subdir = tmp_path / "sub" / "deep"
+        subdir.mkdir(parents=True)
+        with patch("os.getcwd", return_value=str(subdir)), \
+             patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("REASONS_DB", None)
+            result = mcp_server._find_db()
+            assert result == str(db_path)
+
+    def test_falls_back_to_default(self, tmp_path):
+        with patch("os.getcwd", return_value=str(tmp_path)), \
+             patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("REASONS_DB", None)
+            result = mcp_server._find_db()
+            assert result == api.DEFAULT_DB
+
+
+class TestGetDb:
+
+    def test_lazy_discovery(self, tmp_path):
+        db_path = tmp_path / "reasons.db"
+        db_path.touch()
+        mcp_server._db = None
+        with patch("os.getcwd", return_value=str(tmp_path)), \
+             patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("REASONS_DB", None)
+            result = mcp_server._get_db()
+            assert result == str(db_path)
+        mcp_server._db = None
+
+    def test_uses_cached_value(self):
+        mcp_server._db = "/some/path.db"
+        assert mcp_server._get_db() == "/some/path.db"
+        mcp_server._db = None
+
+
+class TestSearchTool:
+
+    def test_search_returns_results(self, db):
+        result = mcp_server.search("true")
+        assert "premise-a" in result or "premise-b" in result
+
+    def test_search_json_format(self, db):
+        result = mcp_server.search("true", output_format="json")
+        data = json.loads(result)
+        assert isinstance(data, (list, dict))
+
+
+class TestShowTool:
+
+    def test_show_existing(self, db):
+        result = json.loads(mcp_server.show("premise-a"))
+        assert result["text"] == "A is true"
+        assert result["truth_value"] == "IN"
+
+    def test_show_missing_returns_error(self, db):
+        result = json.loads(mcp_server.show("nonexistent"))
+        assert "error" in result
+
+
+class TestExplainTool:
+
+    def test_explain_existing(self, db):
+        result = json.loads(mcp_server.explain("derived-c"))
+        assert "steps" in result
+
+    def test_explain_missing_returns_error(self, db):
+        result = json.loads(mcp_server.explain("nonexistent"))
+        assert "error" in result
+
+
+class TestListBeliefsTool:
+
+    def test_list_all(self, db):
+        result = json.loads(mcp_server.list_beliefs())
+        assert len(result["nodes"]) == 3
+
+    def test_list_premises_only(self, db):
+        result = json.loads(mcp_server.list_beliefs(premises_only=True))
+        ids = [n["id"] for n in result["nodes"]]
+        assert "derived-c" not in ids
+
+    def test_list_by_status(self, db):
+        api.retract_node("premise-a", db_path=db)
+        result = json.loads(mcp_server.list_beliefs(status="OUT"))
+        ids = [n["id"] for n in result["nodes"]]
+        assert "premise-a" in ids
+
+    def test_empty_status_means_all(self, db):
+        result = json.loads(mcp_server.list_beliefs(status=""))
+        assert len(result["nodes"]) == 3
+
+
+class TestAddTool:
+
+    def test_add_premise(self, db):
+        result = json.loads(mcp_server.add("new-premise", "Something new"))
+        assert result["node_id"] == "new-premise"
+        node = api.show_node("new-premise", db_path=db)
+        assert node["text"] == "Something new"
+
+    def test_add_derived(self, db):
+        result = json.loads(mcp_server.add("new-derived", "Derived thing",
+                                           sl="premise-a"))
+        assert result["node_id"] == "new-derived"
+
+
+class TestRetractTool:
+
+    def test_retract(self, db):
+        result = json.loads(mcp_server.retract("premise-a", reason="testing"))
+        assert "premise-a" in result["changed"]
+        node = api.show_node("premise-a", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+
+class TestAssertBeliefTool:
+
+    def test_assert_retracted(self, db):
+        api.retract_node("premise-a", db_path=db)
+        result = json.loads(mcp_server.assert_belief("premise-a"))
+        assert "premise-a" in result["went_in"]
+        node = api.show_node("premise-a", db_path=db)
+        assert node["truth_value"] == "IN"
+
+
+class TestWhatIfTool:
+
+    def test_what_if_retract(self, db):
+        result = json.loads(mcp_server.what_if("premise-a", action="retract"))
+        assert "affected" in result or "would_change" in result or isinstance(result, dict)
+
+    def test_what_if_assert(self, db):
+        api.retract_node("premise-a", db_path=db)
+        result = json.loads(mcp_server.what_if("premise-a", action="assert"))
+        assert isinstance(result, dict)
+
+
+class TestAddJustificationTool:
+
+    def test_add_justification(self, db):
+        result = json.loads(mcp_server.add_justification(
+            "derived-c", sl="premise-a", label="extra"))
+        assert isinstance(result, dict)
+
+
+class TestNogoodTool:
+
+    def test_nogood(self, db):
+        result = json.loads(mcp_server.nogood(["premise-a", "premise-b"]))
+        assert isinstance(result, dict)
+
+
+class TestTraceTool:
+
+    def test_trace_derived(self, db):
+        result = json.loads(mcp_server.trace("derived-c"))
+        assert isinstance(result, (dict, list))
+
+    def test_trace_missing_returns_error(self, db):
+        result = json.loads(mcp_server.trace("nonexistent"))
+        assert "error" in result
+
+
+class TestCompactTool:
+
+    def test_compact(self, db):
+        result = mcp_server.compact(budget=500)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+class TestStatusTool:
+
+    def test_status(self, db):
+        result = json.loads(mcp_server.status())
+        assert "nodes" in result or "total" in result or isinstance(result, dict)
+
+
+class TestListGatedTool:
+
+    def test_list_gated(self, db):
+        result = json.loads(mcp_server.list_gated())
+        assert isinstance(result, (dict, list))
+
+
+class TestExportMarkdownTool:
+
+    def test_export_markdown(self, db):
+        result = mcp_server.export_markdown()
+        assert isinstance(result, str)
+        assert "premise-a" in result or "A is true" in result
+
+
+class TestTopicsTool:
+
+    def test_topics(self, db):
+        result = json.loads(mcp_server.topics(limit=10))
+        assert isinstance(result, (dict, list))


### PR DESCRIPTION
## Summary

- Adds `reasons_lib/mcp_server.py` — a FastMCP stdio server exposing 16 tools in 3 tiers (core, reasoning, data management)
- Tools call `reasons_lib.api` directly — no HTTP layer, no auth, no deployment
- Auto-discovers `reasons.db` by walking up from cwd, or uses `REASONS_DB` env var
- Adds `reasons-mcp` entry point to `pyproject.toml`

## Test plan

- [ ] `uv pip install -e '.[mcp]'` installs successfully
- [ ] `reasons-mcp` starts stdio server from a directory with `reasons.db`
- [ ] `claude mcp add reasons -- reasons-mcp` registers in Claude Code
- [ ] Verify search, show, explain, what_if tools return correct results
- [ ] Verify add, retract, assert_belief modify the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)