### PR TITLE
Add build-wiki command (#196)

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2376,7 +2376,7 @@ def build_wiki(
 
     if cluster:
         cluster_result = list_clusters(
-            status=status or "IN",
+            status=status or "",
             n_clusters=n_clusters,
             seed=seed,
             embedding_model=embedding_model,
@@ -2389,7 +2389,7 @@ def build_wiki(
             word_counts: dict[str, int] = {}
             for nid in ids_in_cluster:
                 for word in re.split(r'[-._:]', nid):
-                    if word and len(word) > 2:
+                    if word and len(word) > 2 and word not in _TOPIC_STOP_WORDS:
                         word_counts[word] = word_counts.get(word, 0) + 1
             label = max(word_counts, key=word_counts.get) if word_counts else f"cluster-{c['id']}"
             if label in groups:

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2340,6 +2340,68 @@ def topics(
         }
 
 
+def build_wiki(
+    output_dir: str = "wiki",
+    status: str | None = None,
+    max_topics: int = 20,
+    cluster: bool = False,
+    n_clusters: int | None = None,
+    seed: int | None = None,
+    embedding_model: str | None = None,
+    visible_to: list[str] | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Export beliefs as interlinked markdown wiki pages grouped by topic or cluster.
+
+    Returns: {"output_dir": str, "pages": int, "total_nodes": int}
+    """
+    from .build_wiki import _assign_topics, build_wiki as _build_wiki
+
+    nodes_result = list_nodes(status=status, visible_to=visible_to, db_path=db_path)
+    node_ids = [n["id"] for n in nodes_result["nodes"]]
+
+    if not node_ids:
+        import os
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, "index.md"), "w") as f:
+            f.write("# Belief Wiki\n\n*No beliefs found.*\n")
+        return {"output_dir": output_dir, "pages": 0, "total_nodes": 0}
+
+    node_details = {}
+    for nid in node_ids:
+        try:
+            node_details[nid] = show_node(nid, visible_to=visible_to, db_path=db_path)
+        except (KeyError, PermissionError):
+            pass
+
+    if cluster:
+        cluster_result = list_clusters(
+            status=status or "IN",
+            n_clusters=n_clusters,
+            seed=seed,
+            embedding_model=embedding_model,
+            visible_to=visible_to,
+            db_path=db_path,
+        )
+        groups = {}
+        for c in cluster_result["clusters"]:
+            ids_in_cluster = [b["id"] for b in c["beliefs"]]
+            word_counts: dict[str, int] = {}
+            for nid in ids_in_cluster:
+                for word in re.split(r'[-._:]', nid):
+                    if word and len(word) > 2:
+                        word_counts[word] = word_counts.get(word, 0) + 1
+            label = max(word_counts, key=word_counts.get) if word_counts else f"cluster-{c['id']}"
+            if label in groups:
+                label = f"{label}-{c['id']}"
+            groups[label] = ids_in_cluster
+    else:
+        topics_result = topics(limit=max_topics, db_path=db_path)
+        groups = _assign_topics(node_ids, topics_result["topics"])
+
+    return _build_wiki(node_details, groups, output_dir)
+
+
 def list_gated(
     visible_to: list[str] | None = None,
     db_path: str = DEFAULT_DB,

--- a/reasons_lib/build_wiki.py
+++ b/reasons_lib/build_wiki.py
@@ -87,6 +87,9 @@ def _format_node(node_id, node_detail, node_to_page):
     return "\n".join(lines)
 
 
+_RESERVED_SLUGS = {"index"}
+
+
 def build_wiki(node_details, groups, output_dir):
     """Write index.md and per-group pages to output_dir.
 
@@ -97,9 +100,20 @@ def build_wiki(node_details, groups, output_dir):
     """
     os.makedirs(output_dir, exist_ok=True)
 
+    used_slugs: dict[str, str] = {}
+    label_to_file: dict[str, str] = {}
+    for label in groups:
+        slug = _page_name(label)
+        if slug in _RESERVED_SLUGS:
+            slug = f"{slug}-topic"
+        while slug in used_slugs:
+            slug = f"{slug}-2"
+        used_slugs[slug] = label
+        label_to_file[label] = slug + ".md"
+
     node_to_page = {}
     for label, nids in groups.items():
-        page_file = _page_name(label) + ".md"
+        page_file = label_to_file[label]
         for nid in nids:
             node_to_page[nid] = page_file
 
@@ -107,7 +121,7 @@ def build_wiki(node_details, groups, output_dir):
     index_lines.append("| Topic | Beliefs |")
     index_lines.append("|-------|---------|")
     for label in sorted(groups, key=lambda l: (-len(groups[l]), l)):
-        page_file = _page_name(label) + ".md"
+        page_file = label_to_file[label]
         count = len(groups[label])
         index_lines.append(f"| [{label}]({page_file}) | {count} |")
     index_lines.append("")
@@ -120,7 +134,7 @@ def build_wiki(node_details, groups, output_dir):
         f.write("\n".join(index_lines))
 
     for label, nids in groups.items():
-        page_file = _page_name(label) + ".md"
+        page_file = label_to_file[label]
         page_lines = [f"# {label}", ""]
         page_lines.append(f"[Back to index](index.md)")
         page_lines.append("")

--- a/reasons_lib/build_wiki.py
+++ b/reasons_lib/build_wiki.py
@@ -1,0 +1,134 @@
+"""Build a static wiki from the belief network.
+
+Exports beliefs as interlinked markdown pages grouped by topic
+(word-frequency) or semantic cluster.
+"""
+
+import os
+import re
+
+
+_TOPIC_STOP_WORDS = {
+    "the", "is", "in", "to", "of", "and", "or", "not", "as", "by",
+    "via", "can", "with", "from", "than", "that", "this", "be", "has",
+    "have", "it", "its", "no", "do", "if", "so", "up", "out", "all",
+    "but", "get", "set", "only", "per", "use", "may", "one", "two",
+    "new", "any", "each", "must", "when", "how", "also", "into",
+    "over", "more", "both", "same", "own", "used", "using", "based",
+    "does", "then", "for",
+}
+
+
+def _assign_topics(node_ids, topics):
+    """Assign each node to its best-matching topic based on ID segments.
+
+    Returns {topic_label: [node_id, ...], ...} with "Other" for unmatched.
+    """
+    topic_set = {t["topic"] for t in topics}
+    groups = {t["topic"]: [] for t in topics}
+    groups["Other"] = []
+
+    for nid in node_ids:
+        words = [w for w in re.split(r'[-._:]', nid) if w and len(w) > 2]
+        matched = False
+        for word in words:
+            if word in topic_set:
+                groups[word].append(nid)
+                matched = True
+                break
+        if not matched:
+            groups["Other"].append(nid)
+
+    return {k: v for k, v in groups.items() if v}
+
+
+def _page_name(label):
+    """Sanitize a topic/cluster label to a valid markdown filename."""
+    safe = re.sub(r'[^a-z0-9]+', '-', label.lower()).strip('-')
+    return safe or "other"
+
+
+def _format_node(node_id, node_detail, node_to_page):
+    """Render one node as markdown with cross-reference links."""
+    lines = []
+    lines.append(f"### {node_id}")
+    lines.append(f"**Status:** {node_detail['truth_value']}")
+    lines.append("")
+    lines.append(node_detail["text"])
+    lines.append("")
+
+    antecedents = set()
+    for j in node_detail.get("justifications", []):
+        for a in j.get("antecedents", []):
+            antecedents.add(a)
+
+    if antecedents:
+        links = []
+        for a in sorted(antecedents):
+            page = node_to_page.get(a)
+            if page:
+                links.append(f"[{a}]({page}#{a})")
+            else:
+                links.append(a)
+        lines.append(f"**Depends on:** {', '.join(links)}")
+
+    dependents = node_detail.get("dependents", [])
+    if dependents:
+        links = []
+        for d in sorted(dependents):
+            page = node_to_page.get(d)
+            if page:
+                links.append(f"[{d}]({page}#{d})")
+            else:
+                links.append(d)
+        lines.append(f"**Supports:** {', '.join(links)}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_wiki(node_details, groups, output_dir):
+    """Write index.md and per-group pages to output_dir.
+
+    Args:
+        node_details: {node_id: show_node dict}
+        groups: {group_label: [node_id, ...]}
+        output_dir: directory to write markdown files into
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    node_to_page = {}
+    for label, nids in groups.items():
+        page_file = _page_name(label) + ".md"
+        for nid in nids:
+            node_to_page[nid] = page_file
+
+    index_lines = ["# Belief Wiki", ""]
+    index_lines.append("| Topic | Beliefs |")
+    index_lines.append("|-------|---------|")
+    for label in sorted(groups, key=lambda l: (-len(groups[l]), l)):
+        page_file = _page_name(label) + ".md"
+        count = len(groups[label])
+        index_lines.append(f"| [{label}]({page_file}) | {count} |")
+    index_lines.append("")
+
+    total = sum(len(nids) for nids in groups.values())
+    index_lines.append(f"*{total} beliefs across {len(groups)} pages*")
+    index_lines.append("")
+
+    with open(os.path.join(output_dir, "index.md"), "w") as f:
+        f.write("\n".join(index_lines))
+
+    for label, nids in groups.items():
+        page_file = _page_name(label) + ".md"
+        page_lines = [f"# {label}", ""]
+        page_lines.append(f"[Back to index](index.md)")
+        page_lines.append("")
+        for nid in sorted(nids):
+            detail = node_details.get(nid)
+            if detail:
+                page_lines.append(_format_node(nid, detail, node_to_page))
+        with open(os.path.join(output_dir, page_file), "w") as f:
+            f.write("\n".join(page_lines))
+
+    return {"output_dir": output_dir, "pages": len(groups), "total_nodes": total}

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1454,6 +1454,7 @@ def cmd_topics(args):
 
 
 def cmd_build_wiki(args):
+    _require_sqlite(args, "build-wiki")
     result = api.build_wiki(
         output_dir=args.output,
         status=args.status or None,
@@ -1463,7 +1464,7 @@ def cmd_build_wiki(args):
         seed=args.seed,
         embedding_model=args.embedding_model,
         visible_to=_parse_visible_to(args),
-        **_backend_kwargs(args),
+        db_path=args.db,
     )
     print(f"Wiki written to {result['output_dir']}/")
     print(f"  {result['total_nodes']} beliefs across {result['pages']} pages")

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1453,6 +1453,22 @@ def cmd_topics(args):
     print(f"\n{len(result['topics'])} topics from {result['total_nodes']} nodes")
 
 
+def cmd_build_wiki(args):
+    result = api.build_wiki(
+        output_dir=args.output,
+        status=args.status or None,
+        max_topics=args.max_topics,
+        cluster=args.cluster,
+        n_clusters=args.n_clusters,
+        seed=args.seed,
+        embedding_model=args.embedding_model,
+        visible_to=_parse_visible_to(args),
+        **_backend_kwargs(args),
+    )
+    print(f"Wiki written to {result['output_dir']}/")
+    print(f"  {result['total_nodes']} beliefs across {result['pages']} pages")
+
+
 def cmd_review_beliefs(args):
     _require_sqlite(args, "review-beliefs")
     import json
@@ -2458,6 +2474,17 @@ def main():
     p.add_argument("--limit", type=int, default=20, help="Max topics to show (default: 20)")
     p.add_argument("--json", action="store_true", help="Machine-readable JSON output")
 
+    # build-wiki
+    p = sub.add_parser("build-wiki", help="Export beliefs as interlinked markdown wiki pages")
+    p.add_argument("-o", "--output", default="wiki", help="Output directory (default: wiki)")
+    p.add_argument("--status", choices=["IN", "OUT"], default=None, help="Filter by truth value")
+    p.add_argument("--max-topics", type=int, default=20, help="Max topics for word-frequency grouping (default: 20)")
+    p.add_argument("--cluster", action="store_true", help="Use semantic clustering instead of topic grouping")
+    p.add_argument("--n-clusters", type=int, default=None, help="Override automatic cluster count")
+    p.add_argument("--seed", type=int, default=None, help="Random seed for reproducible clustering")
+    p.add_argument("--embedding-model", default=None, help="Sentence-transformers model for clustering")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only export nodes whose access_tags are a subset of these tags")
+
     # review-beliefs
     p = sub.add_parser("review-beliefs", help="Review derived beliefs for validity, sufficiency, and necessity")
     p.add_argument("ids", nargs="*", help="Specific belief IDs to review (default: all derived)")
@@ -2686,6 +2713,7 @@ def main():
         "list-gated": cmd_list_gated,
         "list-negative": cmd_list_negative,
         "topics": cmd_topics,
+        "build-wiki": cmd_build_wiki,
         "review-beliefs": cmd_review_beliefs,
         "review-premises": cmd_review_premises,
         "repair-premises": cmd_repair_premises,

--- a/tests/test_build_wiki.py
+++ b/tests/test_build_wiki.py
@@ -1,6 +1,5 @@
 """Tests for the build-wiki command."""
 
-import json
 import os
 import sys
 from io import StringIO
@@ -161,6 +160,31 @@ class TestBuildWiki:
         build_wiki(details, groups, output_dir)
         page = open(os.path.join(output_dir, "topic.md")).read()
         assert "[Back to index](index.md)" in page
+
+    def test_index_slug_collision(self, tmp_path):
+        output_dir = str(tmp_path / "wiki")
+        details = {
+            "node-a": {"text": "A", "truth_value": "IN", "justifications": [], "dependents": []},
+        }
+        groups = {"index": ["node-a"]}
+        result = build_wiki(details, groups, output_dir)
+        assert result["pages"] == 1
+        assert os.path.isfile(os.path.join(output_dir, "index.md"))
+        assert os.path.isfile(os.path.join(output_dir, "index-topic.md"))
+        index = open(os.path.join(output_dir, "index.md")).read()
+        assert "Belief Wiki" in index
+
+    def test_duplicate_slug_collision(self, tmp_path):
+        output_dir = str(tmp_path / "wiki")
+        details = {
+            "node-a": {"text": "A", "truth_value": "IN", "justifications": [], "dependents": []},
+            "node-b": {"text": "B", "truth_value": "IN", "justifications": [], "dependents": []},
+        }
+        groups = {"My Topic": ["node-a"], "My-Topic!": ["node-b"]}
+        result = build_wiki(details, groups, output_dir)
+        assert result["pages"] == 2
+        files = [f for f in os.listdir(output_dir) if f != "index.md"]
+        assert len(files) == 2
 
 
 class TestBuildWikiApi:

--- a/tests/test_build_wiki.py
+++ b/tests/test_build_wiki.py
@@ -1,0 +1,220 @@
+"""Tests for the build-wiki command."""
+
+import json
+import os
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib.build_wiki import _assign_topics, _format_node, _page_name, build_wiki
+
+
+def run_cli(*args, db_path=None):
+    from reasons_lib.cli import main
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+            code = 0
+        except SystemExit as e:
+            code = e.code if e.code is not None else 0
+    return stdout.getvalue(), stderr.getvalue(), code
+
+
+@pytest.fixture
+def db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    api.add_node("caching-strategy-redis", "Use Redis for caching", db_path=db_path)
+    api.add_node("caching-ttl-policy", "Set TTL on cache keys", db_path=db_path)
+    api.add_node("testing-unit-coverage", "Aim for high unit test coverage", db_path=db_path)
+    api.add_node("testing-integration-api", "Integration tests for API endpoints", db_path=db_path)
+    api.add_node("deploy-ci-pipeline", "CI pipeline runs on every push",
+                 sl="testing-unit-coverage", db_path=db_path)
+    return db_path
+
+
+class TestAssignTopics:
+
+    def test_assigns_to_matching_topic(self):
+        topics = [{"topic": "caching", "count": 3}, {"topic": "testing", "count": 2}]
+        node_ids = ["caching-strategy-redis", "testing-unit-coverage"]
+        groups = _assign_topics(node_ids, topics)
+        assert "caching-strategy-redis" in groups["caching"]
+        assert "testing-unit-coverage" in groups["testing"]
+
+    def test_unmatched_goes_to_other(self):
+        topics = [{"topic": "caching", "count": 3}]
+        node_ids = ["caching-redis", "xyz-unknown-thing"]
+        groups = _assign_topics(node_ids, topics)
+        assert "xyz-unknown-thing" in groups["Other"]
+
+    def test_empty_nodes(self):
+        topics = [{"topic": "caching", "count": 1}]
+        groups = _assign_topics([], topics)
+        assert groups == {}
+
+    def test_no_topics(self):
+        groups = _assign_topics(["some-node"], [])
+        assert "some-node" in groups["Other"]
+
+
+class TestPageName:
+
+    def test_simple(self):
+        assert _page_name("caching") == "caching"
+
+    def test_special_chars(self):
+        assert _page_name("My Topic!") == "my-topic"
+
+    def test_spaces(self):
+        assert _page_name("hello world") == "hello-world"
+
+    def test_empty_fallback(self):
+        assert _page_name("!!!") == "other"
+
+
+class TestFormatNode:
+
+    def test_basic_output(self):
+        detail = {
+            "text": "Use Redis for caching",
+            "truth_value": "IN",
+            "justifications": [],
+            "dependents": [],
+        }
+        result = _format_node("caching-redis", detail, {})
+        assert "### caching-redis" in result
+        assert "**Status:** IN" in result
+        assert "Use Redis for caching" in result
+
+    def test_cross_references(self):
+        detail = {
+            "text": "CI pipeline",
+            "truth_value": "IN",
+            "justifications": [{"antecedents": ["testing-unit"], "outlist": []}],
+            "dependents": ["deploy-prod"],
+        }
+        node_to_page = {
+            "testing-unit": "testing.md",
+            "deploy-prod": "deploy.md",
+        }
+        result = _format_node("ci-pipeline", detail, node_to_page)
+        assert "[testing-unit](testing.md#testing-unit)" in result
+        assert "[deploy-prod](deploy.md#deploy-prod)" in result
+        assert "**Depends on:**" in result
+        assert "**Supports:**" in result
+
+    def test_no_links_for_unknown_nodes(self):
+        detail = {
+            "text": "Some belief",
+            "truth_value": "OUT",
+            "justifications": [{"antecedents": ["unknown-node"], "outlist": []}],
+            "dependents": [],
+        }
+        result = _format_node("test-node", detail, {})
+        assert "unknown-node" in result
+        assert "[unknown-node]" not in result
+
+
+class TestBuildWiki:
+
+    def test_creates_files(self, tmp_path):
+        output_dir = str(tmp_path / "wiki")
+        details = {
+            "node-a": {"text": "A", "truth_value": "IN", "justifications": [], "dependents": []},
+            "node-b": {"text": "B", "truth_value": "IN", "justifications": [], "dependents": []},
+        }
+        groups = {"alpha": ["node-a"], "beta": ["node-b"]}
+        result = build_wiki(details, groups, output_dir)
+        assert result["pages"] == 2
+        assert result["total_nodes"] == 2
+        assert os.path.isfile(os.path.join(output_dir, "index.md"))
+        assert os.path.isfile(os.path.join(output_dir, "alpha.md"))
+        assert os.path.isfile(os.path.join(output_dir, "beta.md"))
+
+    def test_index_has_links(self, tmp_path):
+        output_dir = str(tmp_path / "wiki")
+        details = {
+            "node-a": {"text": "A", "truth_value": "IN", "justifications": [], "dependents": []},
+        }
+        groups = {"mytopic": ["node-a"]}
+        build_wiki(details, groups, output_dir)
+        index = open(os.path.join(output_dir, "index.md")).read()
+        assert "[mytopic](mytopic.md)" in index
+        assert "1 beliefs across 1 pages" in index
+
+    def test_page_has_back_link(self, tmp_path):
+        output_dir = str(tmp_path / "wiki")
+        details = {
+            "node-a": {"text": "A", "truth_value": "IN", "justifications": [], "dependents": []},
+        }
+        groups = {"topic": ["node-a"]}
+        build_wiki(details, groups, output_dir)
+        page = open(os.path.join(output_dir, "topic.md")).read()
+        assert "[Back to index](index.md)" in page
+
+
+class TestBuildWikiApi:
+
+    def test_creates_wiki_directory(self, db, tmp_path):
+        output_dir = str(tmp_path / "wiki_out")
+        result = api.build_wiki(output_dir=output_dir, db_path=db)
+        assert result["total_nodes"] == 5
+        assert result["pages"] > 0
+        assert os.path.isfile(os.path.join(output_dir, "index.md"))
+
+    def test_status_filter(self, db, tmp_path):
+        api.retract_node("caching-strategy-redis", db_path=db)
+        output_dir = str(tmp_path / "wiki_in")
+        result = api.build_wiki(output_dir=output_dir, status="IN", db_path=db)
+        assert result["total_nodes"] < 5
+
+    def test_empty_db(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        output_dir = str(tmp_path / "wiki_empty")
+        result = api.build_wiki(output_dir=output_dir, db_path=db)
+        assert result["total_nodes"] == 0
+        assert result["pages"] == 0
+        index = open(os.path.join(output_dir, "index.md")).read()
+        assert "No beliefs found" in index
+
+    def test_cross_references_resolve(self, db, tmp_path):
+        output_dir = str(tmp_path / "wiki_xref")
+        api.build_wiki(output_dir=output_dir, db_path=db)
+        found_depends = False
+        for fname in os.listdir(output_dir):
+            if fname == "index.md":
+                continue
+            content = open(os.path.join(output_dir, fname)).read()
+            if "**Depends on:**" in content:
+                found_depends = True
+        assert found_depends
+
+
+class TestBuildWikiCli:
+
+    def test_help(self):
+        stdout, stderr, code = run_cli("build-wiki", "--help")
+        assert code == 0
+        assert "build-wiki" in stdout or "wiki" in stdout
+
+    def test_creates_output(self, db, tmp_path):
+        output_dir = str(tmp_path / "cli_wiki")
+        stdout, stderr, code = run_cli("build-wiki", "-o", output_dir, db_path=db)
+        assert code == 0
+        assert "Wiki written to" in stdout
+        assert os.path.isfile(os.path.join(output_dir, "index.md"))
+
+    def test_status_filter(self, db, tmp_path):
+        output_dir = str(tmp_path / "cli_wiki_in")
+        stdout, stderr, code = run_cli("build-wiki", "-o", output_dir, "--status", "IN", db_path=db)
+        assert code == 0


### PR DESCRIPTION
## Summary
- Adds `reasons build-wiki` command that exports beliefs as a directory of interlinked markdown pages
- Groups beliefs by word-frequency topics (default) or semantic clusters (`--cluster`)
- Each page has cross-reference links between beliefs (depends-on / supports)
- Supports `--status`, `--visible-to`, `--max-topics`, and clustering options (`--n-clusters`, `--seed`, `--embedding-model`)

## Test plan
- [x] 21 new tests in `tests/test_build_wiki.py` covering module functions, API, and CLI
- [x] Full test suite passes (1443 passed)
- [ ] Manual: `reasons build-wiki -o /tmp/test-wiki` and inspect output
- [ ] Manual: `reasons build-wiki -o /tmp/test-wiki-cluster --cluster` with sentence-transformers installed

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)