### PR TITLE
Expand NEGATIVE_TERMS and add --no-llm flag to list-negative

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -2539,11 +2539,20 @@ NEGATIVE_TERMS = [
     'outdated', 'deprecated', 'fragile', 'brittle', 'hack', 'workaround',
     'technical debt', 'tech debt', 'not implemented', 'unimplemented',
     'incomplete', 'inconsistent', 'unclear', 'confusing', 'problem',
-    'issue', 'concern', 'warning', 'danger', 'threat', 'weakness',
-    'limitation', 'constraint', 'bottleneck', 'blocker', 'obstacle',
-    'undermines', 'concentrated', 'single point of failure', 'no tests',
-    'untested', 'not tested', 'hard-coded', 'hardcoded', 'tight coupling',
-    'tightly coupled', 'monolithic', 'legacy', 'unmaintained',
+    'known issue', 'security issue', 'concern', 'warning', 'danger',
+    'threat', 'weakness', 'limitation', 'constraint', 'bottleneck',
+    'blocker', 'obstacle', 'undermines', 'concentrated',
+    'single point of failure', 'no tests', 'untested', 'not tested',
+    'hard-coded', 'hardcoded', 'tight coupling', 'tightly coupled',
+    'monolithic', 'legacy', 'unmaintained',
+    'blocked', 'blocking', 'deferred', 'stalled', 'unresolved',
+    'disabled', 'skipped',
+    'sole', 'empty', 'placeholder', 'regression', 'corrupted',
+    'orphaned', 'zombie',
+    'absent', 'absence', 'invisible', 'silent', 'hollow', 'vacuum',
+    'debt', 'overhead', 'degradation', 'deficit', 'friction',
+    'undocumented', 'unverified',
+    'dysfunction', 'opacity', 'opaque', 'isolated', 'permanently',
 ]
 
 NEGATIVE_CLASSIFY_PROMPT = """\
@@ -2567,19 +2576,22 @@ If none are genuinely negative, return: []
 def list_negative(
     visible_to: list[str] | None = None,
     model: str = "claude",
+    skip_llm: bool = False,
     db_path: str = DEFAULT_DB,
     pg_conninfo=None, project_id=None,
 ) -> dict:
     """Find IN beliefs that describe problems, defects, or risks.
 
-    Uses keyword pre-filtering then LLM classification via an LLM.
+    Uses keyword pre-filtering then LLM classification.
+    With skip_llm=True, returns keyword-filtered candidates directly.
 
     Returns: {"negative": [{"id": str, "text": str}, ...],
               "count": int, "candidates": int, "total": int}
     """
     if pg_conninfo:
         return _pg_dispatch(pg_conninfo, project_id, "list_negative",
-                            visible_to=visible_to, model=model)
+                            visible_to=visible_to, model=model,
+                            skip_llm=skip_llm)
     from . import ask
 
     with _with_network(db_path) as net:
@@ -2605,6 +2617,14 @@ def list_negative(
 
         if not candidates:
             return empty
+
+        if skip_llm:
+            return {
+                "negative": [{"id": nid, "text": text} for nid, text in candidates],
+                "count": len(candidates),
+                "candidates": len(candidates),
+                "total": total,
+            }
 
         from .llm import invoke_model
 

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -1458,6 +1458,7 @@ def cmd_list_negative(args):
     result = api.list_negative(
         visible_to=_parse_visible_to(args),
         model=getattr(args, "model", None) or "claude",
+        skip_llm=getattr(args, "no_llm", False),
         **_backend_kwargs(args),
     )
 
@@ -2523,6 +2524,8 @@ def main():
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
     p.add_argument("-m", "--model", default=None,
                    help="Model to use (default: claude). Prefixes: ollama:<model>, api:<model>, vertex:<model>")
+    p.add_argument("--no-llm", action="store_true",
+                   help="Skip LLM classification; return keyword-filtered candidates directly")
 
     sub.add_parser("namespaces", help="List all agent namespaces in the database")
 

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -1018,11 +1018,10 @@ class PgApi:
             return {k: Path(v) for k, v in result["repos"].items()}
         return None
 
-    def list_negative(self, visible_to=None, model="claude"):
+    def list_negative(self, visible_to=None, model="claude", skip_llm=False):
         """Find IN beliefs describing problems/defects/risks."""
         import sys
         from .api import NEGATIVE_TERMS, NEGATIVE_CLASSIFY_PROMPT, NEGATIVE_BATCH_SIZE
-        from .llm import invoke_model
 
         pid = self.project_id
 
@@ -1057,6 +1056,16 @@ class PgApi:
 
         if not candidates:
             return empty
+
+        if skip_llm:
+            return {
+                "negative": [{"id": nid, "text": text} for nid, text in candidates],
+                "count": len(candidates),
+                "candidates": len(candidates),
+                "total": total,
+            }
+
+        from .llm import invoke_model
 
         negative_ids = set()
         total_batches = (len(candidates) + NEGATIVE_BATCH_SIZE - 1) // NEGATIVE_BATCH_SIZE

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -575,6 +575,34 @@ class TestListNegative:
         found_ids = {n["id"] for n in result["negative"]}
         assert found_ids == {"bug-010", "bug-020", "bug-060"}
 
+    def test_expanded_terms_match(self, db_path):
+        api.add_node("a", "The migration is stalled due to schema conflicts", db_path=db_path)
+        api.add_node("b", "There is a regression in the auth flow", db_path=db_path)
+        api.add_node("c", "The API docs are undocumented for v2", db_path=db_path)
+        api.add_node("d", "Everything works fine", db_path=db_path)
+        with patch("reasons_lib.llm.invoke_model", return_value='["a", "b", "c"]'):
+            result = api.list_negative(db_path=db_path)
+            assert result["candidates"] == 3
+            assert result["total"] == 4
+
+    def test_issue_false_positive_excluded(self, db_path):
+        api.add_node("jira-ref", "The child issue was closed last sprint", db_path=db_path)
+        api.add_node("real-neg", "There is a known issue in the auth module", db_path=db_path)
+        with patch("reasons_lib.llm.invoke_model", return_value='["real-neg"]') as mock_llm:
+            result = api.list_negative(db_path=db_path)
+            assert result["candidates"] == 1
+            assert result["negative"][0]["id"] == "real-neg"
+
+    def test_skip_llm(self, db_path):
+        api.add_node("a", "There is a critical bug here", db_path=db_path)
+        api.add_node("b", "Everything is fine", db_path=db_path)
+        with patch("reasons_lib.llm.invoke_model") as mock_llm:
+            result = api.list_negative(skip_llm=True, db_path=db_path)
+            mock_llm.assert_not_called()
+            assert result["count"] == 1
+            assert result["candidates"] == 1
+            assert result["negative"][0]["id"] == "a"
+
 
 class TestUpdateNode:
 

--- a/tests/test_pg_dispatch.py
+++ b/tests/test_pg_dispatch.py
@@ -518,7 +518,8 @@ class TestListNegativeDispatch:
             MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
             MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
             result = list_negative(pg_conninfo="postgresql://...", project_id="test")
-        mock_pg.list_negative.assert_called_once_with(visible_to=None, model="claude")
+        mock_pg.list_negative.assert_called_once_with(visible_to=None, model="claude",
+                                                          skip_llm=False)
         assert result["count"] == 1
 
     def test_passes_visible_to_and_model(self):
@@ -532,7 +533,7 @@ class TestListNegativeDispatch:
             result = list_negative(visible_to=["admin"], model="gemini",
                                    pg_conninfo="postgresql://...", project_id="test")
         mock_pg.list_negative.assert_called_once_with(
-            visible_to=["admin"], model="gemini")
+            visible_to=["admin"], model="gemini", skip_llm=False)
         assert result["total"] == 5
 
 


### PR DESCRIPTION
## Summary

- Adds ~30 missing negative terms to the keyword pre-filter (blocked, stalled, regression, undocumented, zombie, etc.)
- Replaces bare `issue` with `known issue` / `security issue` to eliminate ~184 Jira-context false positives
- Adds `--no-llm` flag to skip LLM classification and return keyword-filtered candidates directly

Closes #207

## Test plan

- [x] `test_expanded_terms_match` — new terms (stalled, regression, undocumented) are matched by keyword filter
- [x] `test_issue_false_positive_excluded` — bare "issue" no longer matches; "known issue" does
- [x] `test_skip_llm` — `--no-llm` returns keyword candidates without calling LLM
- [x] PG dispatch tests updated for new `skip_llm` parameter
- [x] All 1487 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)