### PR TITLE
Add report-gated command for problems/open-issues reports

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2449,6 +2449,64 @@ def list_gated(
         return {"blockers": blockers, "gated_count": gated_count, "blocker_count": len(blockers)}
 
 
+def report_gated(
+    visible_to: list[str] | None = None,
+    model: str = "",
+    timeout: int = 300,
+    db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
+) -> dict:
+    """Generate a problems/open-issues report from gated beliefs.
+
+    Returns: {"report": str, "blocker_count": int, "gated_count": int,
+              "retracted_count": int}
+    """
+    from .report_gated import report_gated as _report_gated
+
+    backend = dict(db_path=db_path, pg_conninfo=pg_conninfo,
+                   project_id=project_id)
+    vis = dict(visible_to=visible_to)
+
+    in_nodes = list_nodes(status="IN", **vis, **backend)
+    out_nodes = list_nodes(status="OUT", **vis, **backend)
+    in_count = in_nodes["count"]
+    out_count = out_nodes["count"]
+
+    out_premises = list_nodes(status="OUT", premises_only=True, **vis,
+                              **backend)
+    retracted = []
+    for node in out_premises["nodes"]:
+        detail = show_node(node["id"], **vis, **backend)
+        reason = detail.get("metadata", {}).get("retract_reason")
+        if reason:
+            retracted.append({
+                "id": node["id"],
+                "text": node["text"],
+                "retract_reason": reason,
+                "dependent_count": node["dependent_count"],
+            })
+
+    gated_data = list_gated(**vis, **backend)
+
+    blocker_details = {}
+    for bid in gated_data.get("blockers", {}):
+        detail = show_node(bid, **vis, **backend)
+        blocker_details[bid] = {
+            "dependent_count": len(detail.get("dependents", [])),
+        }
+
+    report = _report_gated(
+        gated_data, retracted, blocker_details,
+        in_count, out_count, model=model, timeout=timeout,
+    )
+    return {
+        "report": report,
+        "blocker_count": gated_data["blocker_count"],
+        "gated_count": gated_data["gated_count"],
+        "retracted_count": len(retracted),
+    }
+
+
 NEGATIVE_BATCH_SIZE = 50
 
 NEGATIVE_TERMS = [

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2490,7 +2490,10 @@ def report_gated(
 
     blocker_details = {}
     for bid in gated_data.get("blockers", {}):
-        detail = show_node(bid, **vis, **backend)
+        try:
+            detail = show_node(bid, **vis, **backend)
+        except (KeyError, PermissionError):
+            detail = {}
         blocker_details[bid] = {
             "dependent_count": len(detail.get("dependents", [])),
         }

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1418,6 +1418,42 @@ def cmd_list_gated(args):
     print(f"{result['blocker_count']} blocker(s) gating {result['gated_count']} belief(s)")
 
 
+def cmd_report_gated(args):
+    model = getattr(args, "model", None) or ""
+    if model:
+        from .llm import reset_cost_tracker
+        reset_cost_tracker()
+
+    result = api.report_gated(
+        visible_to=_parse_visible_to(args),
+        model=model,
+        timeout=args.timeout,
+        **_backend_kwargs(args),
+    )
+
+    report = result["report"]
+    output_path = getattr(args, "output", None)
+    if output_path:
+        with open(output_path, "w") as f:
+            f.write(report)
+        print(f"Report written to {output_path}")
+    else:
+        print(report)
+
+    print(
+        f"  {result['blocker_count']} blocker(s), "
+        f"{result['gated_count']} gated belief(s), "
+        f"{result['retracted_count']} retracted premise(s)",
+        file=sys.stderr,
+    )
+
+    if model:
+        from .llm import format_cost_summary
+        cost = format_cost_summary()
+        if cost:
+            print(f"  {cost}", file=sys.stderr)
+
+
 def cmd_list_negative(args):
     result = api.list_negative(
         visible_to=_parse_visible_to(args),
@@ -2475,6 +2511,14 @@ def main():
     p = sub.add_parser("list-gated", help="List OUT nodes blocked by IN outlist nodes")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
 
+    # report-gated
+    p = sub.add_parser("report-gated", help="Generate a problems/open-issues report from gated beliefs")
+    p.add_argument("-o", "--output", default=None, help="Write report to file (default: stdout)")
+    p.add_argument("-m", "--model", default=None,
+                   help="LLM model for narrative synthesis (default: structured report)")
+    p.add_argument("--timeout", type=int, default=300, help="LLM timeout in seconds (default: 300)")
+    p.add_argument("--visible-to", metavar="TAG,TAG", help="Only include nodes whose access_tags are a subset of these tags")
+
     p = sub.add_parser("list-negative", help="Find IN beliefs describing problems/defects/risks (LLM-classified)")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
     p.add_argument("-m", "--model", default=None,
@@ -2728,6 +2772,7 @@ def main():
         "cluster-list": cmd_cluster_list,
         "list": cmd_list,
         "list-gated": cmd_list_gated,
+        "report-gated": cmd_report_gated,
         "list-negative": cmd_list_negative,
         "topics": cmd_topics,
         "build-wiki": cmd_build_wiki,

--- a/reasons_lib/report_gated.py
+++ b/reasons_lib/report_gated.py
@@ -63,9 +63,10 @@ def _build_structured_report(in_count, out_count, gated_data, retracted_premises
         for rp in sorted(retracted_premises, key=lambda r: -r["dependent_count"]):
             dep = rp["dependent_count"]
             impact = f"{dep} dependent(s)" if dep else "no dependents"
+            text = rp["text"][:80].replace("|", "\\|")
+            reason = rp["retract_reason"].replace("|", "\\|")
             lines.append(
-                f"| `{rp['id']}` — {rp['text'][:80]} | {impact} "
-                f"| {rp['retract_reason']} |"
+                f"| `{rp['id']}` — {text} | {impact} | {reason} |"
             )
         lines.append("")
 

--- a/reasons_lib/report_gated.py
+++ b/reasons_lib/report_gated.py
@@ -1,0 +1,188 @@
+"""Generate a problems/open-issues report from gated beliefs.
+
+Identifies retracted premises (fixed defects) and active IN blockers
+(open problems), then generates a structured markdown report.  Optionally
+uses an LLM to synthesize a narrative version.
+"""
+
+from datetime import date
+
+
+REPORT_GATED_PROMPT = """\
+You are generating a problems and open issues report for a belief network \
+(Truth Maintenance System).  The report should be a clear, professional \
+markdown document suitable for stakeholders who want to understand the \
+current state of known issues and what has already been fixed.
+
+## Guidelines
+
+- Write in clear, professional prose
+- Use markdown headers (##, ###) to organize sections
+- Start with a brief Summary section with overall statistics
+- Include a "Fixed Defects" section for retracted premises — these are \
+  solved problems.  For each, mention the belief ID in backticks, its \
+  description, how it was resolved, and its downstream impact (number of \
+  dependent beliefs affected)
+- Include an "Open Problems" section for active blockers, numbered.  For \
+  each, include its description, the number of gated beliefs it blocks, \
+  and the IDs of those gated beliefs
+- Include a brief "Impact Analysis" section discussing themes and priorities
+- Reference belief IDs in backticks when mentioned
+- Do NOT invent information not present in the data
+- Do NOT include a title — the report already has one
+
+## Network Data
+
+{data}
+
+Write the report now.
+"""
+
+
+def _build_structured_report(in_count, out_count, gated_data, retracted_premises,
+                             blocker_details):
+    """Generate a structured markdown report without an LLM."""
+    lines = []
+    lines.append("# Gated Beliefs Report")
+    lines.append("")
+
+    blocker_count = gated_data["blocker_count"]
+    gated_count = gated_data["gated_count"]
+    today = date.today().isoformat()
+    lines.append(
+        f"*Generated {today} — {in_count} IN / {out_count} OUT beliefs, "
+        f"{blocker_count} active blocker(s) gating {gated_count} belief(s)*"
+    )
+    lines.append("")
+
+    if retracted_premises:
+        lines.append("## Fixed Defects (Retracted Premises)")
+        lines.append("")
+        lines.append("| Defect | Impact | Resolution |")
+        lines.append("|--------|--------|------------|")
+        for rp in sorted(retracted_premises, key=lambda r: -r["dependent_count"]):
+            dep = rp["dependent_count"]
+            impact = f"{dep} dependent(s)" if dep else "no dependents"
+            lines.append(
+                f"| `{rp['id']}` — {rp['text'][:80]} | {impact} "
+                f"| {rp['retract_reason']} |"
+            )
+        lines.append("")
+
+    blockers = gated_data.get("blockers", {})
+    if blockers:
+        lines.append("## Active Blockers")
+        lines.append("")
+        for i, (bid, bdata) in enumerate(
+            sorted(blockers.items(), key=lambda kv: -len(kv[1]["gated"])), 1
+        ):
+            detail = blocker_details.get(bid, {})
+            dep_count = detail.get("dependent_count", 0)
+            gated = bdata["gated"]
+            lines.append(f"### {i}. `{bid}`")
+            lines.append("")
+            lines.append(bdata["text"])
+            lines.append("")
+            lines.append(
+                f"**Gates {len(gated)} belief(s)** "
+                f"| {dep_count} total dependent(s)"
+            )
+            lines.append("")
+            for g in sorted(gated, key=lambda g: g["id"]):
+                lines.append(f"- `{g['id']}`: {g['text'][:100]}")
+            lines.append("")
+    elif not retracted_premises:
+        lines.append("No blockers or retracted premises found.")
+        lines.append("")
+
+    lines.append("## Methodology")
+    lines.append("")
+    lines.append(
+        "This report was generated from the belief network using "
+        "`reasons list-gated` (active blockers), retracted premises with "
+        "`retract_reason` metadata (fixed defects), and `reasons show` "
+        "for impact counts."
+    )
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _format_data_for_prompt(in_count, out_count, gated_data, retracted_premises,
+                            blocker_details):
+    """Format all gathered data into structured text for the LLM prompt."""
+    lines = []
+    lines.append(f"Total beliefs: {in_count} IN, {out_count} OUT")
+    lines.append(
+        f"Blockers: {gated_data['blocker_count']} gating "
+        f"{gated_data['gated_count']} belief(s)"
+    )
+    lines.append(f"Retracted premises (fixed defects): {len(retracted_premises)}")
+    lines.append("")
+
+    if retracted_premises:
+        lines.append("### Fixed Defects")
+        lines.append("")
+        for rp in sorted(retracted_premises, key=lambda r: -r["dependent_count"]):
+            lines.append(f"ID: {rp['id']}")
+            lines.append(f"Text: {rp['text']}")
+            lines.append(f"Retract reason: {rp['retract_reason']}")
+            lines.append(f"Dependent count: {rp['dependent_count']}")
+            lines.append("")
+
+    blockers = gated_data.get("blockers", {})
+    if blockers:
+        lines.append("### Active Blockers")
+        lines.append("")
+        for bid, bdata in sorted(
+            blockers.items(), key=lambda kv: -len(kv[1]["gated"])
+        ):
+            detail = blocker_details.get(bid, {})
+            lines.append(f"Blocker ID: {bid}")
+            lines.append(f"Blocker text: {bdata['text']}")
+            lines.append(f"Total dependents: {detail.get('dependent_count', 0)}")
+            lines.append(f"Gates {len(bdata['gated'])} belief(s):")
+            for g in sorted(bdata["gated"], key=lambda g: g["id"]):
+                lines.append(f"  - {g['id']}: {g['text']}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_report(data_text, model, timeout):
+    """Generate a narrative report using an LLM."""
+    from .llm import invoke_model
+
+    prompt = REPORT_GATED_PROMPT.format(data=data_text)
+    return invoke_model(prompt, model=model, timeout=timeout)
+
+
+def report_gated(gated_data, retracted_premises, blocker_details,
+                 in_count, out_count, model="", timeout=300):
+    """Generate a gated-beliefs report.
+
+    Returns a markdown string — either structured (default) or
+    LLM-synthesized (when model is set).
+    """
+    if model:
+        data_text = _format_data_for_prompt(
+            in_count, out_count, gated_data, retracted_premises,
+            blocker_details,
+        )
+        content = generate_report(data_text, model, timeout)
+        lines = ["# Gated Beliefs Report", ""]
+        today = date.today().isoformat()
+        lines.append(
+            f"*Generated {today} — {in_count} IN / {out_count} OUT beliefs, "
+            f"{gated_data['blocker_count']} active blocker(s) gating "
+            f"{gated_data['gated_count']} belief(s)*"
+        )
+        lines.append("")
+        lines.append(content)
+        lines.append("")
+        return "\n".join(lines)
+
+    return _build_structured_report(
+        in_count, out_count, gated_data, retracted_premises,
+        blocker_details,
+    )

--- a/tests/test_report_gated.py
+++ b/tests/test_report_gated.py
@@ -9,8 +9,7 @@ import pytest
 
 from reasons_lib import api
 from reasons_lib.report_gated import (
-    _build_structured_report, _format_data_for_prompt, generate_report,
-    report_gated,
+    _build_structured_report, _format_data_for_prompt, report_gated,
 )
 
 

--- a/tests/test_report_gated.py
+++ b/tests/test_report_gated.py
@@ -1,0 +1,258 @@
+"""Tests for the report-gated command."""
+
+import os
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from reasons_lib import api
+from reasons_lib.report_gated import (
+    _build_structured_report, _format_data_for_prompt, generate_report,
+    report_gated,
+)
+
+
+def run_cli(*args, db_path=None):
+    from reasons_lib.cli import main
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+            code = 0
+        except SystemExit as e:
+            code = e.code if e.code is not None else 0
+    return stdout.getvalue(), stderr.getvalue(), code
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Network with a blocker, gated belief, retracted premise, and normal nodes."""
+    db_path = str(tmp_path / "test.db")
+    api.add_node("normal-premise-a", "A normal IN premise", db_path=db_path)
+    api.add_node("normal-premise-b", "Another IN premise", db_path=db_path)
+    api.add_node("blocker-x", "This blocks a conclusion", db_path=db_path)
+    api.add_node("support-for-gated", "Support node", db_path=db_path)
+    api.add_node("gated-conclusion", "Would be true if blocker removed",
+                 sl="support-for-gated", unless="blocker-x", db_path=db_path)
+    api.add_node("retracted-defect", "A bug that was fixed", db_path=db_path)
+    api.retract_node("retracted-defect", reason="Fixed in PR #99",
+                     db_path=db_path)
+    return db_path
+
+
+class TestBuildStructuredReport:
+
+    def _make_gated_data(self, blockers=None):
+        if blockers is None:
+            blockers = {
+                "blocker-a": {
+                    "text": "Blocker A text",
+                    "gated": [{"id": "gated-1", "text": "Gated node 1"}],
+                },
+            }
+        gated_count = sum(len(b["gated"]) for b in blockers.values())
+        return {
+            "blockers": blockers,
+            "blocker_count": len(blockers),
+            "gated_count": gated_count,
+        }
+
+    def test_includes_title(self):
+        gated = self._make_gated_data()
+        result = _build_structured_report(10, 5, gated, [], {})
+        assert "# Gated Beliefs Report" in result
+
+    def test_includes_summary_stats(self):
+        gated = self._make_gated_data()
+        result = _build_structured_report(100, 50, gated, [], {})
+        assert "100 IN / 50 OUT" in result
+        assert "1 active blocker(s)" in result
+
+    def test_includes_retracted_premises(self):
+        gated = self._make_gated_data({})
+        retracted = [{
+            "id": "fixed-bug",
+            "text": "A bug that existed",
+            "retract_reason": "Fixed in PR #42",
+            "dependent_count": 5,
+        }]
+        result = _build_structured_report(10, 5, gated, retracted, {})
+        assert "Fixed Defects" in result
+        assert "`fixed-bug`" in result
+        assert "Fixed in PR #42" in result
+        assert "5 dependent(s)" in result
+
+    def test_includes_active_blockers(self):
+        gated = self._make_gated_data()
+        details = {"blocker-a": {"dependent_count": 3}}
+        result = _build_structured_report(10, 5, gated, [], details)
+        assert "`blocker-a`" in result
+        assert "Blocker A text" in result
+        assert "Gates 1 belief(s)" in result
+        assert "`gated-1`" in result
+
+    def test_empty_network(self):
+        gated = self._make_gated_data({})
+        result = _build_structured_report(0, 0, gated, [], {})
+        assert "# Gated Beliefs Report" in result
+        assert "0 IN / 0 OUT" in result
+        assert "No blockers or retracted premises found." in result
+
+    def test_no_retracted_premises(self):
+        gated = self._make_gated_data()
+        result = _build_structured_report(10, 5, gated, [], {})
+        assert "Fixed Defects" not in result
+
+    def test_blockers_sorted_by_gated_count(self):
+        gated = self._make_gated_data({
+            "blocker-few": {
+                "text": "Few",
+                "gated": [{"id": "g1", "text": "one"}],
+            },
+            "blocker-many": {
+                "text": "Many",
+                "gated": [
+                    {"id": "g2", "text": "two"},
+                    {"id": "g3", "text": "three"},
+                    {"id": "g4", "text": "four"},
+                ],
+            },
+        })
+        result = _build_structured_report(10, 5, gated, [], {})
+        pos_many = result.index("`blocker-many`")
+        pos_few = result.index("`blocker-few`")
+        assert pos_many < pos_few
+
+
+class TestFormatDataForPrompt:
+
+    def test_includes_counts(self):
+        gated = {"blockers": {}, "blocker_count": 0, "gated_count": 0}
+        result = _format_data_for_prompt(50, 20, gated, [], {})
+        assert "50 IN" in result
+        assert "20 OUT" in result
+
+    def test_includes_retracted(self):
+        gated = {"blockers": {}, "blocker_count": 0, "gated_count": 0}
+        retracted = [{
+            "id": "old-bug",
+            "text": "Old bug text",
+            "retract_reason": "Fixed",
+            "dependent_count": 3,
+        }]
+        result = _format_data_for_prompt(10, 5, gated, retracted, {})
+        assert "old-bug" in result
+        assert "Old bug text" in result
+        assert "Fixed" in result
+
+    def test_includes_blockers(self):
+        gated = {
+            "blockers": {
+                "b1": {"text": "Blocker text", "gated": [{"id": "g1", "text": "Gated"}]},
+            },
+            "blocker_count": 1,
+            "gated_count": 1,
+        }
+        result = _format_data_for_prompt(10, 5, gated, [], {"b1": {"dependent_count": 2}})
+        assert "b1" in result
+        assert "Blocker text" in result
+        assert "g1" in result
+
+
+class TestReportGatedApi:
+
+    def test_returns_report_string(self, db):
+        result = api.report_gated(db_path=db)
+        assert "# Gated Beliefs Report" in result["report"]
+        assert isinstance(result["report"], str)
+
+    def test_counts_match(self, db):
+        result = api.report_gated(db_path=db)
+        assert result["blocker_count"] == 1
+        assert result["gated_count"] == 1
+        assert result["retracted_count"] == 1
+
+    def test_report_contains_blocker(self, db):
+        result = api.report_gated(db_path=db)
+        assert "blocker-x" in result["report"]
+        assert "gated-conclusion" in result["report"]
+
+    def test_report_contains_retracted(self, db):
+        result = api.report_gated(db_path=db)
+        assert "retracted-defect" in result["report"]
+        assert "Fixed in PR #99" in result["report"]
+
+    def test_empty_db(self, tmp_path):
+        db = str(tmp_path / "empty.db")
+        result = api.report_gated(db_path=db)
+        assert result["blocker_count"] == 0
+        assert result["gated_count"] == 0
+        assert result["retracted_count"] == 0
+        assert "# Gated Beliefs Report" in result["report"]
+
+
+class TestReportGatedLlm:
+
+    def test_llm_mode_calls_invoke_model(self):
+        gated = {
+            "blockers": {"b1": {"text": "T", "gated": [{"id": "g1", "text": "G"}]}},
+            "blocker_count": 1, "gated_count": 1,
+        }
+        with patch("reasons_lib.llm.invoke_model",
+                    return_value="LLM narrative") as mock:
+            result = report_gated(gated, [], {}, 10, 5, model="claude")
+            mock.assert_called_once()
+            assert "LLM narrative" in result
+
+    def test_no_model_no_invoke(self):
+        gated = {"blockers": {}, "blocker_count": 0, "gated_count": 0}
+        with patch("reasons_lib.llm.invoke_model") as mock:
+            report_gated(gated, [], {}, 10, 5)
+            mock.assert_not_called()
+
+    def test_llm_includes_title_and_stats(self):
+        gated = {"blockers": {}, "blocker_count": 0, "gated_count": 0}
+        with patch("reasons_lib.llm.invoke_model",
+                    return_value="Some content"):
+            result = report_gated(gated, [], {}, 10, 5, model="claude")
+            assert "# Gated Beliefs Report" in result
+            assert "10 IN / 5 OUT" in result
+
+    def test_api_passes_model_through(self, db):
+        with patch("reasons_lib.llm.invoke_model",
+                    return_value="Generated report") as mock:
+            result = api.report_gated(model="claude", db_path=db)
+        assert mock.call_count == 1
+        assert "Generated report" in result["report"]
+
+
+class TestReportGatedCli:
+
+    def test_help(self):
+        stdout, stderr, code = run_cli("report-gated", "--help")
+        assert code == 0
+        assert "report-gated" in stdout or "report" in stdout
+
+    def test_stdout_output(self, db):
+        stdout, stderr, code = run_cli("report-gated", db_path=db)
+        assert code == 0
+        assert "# Gated Beliefs Report" in stdout
+        assert "blocker(s)" in stderr
+
+    def test_file_output(self, db, tmp_path):
+        out_file = str(tmp_path / "report.md")
+        stdout, stderr, code = run_cli("report-gated", "-o", out_file,
+                                       db_path=db)
+        assert code == 0
+        assert "Report written to" in stdout
+        assert os.path.isfile(out_file)
+        content = open(out_file).read()
+        assert "# Gated Beliefs Report" in content


### PR DESCRIPTION
## Summary

- New `reasons report-gated` command that generates a markdown report combining gated beliefs (open problems) and retracted premises (fixed defects)
- Structured mode (default) produces formatted markdown with summary stats, fixed defects table sorted by impact, and numbered active blockers with their gated beliefs
- LLM mode (`--model`) sends the data to an LLM for narrative synthesis into a professional report
- New module `report_gated.py`, API function `api.report_gated()`, CLI with `-o`/`--model`/`--timeout`/`--visible-to`

## Test plan

- [x] 22 new tests in `test_report_gated.py` (structured report, API integration, LLM mode with mocks, CLI)
- [x] Full test suite passes (1479 passed)
- [x] Smoke-tested on ftl-reasons-expert (715 IN / 386 OUT, 8 blockers, 18 retracted premises)

🤖 Generated with [Claude Code](https://claude.com/claude-code)