### PR TITLE
Add set-metadata CLI command

### DIFF
--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -383,6 +383,18 @@ def cmd_update(args):
     print(f"Updated {result['node_id']} ({fields})")
 
 
+def cmd_set_metadata(args):
+    try:
+        result = api.set_metadata(
+            args.node_id, args.key, args.value,
+            **_backend_kwargs(args),
+        )
+    except KeyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Set {result['key']} on {result['node_id']}")
+
+
 def cmd_challenge(args):
     try:
         result = api.challenge(
@@ -2219,6 +2231,12 @@ def main():
     p.add_argument("--source-url", default=None, help="Update source URL")
     p.add_argument("--example", default=None, help="Code example demonstrating the belief")
 
+    # set-metadata
+    p = sub.add_parser("set-metadata", help="Set a metadata key on a belief")
+    p.add_argument("node_id", help="Belief to update")
+    p.add_argument("key", help="Metadata key")
+    p.add_argument("value", help="Metadata value")
+
     # challenge
     p = sub.add_parser("challenge", help="Challenge a node — target goes OUT")
     p.add_argument("target_id", help="Node to challenge")
@@ -2763,6 +2781,7 @@ def main():
         "summarize": cmd_summarize,
         "supersede": cmd_supersede,
         "update": cmd_update,
+        "set-metadata": cmd_set_metadata,
         "challenge": cmd_challenge,
         "defend": cmd_defend,
         "trace": cmd_trace,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -652,6 +652,30 @@ class TestUpdateNode:
         assert node["truth_value"] == "OUT"
 
 
+class TestSetMetadata:
+
+    def test_sets_key(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("a", "A belief", db_path=db)
+        result = api.set_metadata("a", "source_file", "src/foo.py", db_path=db)
+        assert result == {"node_id": "a", "key": "source_file"}
+        node = api.show_node("a", db_path=db)
+        assert node["metadata"]["source_file"] == "src/foo.py"
+
+    def test_overwrites_existing_key(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("a", "A belief", db_path=db)
+        api.set_metadata("a", "k", "v1", db_path=db)
+        api.set_metadata("a", "k", "v2", db_path=db)
+        node = api.show_node("a", db_path=db)
+        assert node["metadata"]["k"] == "v2"
+
+    def test_nonexistent_raises(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        with pytest.raises(KeyError):
+            api.set_metadata("nope", "k", "v", db_path=db)
+
+
 class TestListClusters:
 
     @pytest.fixture


### PR DESCRIPTION
## Summary

- Adds `reasons set-metadata NODE KEY VALUE` CLI command
- Exposes the existing `api.set_metadata()` function added in PR #206
- Needed by ftl-code-expert to store `source_file` metadata during `accept-beliefs` (see benthomasson/ftl-code-expert#12)
- Adds 3 integration tests for `api.set_metadata` (set, overwrite, missing node KeyError)

## Test plan

- [x] `test_sets_key` — sets metadata and verifies via show_node
- [x] `test_overwrites_existing_key` — second set overwrites first
- [x] `test_nonexistent_raises` — KeyError on missing node
- [x] All 1490 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)