### PR TITLE
Add repair_action metadata to repair and repair_premises

### DIFF
--- a/reasons_lib/api.py
+++ b/reasons_lib/api.py
@@ -3016,6 +3016,7 @@ def repair_premises(
             if action == "rewrite" and r.get("corrected_text"):
                 try:
                     update_node(nid, text=r["corrected_text"], db_path=db_path)
+                    set_metadata(nid, "repair_action", "rewritten", db_path=db_path)
                 except Exception as e:
                     print(f"  ERROR updating {nid}: {e}", file=sys.stderr)
                     r["action"] = "error"
@@ -3024,6 +3025,7 @@ def repair_premises(
                     retract_node(nid,
                                  reason=f"repair-premises: {r.get('rationale', 'inaccurate')}",
                                  db_path=db_path)
+                    set_metadata(nid, "repair_action", "retracted", db_path=db_path)
                 except Exception as e:
                     print(f"  ERROR retracting {nid}: {e}", file=sys.stderr)
                     r["action"] = "error"

--- a/reasons_lib/repair.py
+++ b/reasons_lib/repair.py
@@ -434,6 +434,8 @@ def repair_beliefs(review_results, nodes, model="claude",
                 result["matched_premises"] = matched
                 if rationale:
                     result["rationale"] = rationale
+                if not dry_run and status == "linked":
+                    api.set_metadata(belief_id, "repair_action", "search_and_link", db_path=db_path)
 
             elif pattern == "soften":
                 print(f"  Pattern: soften for {belief_id}...",
@@ -452,6 +454,7 @@ def repair_beliefs(review_results, nodes, model="claude",
                 result["rationale"] = soften_result.get("rationale", "")
                 if not dry_run:
                     api.update_node(belief_id, text=softened, db_path=db_path)
+                    api.set_metadata(belief_id, "repair_action", "softened", db_path=db_path)
                 result["status"] = "softened"
 
             elif pattern == "abandon":
@@ -463,6 +466,7 @@ def repair_beliefs(review_results, nodes, model="claude",
                         reason=f"repair: abandoned — {triage.get('rationale', '')}",
                         db_path=db_path,
                     )
+                    api.set_metadata(belief_id, "repair_action", "abandoned", db_path=db_path)
                 result["status"] = "abandoned"
 
             elif pattern == "research":
@@ -474,6 +478,7 @@ def repair_beliefs(review_results, nodes, model="claude",
                         triage.get("rationale", ""),
                         db_path=db_path,
                     )
+                    api.set_metadata(belief_id, "repair_action", "research", db_path=db_path)
                 result["status"] = "needs_research"
 
         except Exception as exc:

--- a/tests/test_repair_premises.py
+++ b/tests/test_repair_premises.py
@@ -280,6 +280,75 @@ class TestApiRepairPremises:
         assert result["results"] == []
 
 
+class TestRepairActionMetadata:
+
+    @pytest.fixture
+    def db_with_reviewed(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "entry.md"
+        source_file.write_text("The system uses PostgreSQL for storage.")
+
+        api.init_db(db_path=db)
+        api.add_node("obs-1", "Redis is used for storage",
+                     source=str(source_file), db_path=db)
+        api.add_node("obs-2", "Memcached handles caching",
+                     source=str(source_file), db_path=db)
+
+        review_report = {
+            "results": [
+                {"id": "obs-1", "accurate": False, "well_scoped": True,
+                 "error_type": "misread_source", "comment": "Source says PostgreSQL"},
+                {"id": "obs-2", "accurate": False, "well_scoped": True,
+                 "error_type": "fabricated", "comment": "Source never mentions caching"},
+            ]
+        }
+        review_file = tmp_path / "review.json"
+        review_file.write_text(json.dumps(review_report))
+        return db, str(review_file)
+
+    def test_rewrite_sets_repair_action(self, db_with_reviewed):
+        db, review_file = db_with_reviewed
+        llm_resp = json.dumps([{
+            "id": "obs-1", "action": "rewrite",
+            "corrected_text": "PostgreSQL is used for storage", "rationale": "fixed",
+        }])
+        mock = type("R", (), {"returncode": 0, "stdout": llm_resp, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock):
+            api.repair_premises(review_file=review_file, db_path=db)
+
+        node = api.show_node("obs-1", db_path=db)
+        assert node["metadata"].get("repair_action") == "rewritten"
+
+    def test_retract_sets_repair_action(self, db_with_reviewed):
+        db, review_file = db_with_reviewed
+        llm_resp = json.dumps([{
+            "id": "obs-2", "action": "retract",
+            "corrected_text": None, "rationale": "fabricated",
+        }])
+        mock = type("R", (), {"returncode": 0, "stdout": llm_resp, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock):
+            api.repair_premises(review_file=review_file, db_path=db)
+
+        node = api.show_node("obs-2", db_path=db)
+        assert node["metadata"].get("repair_action") == "retracted"
+
+    def test_dry_run_no_repair_action(self, db_with_reviewed):
+        db, review_file = db_with_reviewed
+        llm_resp = json.dumps([{
+            "id": "obs-1", "action": "rewrite",
+            "corrected_text": "Fixed", "rationale": "ok",
+        }])
+        mock = type("R", (), {"returncode": 0, "stdout": llm_resp, "stderr": ""})()
+        with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons_lib.llm.subprocess.run", return_value=mock):
+            api.repair_premises(review_file=review_file, dry_run=True, db_path=db)
+
+        node = api.show_node("obs-1", db_path=db)
+        assert node["metadata"].get("repair_action") is None
+
+
 class TestCliDispatch:
 
     def test_repair_premises_registered(self):

--- a/tests/test_research.py
+++ b/tests/test_research.py
@@ -221,7 +221,8 @@ class TestResearchBeliefs:
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp, extract_resp, match_resp]), \
-             patch("reasons_lib.api.add_justification"):
+             patch("reasons_lib.api.add_justification"), \
+             patch("reasons_lib.api.set_metadata") as mock_meta:
             results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search(search_results),
@@ -231,6 +232,9 @@ class TestResearchBeliefs:
         assert results[0]["pattern"] == "search_and_link"
         assert results[0]["status"] == "linked"
         assert results[0]["matched_premises"] == ["premise-a"]
+        mock_meta.assert_called_once_with(
+            "derived-boil", "repair_action", "search_and_link", db_path="test.db",
+        )
 
     def test_soften(self):
         nodes = _make_nodes()
@@ -245,7 +249,8 @@ class TestResearchBeliefs:
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp, soften_resp]), \
-             patch("reasons_lib.api.update_node") as mock_update:
+             patch("reasons_lib.api.update_node") as mock_update, \
+             patch("reasons_lib.api.set_metadata") as mock_meta:
             results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),
@@ -256,6 +261,9 @@ class TestResearchBeliefs:
         assert results[0]["softened_text"] == "The water likely boiled"
         mock_update.assert_called_once_with(
             "derived-boil", text="The water likely boiled", db_path="test.db",
+        )
+        mock_meta.assert_called_once_with(
+            "derived-boil", "repair_action", "softened", db_path="test.db",
         )
 
     def test_abandon(self):
@@ -268,7 +276,8 @@ class TestResearchBeliefs:
         with patch("reasons_lib.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage_resp]), \
-             patch("reasons_lib.api.retract_node") as mock_retract:
+             patch("reasons_lib.api.retract_node") as mock_retract, \
+             patch("reasons_lib.api.set_metadata") as mock_meta:
             results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),
@@ -278,6 +287,9 @@ class TestResearchBeliefs:
         assert results[0]["status"] == "abandoned"
         mock_retract.assert_called_once()
         assert "abandoned" in mock_retract.call_args[1]["reason"]
+        mock_meta.assert_called_once_with(
+            "derived-boil", "repair_action", "abandoned", db_path="test.db",
+        )
 
     def test_research_pattern(self):
         nodes = _make_nodes()
@@ -297,8 +309,13 @@ class TestResearchBeliefs:
 
         assert results[0]["pattern"] == "research"
         assert results[0]["status"] == "needs_research"
-        mock_meta.assert_called_once_with(
+        assert mock_meta.call_count == 2
+        mock_meta.assert_any_call(
             "derived-boil", "repair_research", "needs code review",
+            db_path="test.db",
+        )
+        mock_meta.assert_any_call(
+            "derived-boil", "repair_action", "research",
             db_path="test.db",
         )
 
@@ -412,7 +429,8 @@ class TestResearchBeliefs:
              patch("reasons_lib.llm.subprocess.run",
                    side_effect=[triage1, soften1, triage2]), \
              patch("reasons_lib.api.update_node"), \
-             patch("reasons_lib.api.retract_node"):
+             patch("reasons_lib.api.retract_node"), \
+             patch("reasons_lib.api.set_metadata"):
             results = repair_beliefs(
                 review_results, nodes, db_path="test.db",
                 search_fn=_mock_search([]),


### PR DESCRIPTION
## Summary

- Records `repair_action` metadata on each node after repair/repair_premises acts on it
- Values: `search_and_link`, `softened`, `abandoned`, `research` (repair_beliefs); `rewritten`, `retracted` (repair_premises)
- Metadata is skipped in dry_run mode
- Visible via `reasons show <node>` for post-hoc audit trail

## Test plan

- [x] All 6 repair patterns verified: search_and_link, soften, abandon, research, rewrite, retract
- [x] Dry-run mode verified: no metadata written
- [x] Full test suite passes (1503 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)