### PR TITLE
Add research repair triage pattern

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -3146,7 +3146,7 @@ def repair(
     dry_run: bool = False,
     db_path: str = DEFAULT_DB,
 ) -> dict:
-    """Repair flagged beliefs: triage into search-and-link, soften, or abandon.
+    """Repair flagged beliefs: triage into search-and-link, soften, abandon, or research.
 
     Two input modes:
         review_file: path to a review-beliefs JSON report

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -811,6 +811,27 @@ def update_node(
         return {"node_id": node_id, "updated_fields": updated}
 
 
+def set_metadata(
+    node_id: str,
+    key: str,
+    value,
+    db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
+) -> dict:
+    """Set a single metadata key on a node."""
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "set_metadata",
+                            node_id=node_id, key=key, value=value)
+    with _with_network(db_path, write=True) as net:
+        if node_id not in net.nodes:
+            raise KeyError(f"Node '{node_id}' not found")
+        node = net.nodes[node_id]
+        meta = node.metadata or {}
+        meta[key] = value
+        node.metadata = meta
+        return {"node_id": node_id, "key": key}
+
+
 def challenge(
     target_id: str,
     reason: str,
@@ -3158,6 +3179,7 @@ def repair(
             "linked": 0,
             "softened": 0,
             "abandoned": 0,
+            "needs_research": 0,
             "failed": 0,
             "errors": 0,
         }
@@ -3176,6 +3198,7 @@ def repair(
         "linked": sum(1 for r in results if r["status"] == "linked"),
         "softened": sum(1 for r in results if r["status"] == "softened"),
         "abandoned": sum(1 for r in results if r["status"] == "abandoned"),
+        "needs_research": sum(1 for r in results if r["status"] == "needs_research"),
         "failed": sum(1 for r in results if r["status"] in
                        ("triage_failed", "no_candidates", "no_match",
                         "soften_failed", "extraction_failed")),

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -2019,8 +2019,8 @@ def cmd_repair(args):
 
     print(f"\nTotal invalid: {result['total_invalid']}")
     print(f"  Linked: {result['linked']}  Softened: {result['softened']}"
-          f"  Abandoned: {result['abandoned']}  Failed: {result['failed']}"
-          f"  Errors: {result['errors']}")
+          f"  Abandoned: {result['abandoned']}  Research: {result['needs_research']}"
+          f"  Failed: {result['failed']}  Errors: {result['errors']}")
 
     if args.dry_run:
         print("\n  (dry run -- no changes applied)")

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1464,6 +1464,25 @@ class PgApi:
         self.conn.commit()
         return {"node_id": node_id, "updated_fields": updated_fields}
 
+    def set_metadata(self, node_id, key, value):
+        pid = self.project_id
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "SELECT metadata_json FROM rms_nodes WHERE id = %s AND project_id = %s",
+                (node_id, pid),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise KeyError(f"Node '{node_id}' not found")
+            meta = json.loads(row[0]) if row[0] else {}
+            meta[key] = value
+            cur.execute(
+                "UPDATE rms_nodes SET metadata_json = %s WHERE id = %s AND project_id = %s",
+                (json.dumps(meta), node_id, pid),
+            )
+        self.conn.commit()
+        return {"node_id": node_id, "key": key}
+
     def convert_to_premise(self, node_id):
         pid = self.project_id
         with self.conn.cursor() as cur:

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1437,7 +1437,7 @@ class PgApi:
 
         with self.conn.cursor() as cur:
             cur.execute(
-                "SELECT id, metadata_json FROM rms_nodes WHERE id = %s AND project_id = %s",
+                "SELECT id, metadata FROM rms_nodes WHERE id = %s AND project_id = %s",
                 (node_id, pid),
             )
             row = cur.fetchone()
@@ -1447,7 +1447,7 @@ class PgApi:
             if example is not None:
                 meta = json.loads(row[1]) if row[1] else {}
                 meta["example"] = example
-                updates.append("metadata_json = %s")
+                updates.append("metadata = %s")
                 params.append(json.dumps(meta))
                 updated_fields.append("example")
 
@@ -1468,7 +1468,7 @@ class PgApi:
         pid = self.project_id
         with self.conn.cursor() as cur:
             cur.execute(
-                "SELECT metadata_json FROM rms_nodes WHERE id = %s AND project_id = %s",
+                "SELECT metadata FROM rms_nodes WHERE id = %s AND project_id = %s",
                 (node_id, pid),
             )
             row = cur.fetchone()
@@ -1477,7 +1477,7 @@ class PgApi:
             meta = json.loads(row[0]) if row[0] else {}
             meta[key] = value
             cur.execute(
-                "UPDATE rms_nodes SET metadata_json = %s WHERE id = %s AND project_id = %s",
+                "UPDATE rms_nodes SET metadata = %s WHERE id = %s AND project_id = %s",
                 (json.dumps(meta), node_id, pid),
             )
         self.conn.commit()

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -362,8 +362,8 @@ def repair_beliefs(review_results, nodes, model="claude",
                      search_fn=None):
     """Orchestrate triage and repair for invalid beliefs.
 
-    Triages each invalid belief into search_and_link, soften, or abandon,
-    then executes the appropriate pattern.
+    Triages each invalid belief into search_and_link, soften, abandon, or
+    research, then executes the appropriate pattern.
 
     Returns list of repair result dicts.
     """

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -96,8 +96,14 @@ Your task: decide which repair pattern is most appropriate.
    removed from the evidence to repair. Choose this when neither linking nor softening
    can make the derivation sound.
 
+4. **research** — The claim is plausible but cannot be confirmed or denied from the
+   current evidence in the network. Further investigation (code reading, testing,
+   documentation review) could validate or refine it. Choose this when the belief is
+   worth preserving pending more information, rather than abandoning or weakening
+   prematurely.
+
 Respond with ONLY a JSON object:
-{{"pattern": "search_and_link" | "soften" | "abandon", "rationale": "brief explanation"}}"""
+{{"pattern": "search_and_link" | "soften" | "abandon" | "research", "rationale": "brief explanation"}}"""
 
 SOFTEN_PROMPT = """\
 You are rewriting a derived belief to match what its antecedents actually support.
@@ -118,7 +124,7 @@ Preserve the core insight but remove unsupported specificity.
 Respond with ONLY a JSON object:
 {{"softened_text": "the rewritten claim", "rationale": "what was weakened and why"}}"""
 
-VALID_PATTERNS = {"search_and_link", "soften", "abandon"}
+VALID_PATTERNS = {"search_and_link", "soften", "abandon", "research"}
 
 
 def parse_extract_response(response):
@@ -458,6 +464,17 @@ def repair_beliefs(review_results, nodes, model="claude",
                         db_path=db_path,
                     )
                 result["status"] = "abandoned"
+
+            elif pattern == "research":
+                print(f"  Pattern: research for {belief_id}...",
+                      file=sys.stderr)
+                if not dry_run:
+                    api.set_metadata(
+                        belief_id, "repair_research",
+                        triage.get("rationale", ""),
+                        db_path=db_path,
+                    )
+                result["status"] = "needs_research"
 
         except Exception as exc:
             result["error"] = str(exc)

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -93,6 +93,12 @@ class TestParseTriageResponse:
         result = parse_triage_response(resp)
         assert result["pattern"] == "abandon"
 
+    def test_valid_research(self):
+        resp = '{"pattern": "research", "rationale": "needs investigation"}'
+        result = parse_triage_response(resp)
+        assert result["pattern"] == "research"
+        assert result["rationale"] == "needs investigation"
+
     def test_invalid_pattern_ignored(self):
         resp = '{"pattern": "unknown", "rationale": "hmm"}'
         result = parse_triage_response(resp)
@@ -273,6 +279,49 @@ class TestResearchBeliefs:
         mock_retract.assert_called_once()
         assert "abandoned" in mock_retract.call_args[1]["reason"]
 
+    def test_research_pattern(self):
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "needs more evidence",
+        }]
+        triage_resp = _mock_result('{"pattern": "research", "rationale": "needs code review"}')
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp]), \
+             patch("reasons_lib.api.set_metadata") as mock_meta:
+            results = repair_beliefs(
+                review_results, nodes, db_path="test.db",
+                search_fn=_mock_search([]),
+            )
+
+        assert results[0]["pattern"] == "research"
+        assert results[0]["status"] == "needs_research"
+        mock_meta.assert_called_once_with(
+            "derived-boil", "repair_research", "needs code review",
+            db_path="test.db",
+        )
+
+    def test_research_dry_run_no_metadata(self):
+        nodes = _make_nodes()
+        review_results = [{
+            "id": "derived-boil", "valid": False, "comment": "needs more evidence",
+        }]
+        triage_resp = _mock_result('{"pattern": "research", "rationale": "needs investigation"}')
+
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run",
+                   side_effect=[triage_resp]), \
+             patch("reasons_lib.api.set_metadata") as mock_meta:
+            results = repair_beliefs(
+                review_results, nodes, db_path="test.db", dry_run=True,
+                search_fn=_mock_search([]),
+            )
+
+        assert results[0]["pattern"] == "research"
+        assert results[0]["status"] == "needs_research"
+        mock_meta.assert_not_called()
+
     def test_triage_failed(self):
         nodes = _make_nodes()
         review_results = [{
@@ -323,7 +372,8 @@ class TestResearchBeliefs:
                    side_effect=[triage_resp, soften_resp]), \
              patch("reasons_lib.api.update_node") as mock_update, \
              patch("reasons_lib.api.retract_node") as mock_retract, \
-             patch("reasons_lib.api.add_justification") as mock_add:
+             patch("reasons_lib.api.add_justification") as mock_add, \
+             patch("reasons_lib.api.set_metadata") as mock_meta:
             results = repair_beliefs(
                 review_results, nodes, db_path="test.db", dry_run=True,
                 search_fn=_mock_search([]),
@@ -333,6 +383,7 @@ class TestResearchBeliefs:
         mock_update.assert_not_called()
         mock_retract.assert_not_called()
         mock_add.assert_not_called()
+        mock_meta.assert_not_called()
 
     def test_multiple_beliefs_different_patterns(self):
         nodes = _make_nodes()


### PR DESCRIPTION
## Summary

- Adds a fourth repair triage pattern **research** alongside search_and_link, soften, and abandon
- Beliefs triaged as "research" are tagged with `repair_research` metadata for a later research phase, preserving them rather than prematurely abandoning
- Adds `api.set_metadata()` utility for setting individual metadata keys on nodes
- Updates CLI summary output to show research count

## Test plan

- [x] New `test_valid_research` parse test
- [x] New `test_research_pattern` verifies metadata is set
- [x] New `test_research_dry_run_no_metadata` verifies dry run skips metadata
- [x] Updated `test_dry_run_no_mutations` also asserts `set_metadata` not called
- [x] All 1484 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)