### PR TITLE
Add lifecycle timestamps to Node dataclass

### DIFF
--- a/reasons_lib/__init__.py
+++ b/reasons_lib/__init__.py
@@ -39,6 +39,11 @@ class Node:
     source_hash: str = ""
     date: str = ""
     metadata: dict = field(default_factory=dict)
+    created_at: str = ""
+    updated_at: str = ""
+    reviewed_at: str = ""
+    verified_at: str = ""
+    retracted_at: str = ""
 
 
 @dataclass

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -13,6 +13,7 @@ import re
 import sqlite3
 import sys
 from collections.abc import Callable
+from datetime import datetime, timezone
 from itertools import combinations
 from pathlib import Path
 
@@ -627,6 +628,11 @@ def show_node(node_id: str, visible_to: list[str] | None = None, db_path: str = 
             ],
             "dependents": sorted(node.dependents),
             "metadata": node.metadata,
+            "created_at": node.created_at,
+            "updated_at": node.updated_at,
+            "reviewed_at": node.reviewed_at,
+            "verified_at": node.verified_at,
+            "retracted_at": node.retracted_at,
         }
 
 
@@ -808,6 +814,8 @@ def update_node(
             meta["example"] = example
             node.metadata = meta
             updated.append("example")
+        if updated:
+            node.updated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
         return {"node_id": node_id, "updated_fields": updated}
 
 
@@ -829,6 +837,7 @@ def set_metadata(
         meta = node.metadata or {}
         meta[key] = value
         node.metadata = meta
+        node.updated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
         return {"node_id": node_id, "key": key}
 
 
@@ -950,6 +959,11 @@ def export_network(visible_to: list[str] | None = None, db_path: str = DEFAULT_D
                 "source_hash": n.source_hash,
                 "date": n.date,
                 "metadata": {k: v for k, v in n.metadata.items() if not k.startswith("_")},
+                "created_at": n.created_at,
+                "updated_at": n.updated_at,
+                "reviewed_at": n.reviewed_at,
+                "verified_at": n.verified_at,
+                "retracted_at": n.retracted_at,
             }
             for nid, n in sorted(net.nodes.items())
             if visible_to is None or _is_visible(n, visible_to)
@@ -1258,7 +1272,12 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB,
                         source_hash=ndata.get("source_hash", ""),
                         date=ndata.get("date", ""),
                         metadata=ndata.get("metadata", {}),
+                        created_at=ndata.get("created_at", ""),
+                        updated_at=ndata.get("updated_at", ""),
                     )
+                    node.reviewed_at = ndata.get("reviewed_at", "")
+                    node.verified_at = ndata.get("verified_at", "")
+                    node.retracted_at = ndata.get("retracted_at", "")
                     # Restore exact truth value (may differ from computed if retracted)
                     target_tv = ndata.get("truth_value", "IN")
                     if node.truth_value != target_tv:
@@ -1287,7 +1306,7 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB,
                             )
                             for j in jlist
                         ]
-                    net.add_node(
+                    node = net.add_node(
                         id=nid,
                         text=ndata.get("text", ""),
                         justifications=justifications,
@@ -1296,9 +1315,14 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB,
                         source_hash=ndata.get("source_hash", ""),
                         date=ndata.get("date", ""),
                         metadata=ndata.get("metadata", {}),
+                        created_at=ndata.get("created_at", ""),
+                        updated_at=ndata.get("updated_at", ""),
                     )
+                    node.reviewed_at = ndata.get("reviewed_at", "")
+                    node.verified_at = ndata.get("verified_at", "")
+                    node.retracted_at = ndata.get("retracted_at", "")
                     target_tv = ndata.get("truth_value", "IN")
-                    if net.nodes[nid].truth_value != target_tv:
+                    if node.truth_value != target_tv:
                         if target_tv == "OUT":
                             net.retract(nid)
                         else:
@@ -2265,12 +2289,12 @@ def list_nodes(
                             status=status, premises_only=premises_only,
                             has_dependents=has_dependents, namespace=namespace,
                             visible_to=visible_to, label=label)
-    from datetime import datetime, timedelta
+    from datetime import timedelta
 
     with _with_network(db_path) as net:
         memo = {} if (min_depth is not None or max_depth is not None) else None
         if not_reviewed_since is not None:
-            cutoff = datetime.now() - timedelta(days=not_reviewed_since)
+            cutoff = datetime.now(timezone.utc) - timedelta(days=not_reviewed_since)
         else:
             cutoff = None
         nodes = []
@@ -2298,12 +2322,12 @@ def list_nodes(
             if never_reviewed:
                 if not node.justifications:
                     continue
-                if node.metadata.get("last_reviewed"):
+                if node.reviewed_at or node.metadata.get("last_reviewed"):
                     continue
             if cutoff is not None:
                 if not node.justifications:
                     continue
-                last = node.metadata.get("last_reviewed")
+                last = node.reviewed_at or node.metadata.get("last_reviewed", "")
                 if last:
                     try:
                         if datetime.fromisoformat(last) >= cutoff:
@@ -2317,7 +2341,7 @@ def list_nodes(
                 "justification_count": len(node.justifications),
                 "dependent_count": len(node.dependents),
                 "challenges": node.metadata.get("challenges", []),
-                "last_reviewed": node.metadata.get("last_reviewed"),
+                "last_reviewed": node.reviewed_at or node.metadata.get("last_reviewed"),
                 "review_result": node.metadata.get("review_result"),
                 "source_type": node.metadata.get("source_type", ""),
             })
@@ -2692,14 +2716,13 @@ def review_beliefs(
     """Review derived beliefs for validity, sufficiency, and necessity.
 
     Uses an LLM to evaluate whether each derived belief's reasoning
-    from antecedents to conclusion is sound. Writes last_reviewed and
-    review_result metadata to each reviewed node (unless dry_run=True).
+    from antecedents to conclusion is sound. Sets reviewed_at and updated_at
+    timestamps and writes review_result metadata to each reviewed node
+    (unless dry_run=True).
 
     Returns: {"results": [...], "reviewed": int, "invalid": int,
               "insufficient": int, "unnecessary": int, "total_derived": int}
     """
-    from datetime import datetime
-
     from .derive import _get_depth
     from .review import review_beliefs as _review
 
@@ -2761,14 +2784,15 @@ def review_beliefs(
     results = _review(nodes, belief_ids=review_ids, model=model, timeout=timeout,
                       on_batch=on_batch)
 
-    now = datetime.now().isoformat(timespec="seconds")
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     if not dry_run and results:
         result_map = {r["id"]: r for r in results}
         with _with_network(db_path, write=True) as net:
             for nid in review_ids:
                 if nid in net.nodes and nid in result_map:
-                    net.nodes[nid].metadata["last_reviewed"] = now
+                    net.nodes[nid].reviewed_at = now
+                    net.nodes[nid].updated_at = now
                     net.nodes[nid].metadata["review_result"] = _classify_review_result(result_map[nid])
 
     invalid = sum(1 for r in results if not r.get("valid", True))
@@ -2808,8 +2832,6 @@ def review_premises(
               "skipped_no_source": int}
     """
     import sys
-    from datetime import datetime
-    from pathlib import Path
 
     from .check_stale import resolve_source_path
     from .review_premises import review_premises as _review
@@ -3030,8 +3052,6 @@ def propose_update(
 
     Returns: {"proposals": [...], "reviewed": int, "timestamp": str}
     """
-    from datetime import datetime
-
     from .propose_update import propose_updates as _propose
 
     result = export_network(db_path=db_path)

--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -1275,9 +1275,6 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB,
                         created_at=ndata.get("created_at", ""),
                         updated_at=ndata.get("updated_at", ""),
                     )
-                    node.reviewed_at = ndata.get("reviewed_at", "")
-                    node.verified_at = ndata.get("verified_at", "")
-                    node.retracted_at = ndata.get("retracted_at", "")
                     # Restore exact truth value (may differ from computed if retracted)
                     target_tv = ndata.get("truth_value", "IN")
                     if node.truth_value != target_tv:
@@ -1285,6 +1282,11 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB,
                             net.retract(nid)
                         else:
                             net.assert_node(nid)
+                    # Restore exact timestamps AFTER retract/assert to avoid overwrite
+                    node.reviewed_at = ndata.get("reviewed_at", "")
+                    node.verified_at = ndata.get("verified_at", "")
+                    node.retracted_at = ndata.get("retracted_at", "")
+                    node.updated_at = ndata.get("updated_at", "")
                     added.add(nid)
                     nodes_imported += 1
                 else:
@@ -1318,15 +1320,16 @@ def import_json(json_file: str, db_path: str = DEFAULT_DB,
                         created_at=ndata.get("created_at", ""),
                         updated_at=ndata.get("updated_at", ""),
                     )
-                    node.reviewed_at = ndata.get("reviewed_at", "")
-                    node.verified_at = ndata.get("verified_at", "")
-                    node.retracted_at = ndata.get("retracted_at", "")
                     target_tv = ndata.get("truth_value", "IN")
                     if node.truth_value != target_tv:
                         if target_tv == "OUT":
                             net.retract(nid)
                         else:
                             net.assert_node(nid)
+                    node.reviewed_at = ndata.get("reviewed_at", "")
+                    node.verified_at = ndata.get("verified_at", "")
+                    node.retracted_at = ndata.get("retracted_at", "")
+                    node.updated_at = ndata.get("updated_at", "")
                     added.add(nid)
                     nodes_imported += 1
                 break
@@ -2330,7 +2333,10 @@ def list_nodes(
                 last = node.reviewed_at or node.metadata.get("last_reviewed", "")
                 if last:
                     try:
-                        if datetime.fromisoformat(last) >= cutoff:
+                        dt = datetime.fromisoformat(last)
+                        if dt.tzinfo is None:
+                            dt = dt.replace(tzinfo=timezone.utc)
+                        if dt >= cutoff:
                             continue
                     except ValueError:
                         pass

--- a/reasons_lib/cli.py
+++ b/reasons_lib/cli.py
@@ -290,6 +290,17 @@ def cmd_show(args):
         indented = node["metadata"]["example"].replace("\n", "\n  ")
         print(f"\nExample:\n  {indented}")
 
+    timestamps = []
+    for ts_key in ("created_at", "updated_at", "reviewed_at", "verified_at", "retracted_at"):
+        ts_val = node.get(ts_key, "")
+        if ts_val:
+            label = ts_key.replace("_", " ").title().replace(" At", "")
+            timestamps.append((label, ts_val))
+    if timestamps:
+        print()
+        for label, val in timestamps:
+            print(f"{label}: {val}")
+
     if node["dependents"]:
         print(f"\nDependents: {', '.join(node['dependents'])}")
 

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -9,7 +9,7 @@ Implements Doyle's (1979) TMS algorithm:
 """
 
 from collections import deque
-from datetime import datetime
+from datetime import datetime, timezone
 
 from . import Node, Justification, Nogood
 
@@ -79,6 +79,11 @@ class Network:
         source_hash: str = "",
         date: str = "",
         metadata: dict | None = None,
+        created_at: str = "",
+        updated_at: str = "",
+        reviewed_at: str = "",
+        verified_at: str = "",
+        retracted_at: str = "",
     ) -> Node:
         """Add a node to the network and propagate.
 
@@ -87,6 +92,11 @@ class Network:
         """
         if id in self.nodes:
             raise ValueError(f"Node '{id}' already exists")
+
+        if not created_at:
+            now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            created_at = now
+            updated_at = now
 
         node = Node(
             id=id,
@@ -97,6 +107,11 @@ class Network:
             source_hash=source_hash,
             date=date,
             metadata=metadata or {},
+            created_at=created_at,
+            updated_at=updated_at,
+            reviewed_at=reviewed_at,
+            verified_at=verified_at,
+            retracted_at=retracted_at,
         )
 
         # Register as dependent of antecedents (inlist) and outlist nodes.
@@ -135,12 +150,17 @@ class Network:
             raise KeyError(f"Node '{node_id}' not found")
 
         node = self.nodes[node_id]
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         if node.truth_value == "OUT":
             node.metadata["_retracted"] = True
+            node.retracted_at = now
+            node.updated_at = now
             return []
 
         node.truth_value = "OUT"
         node.metadata["_retracted"] = True
+        node.retracted_at = now
+        node.updated_at = now
         if reason:
             node.metadata["retract_reason"] = reason
         changed = [node_id]

--- a/reasons_lib/network.py
+++ b/reasons_lib/network.py
@@ -184,6 +184,8 @@ class Network:
 
         node.truth_value = "IN"
         node.metadata.pop("_retracted", None)
+        node.retracted_at = ""
+        node.updated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
         changed = [node_id]
         self._log("assert", node_id, "IN")
 

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -30,6 +30,10 @@ CREATE TABLE IF NOT EXISTS rms_nodes (
     date TEXT DEFAULT '',
     metadata JSONB DEFAULT '{}',
     created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ,
+    reviewed_at TIMESTAMPTZ,
+    verified_at TIMESTAMPTZ,
+    retracted_at TIMESTAMPTZ,
     PRIMARY KEY (id, project_id)
 );
 
@@ -132,6 +136,14 @@ class PgApi:
             )
             if not cur.fetchone():
                 cur.execute("ALTER TABLE rms_nodes ADD COLUMN source_url TEXT DEFAULT ''")
+            for col in ("updated_at", "reviewed_at", "verified_at", "retracted_at"):
+                cur.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'rms_nodes' AND column_name = %s",
+                    (col,),
+                )
+                if not cur.fetchone():
+                    cur.execute(f"ALTER TABLE rms_nodes ADD COLUMN {col} TIMESTAMPTZ")
             now = datetime.now(timezone.utc).isoformat(timespec="seconds")
             pname = project_name or self.project_id
             for key, val in [
@@ -153,22 +165,25 @@ class PgApi:
 
     def _add_node_raw(self, cur, node_id, text, justifications=None,
                       source="", source_url="", source_hash="", date="",
-                      metadata=None):
+                      metadata=None, created_at="", updated_at=""):
         """Insert a node with pre-parsed justification dicts.
 
         Does NOT commit, validate refs, or inherit access tags.
         Caller is responsible for transaction management.
         """
         pid = self.project_id
-        now = date or datetime.now().isoformat(timespec="seconds")
+        now_ts = datetime.now(timezone.utc)
+        now = date or now_ts.isoformat(timespec="seconds")
         meta = metadata or {}
+        ts_created = created_at or now_ts.isoformat(timespec="seconds")
+        ts_updated = updated_at or ts_created
 
         cur.execute(
             "INSERT INTO rms_nodes (id, project_id, text, source, source_url, "
-            "source_hash, date, metadata) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+            "source_hash, date, metadata, created_at, updated_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
             (node_id, pid, text, source, source_url, source_hash, now,
-             json.dumps(meta)),
+             json.dumps(meta), ts_created, ts_updated),
         )
 
         if justifications:
@@ -358,18 +373,22 @@ class PgApi:
             if reason:
                 metadata["retract_reason"] = reason
 
+            now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
             if old_value == "OUT":
                 cur.execute(
-                    "UPDATE rms_nodes SET metadata = %s WHERE id = %s AND project_id = %s",
-                    (json.dumps(metadata), node_id, pid),
+                    "UPDATE rms_nodes SET metadata = %s, retracted_at = %s, updated_at = %s "
+                    "WHERE id = %s AND project_id = %s",
+                    (json.dumps(metadata), now, now, node_id, pid),
                 )
                 self.conn.commit()
                 return {"changed": [], "went_out": [], "went_in": []}
 
             cur.execute(
-                "UPDATE rms_nodes SET truth_value = 'OUT', metadata = %s "
+                "UPDATE rms_nodes SET truth_value = 'OUT', metadata = %s, "
+                "retracted_at = %s, updated_at = %s "
                 "WHERE id = %s AND project_id = %s",
-                (json.dumps(metadata), node_id, pid),
+                (json.dumps(metadata), now, now, node_id, pid),
             )
             self._log(cur, "retract", node_id, reason or "OUT")
 
@@ -657,7 +676,8 @@ class PgApi:
         pid = self.project_id
         with self.conn.cursor() as cur:
             cur.execute(
-                "SELECT id, text, truth_value, source, source_url, source_hash, metadata "
+                "SELECT id, text, truth_value, source, source_url, source_hash, metadata, "
+                "created_at, updated_at, reviewed_at, verified_at, retracted_at "
                 "FROM rms_nodes WHERE id = %s AND project_id = %s",
                 (node_id, pid),
             )
@@ -665,7 +685,8 @@ class PgApi:
             if not row:
                 raise KeyError(f"Node '{node_id}' not found")
 
-            nid, text, tv, source, source_url, source_hash, meta = row
+            nid, text, tv, source, source_url, source_hash, meta, \
+                created_at, updated_at, reviewed_at, verified_at, retracted_at = row
             if isinstance(meta, str):
                 meta = json.loads(meta)
 
@@ -689,6 +710,9 @@ class PgApi:
 
             dependents = sorted(self._find_dependents(cur, [node_id]))
 
+        def _fmt_ts(val):
+            return val.isoformat(timespec="seconds") if val else ""
+
         return {
             "id": nid,
             "text": text,
@@ -699,6 +723,11 @@ class PgApi:
             "justifications": justifications,
             "dependents": dependents,
             "metadata": meta,
+            "created_at": _fmt_ts(created_at),
+            "updated_at": _fmt_ts(updated_at),
+            "reviewed_at": _fmt_ts(reviewed_at),
+            "verified_at": _fmt_ts(verified_at),
+            "retracted_at": _fmt_ts(retracted_at),
         }
 
     def search(self, query, visible_to=None, format="markdown"):
@@ -1271,16 +1300,23 @@ class PgApi:
         with self.conn.cursor() as cur:
             cur.execute(
                 "SELECT id, text, truth_value, source, source_url, source_hash, "
-                "date, metadata FROM rms_nodes WHERE project_id = %s ORDER BY id",
+                "date, metadata, created_at, updated_at, reviewed_at, "
+                "verified_at, retracted_at "
+                "FROM rms_nodes WHERE project_id = %s ORDER BY id",
                 (pid,),
             )
             nodes = {}
             for row in cur.fetchall():
-                nid, text, tv, source, source_url, source_hash, date, meta = row
+                nid, text, tv, source, source_url, source_hash, date, meta, \
+                    created_at, updated_at, reviewed_at, verified_at, retracted_at = row
                 if isinstance(meta, str):
                     meta = json.loads(meta)
                 if visible_to is not None and not self._is_visible(meta, visible_to):
                     continue
+
+                def _fmt_ts(val):
+                    return val.isoformat(timespec="seconds") if val else ""
+
                 nodes[nid] = {
                     "text": text,
                     "truth_value": tv,
@@ -1290,6 +1326,11 @@ class PgApi:
                     "source_hash": source_hash or "",
                     "date": date or "",
                     "metadata": {k: v for k, v in meta.items() if not k.startswith("_")},
+                    "created_at": _fmt_ts(created_at),
+                    "updated_at": _fmt_ts(updated_at),
+                    "reviewed_at": _fmt_ts(reviewed_at),
+                    "verified_at": _fmt_ts(verified_at),
+                    "retracted_at": _fmt_ts(retracted_at),
                 }
 
             if nodes:
@@ -1463,6 +1504,8 @@ class PgApi:
             if not updates:
                 return {"node_id": node_id, "updated_fields": []}
 
+            updates.append("updated_at = %s")
+            params.append(datetime.now(timezone.utc).isoformat(timespec="seconds"))
             params.extend([node_id, pid])
             cur.execute(
                 f"UPDATE rms_nodes SET {', '.join(updates)} "
@@ -1485,9 +1528,11 @@ class PgApi:
                 raise KeyError(f"Node '{node_id}' not found")
             meta = json.loads(row[0]) if row[0] else {}
             meta[key] = value
+            now = datetime.now(timezone.utc).isoformat(timespec="seconds")
             cur.execute(
-                "UPDATE rms_nodes SET metadata = %s WHERE id = %s AND project_id = %s",
-                (json.dumps(meta), node_id, pid),
+                "UPDATE rms_nodes SET metadata = %s, updated_at = %s "
+                "WHERE id = %s AND project_id = %s",
+                (json.dumps(meta), now, node_id, pid),
             )
         self.conn.commit()
         return {"node_id": node_id, "key": key}
@@ -2247,6 +2292,8 @@ class PgApi:
                             source_hash=ndata.get("source_hash", ""),
                             date=ndata.get("date", ""),
                             metadata=meta,
+                            created_at=ndata.get("created_at", ""),
+                            updated_at=ndata.get("updated_at", ""),
                         )
                         added.add(nid)
                         nodes_imported += 1
@@ -2267,6 +2314,8 @@ class PgApi:
                             source_hash=ndata.get("source_hash", ""),
                             date=ndata.get("date", ""),
                             metadata=meta,
+                            created_at=ndata.get("created_at", ""),
+                            updated_at=ndata.get("updated_at", ""),
                         )
                         added.add(nid)
                         nodes_imported += 1
@@ -2279,6 +2328,21 @@ class PgApi:
 
         with self.conn.cursor() as cur:
             for nid, ndata in data.get("nodes", {}).items():
+                ts_updates = []
+                ts_params = []
+                for ts_col in ("reviewed_at", "verified_at", "retracted_at"):
+                    ts_val = ndata.get(ts_col, "")
+                    if ts_val:
+                        ts_updates.append(f"{ts_col} = %s")
+                        ts_params.append(ts_val)
+                if ts_updates:
+                    ts_params.extend([nid, pid])
+                    cur.execute(
+                        f"UPDATE rms_nodes SET {', '.join(ts_updates)} "
+                        f"WHERE id = %s AND project_id = %s",
+                        ts_params,
+                    )
+
                 target_tv = ndata.get("truth_value", "IN")
                 cur.execute(
                     "SELECT truth_value FROM rms_nodes "

--- a/reasons_lib/pg.py
+++ b/reasons_lib/pg.py
@@ -418,10 +418,12 @@ class PgApi:
                 return {"changed": [], "went_out": [], "went_in": []}
 
             metadata.pop("_retracted", None)
+            now = datetime.now(timezone.utc).isoformat(timespec="seconds")
             cur.execute(
-                "UPDATE rms_nodes SET truth_value = 'IN', metadata = %s "
+                "UPDATE rms_nodes SET truth_value = 'IN', metadata = %s, "
+                "retracted_at = NULL, updated_at = %s "
                 "WHERE id = %s AND project_id = %s",
-                (json.dumps(metadata), node_id, pid),
+                (json.dumps(metadata), now, node_id, pid),
             )
             self._log(cur, "assert", node_id, "IN")
 
@@ -1305,6 +1307,9 @@ class PgApi:
                 "FROM rms_nodes WHERE project_id = %s ORDER BY id",
                 (pid,),
             )
+            def _fmt_ts(val):
+                return val.isoformat(timespec="seconds") if val else ""
+
             nodes = {}
             for row in cur.fetchall():
                 nid, text, tv, source, source_url, source_hash, date, meta, \
@@ -1313,9 +1318,6 @@ class PgApi:
                     meta = json.loads(meta)
                 if visible_to is not None and not self._is_visible(meta, visible_to):
                     continue
-
-                def _fmt_ts(val):
-                    return val.isoformat(timespec="seconds") if val else ""
 
                 nodes[nid] = {
                     "text": text,
@@ -2328,21 +2330,6 @@ class PgApi:
 
         with self.conn.cursor() as cur:
             for nid, ndata in data.get("nodes", {}).items():
-                ts_updates = []
-                ts_params = []
-                for ts_col in ("reviewed_at", "verified_at", "retracted_at"):
-                    ts_val = ndata.get(ts_col, "")
-                    if ts_val:
-                        ts_updates.append(f"{ts_col} = %s")
-                        ts_params.append(ts_val)
-                if ts_updates:
-                    ts_params.extend([nid, pid])
-                    cur.execute(
-                        f"UPDATE rms_nodes SET {', '.join(ts_updates)} "
-                        f"WHERE id = %s AND project_id = %s",
-                        ts_params,
-                    )
-
                 target_tv = ndata.get("truth_value", "IN")
                 cur.execute(
                     "SELECT truth_value FROM rms_nodes "
@@ -2352,7 +2339,6 @@ class PgApi:
                 row = cur.fetchone()
                 if row and row[0] != target_tv:
                     if target_tv == "OUT":
-                        meta = ndata.get("metadata", {})
                         cur.execute(
                             "UPDATE rms_nodes SET truth_value = 'OUT', "
                             "metadata = metadata || %s "
@@ -2368,6 +2354,22 @@ class PgApi:
                             (nid, pid),
                         )
                         self._log(cur, "assert", nid, "IN")
+
+                # Restore exact timestamps AFTER truth-value fixup
+                ts_updates = []
+                ts_params = []
+                for ts_col in ("updated_at", "reviewed_at", "verified_at", "retracted_at"):
+                    ts_val = ndata.get(ts_col, "")
+                    if ts_val:
+                        ts_updates.append(f"{ts_col} = %s")
+                        ts_params.append(ts_val)
+                if ts_updates:
+                    ts_params.extend([nid, pid])
+                    cur.execute(
+                        f"UPDATE rms_nodes SET {', '.join(ts_updates)} "
+                        f"WHERE id = %s AND project_id = %s",
+                        ts_params,
+                    )
 
             nogoods_imported = 0
             for ng_data in data.get("nogoods", []):

--- a/reasons_lib/storage.py
+++ b/reasons_lib/storage.py
@@ -23,7 +23,12 @@ CREATE TABLE IF NOT EXISTS nodes (
     source_url TEXT DEFAULT '',
     source_hash TEXT DEFAULT '',
     date TEXT DEFAULT '',
-    metadata_json TEXT DEFAULT '{}'
+    metadata_json TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT '',
+    updated_at TEXT DEFAULT '',
+    reviewed_at TEXT DEFAULT '',
+    verified_at TEXT DEFAULT '',
+    retracted_at TEXT DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS justifications (
@@ -82,6 +87,9 @@ class Storage:
         cols = [c[1] for c in self.conn.execute("PRAGMA table_info(nodes)").fetchall()]
         if "source_url" not in cols:
             self.conn.execute("ALTER TABLE nodes ADD COLUMN source_url TEXT DEFAULT ''")
+        for col in ("created_at", "updated_at", "reviewed_at", "verified_at", "retracted_at"):
+            if col not in cols:
+                self.conn.execute(f"ALTER TABLE nodes ADD COLUMN {col} TEXT DEFAULT ''")
         if self._is_new:
             now = datetime.now(timezone.utc).isoformat(timespec="seconds")
             project_name = self._project_name or self.db_path.stem
@@ -112,8 +120,9 @@ class Storage:
 
             for node in network.nodes.values():
                 self.conn.execute(
-                    "INSERT INTO nodes (id, text, truth_value, source, source_url, source_hash, date, metadata_json) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    "INSERT INTO nodes (id, text, truth_value, source, source_url, source_hash, date, metadata_json, "
+                    "created_at, updated_at, reviewed_at, verified_at, retracted_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         node.id,
                         node.text,
@@ -123,6 +132,11 @@ class Storage:
                         node.source_hash,
                         node.date,
                         json.dumps(node.metadata),
+                        node.created_at,
+                        node.updated_at,
+                        node.reviewed_at,
+                        node.verified_at,
+                        node.retracted_at,
                     ),
                 )
                 self.conn.execute(
@@ -178,9 +192,15 @@ class Storage:
         network = Network()
 
         # Load nodes (without justifications first, to avoid ordering issues)
-        # Check if source_url column exists (backward compat with older DBs)
-        has_source_url = "source_url" in [c[1] for c in self.conn.execute("PRAGMA table_info(nodes)").fetchall()]
-        if has_source_url:
+        cols = [c[1] for c in self.conn.execute("PRAGMA table_info(nodes)").fetchall()]
+        has_source_url = "source_url" in cols
+        has_timestamps = "created_at" in cols
+        if has_timestamps:
+            cursor = self.conn.execute(
+                "SELECT id, text, truth_value, source, source_url, source_hash, date, metadata_json, "
+                "created_at, updated_at, reviewed_at, verified_at, retracted_at FROM nodes"
+            )
+        elif has_source_url:
             cursor = self.conn.execute(
                 "SELECT id, text, truth_value, source, source_url, source_hash, date, metadata_json FROM nodes"
             )
@@ -206,7 +226,12 @@ class Storage:
 
         # Build nodes directly (bypass add_node to preserve exact state)
         for row in node_rows:
-            nid, text, truth_value, source, source_url, source_hash, date, meta_json = row
+            if has_timestamps:
+                nid, text, truth_value, source, source_url, source_hash, date, meta_json, \
+                    created_at, updated_at, reviewed_at, verified_at, retracted_at = row
+            else:
+                nid, text, truth_value, source, source_url, source_hash, date, meta_json = row
+                created_at = updated_at = reviewed_at = verified_at = retracted_at = ""
             node = Node(
                 id=nid,
                 text=text,
@@ -217,6 +242,11 @@ class Storage:
                 source_hash=source_hash,
                 date=date,
                 metadata=json.loads(meta_json),
+                created_at=created_at or "",
+                updated_at=updated_at or "",
+                reviewed_at=reviewed_at or "",
+                verified_at=verified_at or "",
+                retracted_at=retracted_at or "",
             )
             network.nodes[nid] = node
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -785,3 +785,64 @@ class TestDeduplicateSemantic:
     def test_jaccard_mode_unchanged(self, db_with_similar):
         result = api.deduplicate(threshold=0.5, semantic=False, db_path=db_with_similar)
         assert result["retracted"] == []
+
+
+class TestLifecycleTimestamps:
+
+    def test_add_node_sets_created_at(self, db_path):
+        api.add_node("ts-a", "Timestamped node", db_path=db_path)
+        node = api.show_node("ts-a", db_path=db_path)
+        assert node["created_at"] != ""
+        assert node["updated_at"] != ""
+        assert node["created_at"] == node["updated_at"]
+
+    def test_update_node_sets_updated_at(self, db_path):
+        api.add_node("ts-b", "Original", db_path=db_path)
+        original = api.show_node("ts-b", db_path=db_path)
+        api.update_node("ts-b", text="Modified", db_path=db_path)
+        updated = api.show_node("ts-b", db_path=db_path)
+        assert updated["updated_at"] >= original["updated_at"]
+
+    def test_set_metadata_sets_updated_at(self, db_path):
+        api.add_node("ts-c", "Meta node", db_path=db_path)
+        original = api.show_node("ts-c", db_path=db_path)
+        api.set_metadata("ts-c", "key", "value", db_path=db_path)
+        updated = api.show_node("ts-c", db_path=db_path)
+        assert updated["updated_at"] >= original["updated_at"]
+
+    def test_retract_sets_retracted_at(self, db_path):
+        api.add_node("ts-d", "To retract", db_path=db_path)
+        api.retract_node("ts-d", db_path=db_path)
+        node = api.show_node("ts-d", db_path=db_path)
+        assert node["retracted_at"] != ""
+        assert node["truth_value"] == "OUT"
+
+    def test_show_node_includes_all_timestamps(self, db_path):
+        api.add_node("ts-e", "Full timestamps", db_path=db_path)
+        node = api.show_node("ts-e", db_path=db_path)
+        for key in ("created_at", "updated_at", "reviewed_at", "verified_at", "retracted_at"):
+            assert key in node
+
+    def test_export_includes_timestamps(self, db_path):
+        api.add_node("ts-f", "Exported node", db_path=db_path)
+        result = api.export_network(db_path=db_path)
+        node_data = result["nodes"]["ts-f"]
+        assert "created_at" in node_data
+        assert node_data["created_at"] != ""
+
+    def test_import_roundtrips_timestamps(self, tmp_path, db_path):
+        api.add_node("ts-g", "Roundtrip node", db_path=db_path)
+        api.retract_node("ts-g", reason="testing", db_path=db_path)
+        export = api.export_network(db_path=db_path)
+
+        import json
+        json_path = str(tmp_path / "export.json")
+        with open(json_path, "w") as f:
+            json.dump(export, f)
+
+        db2 = str(tmp_path / "imported.db")
+        api.init_db(db_path=db2)
+        api.import_json(json_path, db_path=db2)
+        node = api.show_node("ts-g", db_path=db2)
+        assert node["created_at"] == export["nodes"]["ts-g"]["created_at"]
+        assert node["retracted_at"] != ""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -847,3 +847,53 @@ class TestLifecycleTimestamps:
         assert node["created_at"] == export["nodes"]["ts-g"]["created_at"]
         assert node["retracted_at"] == export["nodes"]["ts-g"]["retracted_at"]
         assert node["updated_at"] == export["nodes"]["ts-g"]["updated_at"]
+
+    def test_assert_clears_retracted_at(self, db_path):
+        api.add_node("ts-h", "Retract then restore", db_path=db_path)
+        api.retract_node("ts-h", db_path=db_path)
+        retracted = api.show_node("ts-h", db_path=db_path)
+        assert retracted["retracted_at"] != ""
+        assert retracted["truth_value"] == "OUT"
+
+        api.assert_node("ts-h", db_path=db_path)
+        restored = api.show_node("ts-h", db_path=db_path)
+        assert restored["retracted_at"] == ""
+        assert restored["truth_value"] == "IN"
+        assert restored["updated_at"] >= retracted["updated_at"]
+
+    def test_cascade_does_not_set_retracted_at_on_dependents(self, db_path):
+        api.add_node("ts-root", "Root premise", db_path=db_path)
+        api.add_node("ts-dep", "Depends on root", sl="ts-root", db_path=db_path)
+        api.retract_node("ts-root", db_path=db_path)
+
+        root = api.show_node("ts-root", db_path=db_path)
+        dep = api.show_node("ts-dep", db_path=db_path)
+        assert root["retracted_at"] != ""
+        assert dep["truth_value"] == "OUT"
+        assert dep["retracted_at"] == ""
+
+    def test_verified_at_preserved_through_export_import(self, tmp_path, db_path):
+        from datetime import datetime, timezone
+        api.add_node("ts-ver", "Verified node", db_path=db_path)
+
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        from reasons_lib.storage import Storage
+        store = Storage(db_path)
+        net = store.load()
+        net.nodes["ts-ver"].verified_at = now
+        store.save(net)
+        store.close()
+
+        export = api.export_network(db_path=db_path)
+        assert export["nodes"]["ts-ver"]["verified_at"] == now
+
+        import json
+        json_path = str(tmp_path / "verified.json")
+        with open(json_path, "w") as f:
+            json.dump(export, f)
+
+        db2 = str(tmp_path / "verified_import.db")
+        api.init_db(db_path=db2)
+        api.import_json(json_path, db_path=db2)
+        node = api.show_node("ts-ver", db_path=db2)
+        assert node["verified_at"] == now

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -845,4 +845,5 @@ class TestLifecycleTimestamps:
         api.import_json(json_path, db_path=db2)
         node = api.show_node("ts-g", db_path=db2)
         assert node["created_at"] == export["nodes"]["ts-g"]["created_at"]
-        assert node["retracted_at"] != ""
+        assert node["retracted_at"] == export["nodes"]["ts-g"]["retracted_at"]
+        assert node["updated_at"] == export["nodes"]["ts-g"]["updated_at"]

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -628,11 +628,11 @@ class TestReviewBeliefsMetadata:
             api.review_beliefs(db_path=db_path)
 
         node_ab = api.show_node("derived-ab", db_path=db_path)
-        assert node_ab["metadata"]["last_reviewed"]
+        assert node_ab["reviewed_at"]
         assert node_ab["metadata"]["review_result"] == "pass"
 
         node_abc = api.show_node("derived-abc", db_path=db_path)
-        assert node_abc["metadata"]["last_reviewed"]
+        assert node_abc["reviewed_at"]
         assert node_abc["metadata"]["review_result"] == "invalid"
 
     def test_dry_run_skips_metadata(self, db_path):
@@ -646,7 +646,7 @@ class TestReviewBeliefsMetadata:
             api.review_beliefs(dry_run=True, db_path=db_path)
 
         node = api.show_node("derived-ab", db_path=db_path)
-        assert "last_reviewed" not in node["metadata"]
+        assert not node["reviewed_at"]
 
     def test_review_result_classification_priority(self, db_path):
         mock_response = json.dumps([


### PR DESCRIPTION
## Summary
- Adds created_at, updated_at, reviewed_at, verified_at, retracted_at as first-class fields on the Node dataclass (closes #210)
- Auto-sets created_at/updated_at on add_node, updated_at on mutations (update_node, set_metadata), retracted_at/updated_at on retract, reviewed_at/updated_at on review_beliefs
- Migrates review_beliefs from metadata[last_reviewed] to node.reviewed_at
- Updates SQLite schema + migration, PG schema + migration, storage save/load, API (show/export/import), CLI show output
- 7 new lifecycle timestamp tests, all 1497 tests passing

## Test plan
- [x] TestLifecycleTimestamps::test_add_node_sets_created_at
- [x] TestLifecycleTimestamps::test_update_node_sets_updated_at
- [x] TestLifecycleTimestamps::test_set_metadata_sets_updated_at
- [x] TestLifecycleTimestamps::test_retract_sets_retracted_at
- [x] TestLifecycleTimestamps::test_show_node_includes_all_timestamps
- [x] TestLifecycleTimestamps::test_export_includes_timestamps
- [x] TestLifecycleTimestamps::test_import_roundtrips_timestamps
- [x] Full test suite: 1497 passed, 166 skipped