### PR TITLE
Add verify command to check beliefs against source documents

### DIFF
--- a/reasons/api.py
+++ b/reasons/api.py
@@ -2696,6 +2696,8 @@ def verify_belief(
 
     verified = []
     stale = []
+    retract_failed = []
+    stamp_failed = []
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     for b, _ in beliefs_with_sources:
@@ -2712,7 +2714,7 @@ def verify_belief(
                     reason = verdict.get("reason", "stale per verify")
                     retract_node(bid, reason=f"verify: {reason}", **backend)
                 except Exception:
-                    pass
+                    retract_failed.append(bid)
 
     if not pg_conninfo and verified:
         try:
@@ -2721,10 +2723,12 @@ def verify_belief(
                     if bid in net.nodes:
                         net.nodes[bid].verified_at = now
                         net.nodes[bid].updated_at = now
+                    else:
+                        stamp_failed.append(bid)
         except Exception:
-            pass
+            stamp_failed = list(verified)
 
-    return {
+    result = {
         "results": verdicts,
         "verified": verified,
         "stale": stale,
@@ -2732,6 +2736,11 @@ def verify_belief(
         "is_derived": has_justifications,
         "dry_run": False,
     }
+    if retract_failed:
+        result["retract_failed"] = retract_failed
+    if stamp_failed:
+        result["stamp_failed"] = stamp_failed
+    return result
 
 
 NEGATIVE_BATCH_SIZE = 50

--- a/reasons/api.py
+++ b/reasons/api.py
@@ -2616,6 +2616,119 @@ def report_belief(
     }
 
 
+def verify_belief(
+    node_id: str,
+    trace: bool = False,
+    retract: bool = False,
+    dry_run: bool = False,
+    model: str = "claude",
+    timeout: int = 120,
+    db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
+) -> dict:
+    """Verify a belief against its source documents.
+
+    If trace=True and the belief is derived, traces to leaf premises and
+    verifies each one.  Stamps verified_at on CONFIRMED beliefs.  If
+    retract=True, retracts STALE beliefs.
+
+    Returns: {"results": dict[id, verdict_dict], "verified": list[str],
+              "stale": list[str], "beliefs_checked": list[dict],
+              "is_derived": bool, "dry_run": bool}
+    """
+    from .verify import read_source, verify_beliefs
+    from datetime import datetime, timezone
+
+    backend = dict(db_path=db_path, pg_conninfo=pg_conninfo,
+                   project_id=project_id)
+
+    detail = show_node(node_id, **backend)
+    has_justifications = bool(detail.get("justifications"))
+
+    if has_justifications and trace:
+        trace_data = trace_assumptions(node_id, **backend)
+        premise_ids = trace_data["premises"]
+        beliefs_to_check = []
+        seen = set()
+        for pid in premise_ids:
+            if pid in seen:
+                continue
+            seen.add(pid)
+            try:
+                pd = show_node(pid, **backend)
+                beliefs_to_check.append({
+                    "id": pid,
+                    "text": pd.get("text", ""),
+                    "truth_value": pd.get("truth_value", ""),
+                    "source": pd.get("source", ""),
+                    "source_url": pd.get("source_url", ""),
+                })
+            except (KeyError, PermissionError):
+                beliefs_to_check.append({
+                    "id": pid, "text": "", "truth_value": "UNKNOWN",
+                    "source": "", "source_url": "",
+                })
+    else:
+        beliefs_to_check = [{
+            "id": node_id,
+            "text": detail.get("text", ""),
+            "truth_value": detail.get("truth_value", ""),
+            "source": detail.get("source", ""),
+            "source_url": detail.get("source_url", ""),
+        }]
+
+    beliefs_with_sources = []
+    for b in beliefs_to_check:
+        source_content = read_source(b["source"], db_path=db_path) if b["source"] else None
+        beliefs_with_sources.append((b, source_content))
+
+    if dry_run:
+        return {
+            "results": {},
+            "verified": [],
+            "stale": [],
+            "beliefs_checked": beliefs_to_check,
+            "is_derived": has_justifications,
+            "dry_run": True,
+        }
+
+    verdicts = verify_beliefs(beliefs_with_sources, model=model, timeout=timeout)
+
+    verified = []
+    stale = []
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for b, _ in beliefs_with_sources:
+        bid = b["id"]
+        verdict = verdicts.get(bid, {})
+        v = verdict.get("verdict", "INCONCLUSIVE")
+
+        if v == "CONFIRMED":
+            verified.append(bid)
+            try:
+                set_metadata(bid, "verified_at", now, **backend)
+            except Exception:
+                pass
+
+        elif v == "STALE":
+            stale.append(bid)
+            if retract:
+                try:
+                    reason = verdict.get("reason", "stale per verify")
+                    retract_node(bid, reason=f"verify: {reason}", **backend)
+                except Exception:
+                    pass
+
+    return {
+        "results": verdicts,
+        "verified": verified,
+        "stale": stale,
+        "beliefs_checked": beliefs_to_check,
+        "is_derived": has_justifications,
+        "dry_run": False,
+    }
+
+
 NEGATIVE_BATCH_SIZE = 50
 
 NEGATIVE_TERMS = [

--- a/reasons/api.py
+++ b/reasons/api.py
@@ -2705,11 +2705,6 @@ def verify_belief(
 
         if v == "CONFIRMED":
             verified.append(bid)
-            try:
-                set_metadata(bid, "verified_at", now, **backend)
-            except Exception:
-                pass
-
         elif v == "STALE":
             stale.append(bid)
             if retract:
@@ -2718,6 +2713,16 @@ def verify_belief(
                     retract_node(bid, reason=f"verify: {reason}", **backend)
                 except Exception:
                     pass
+
+    if not pg_conninfo and verified:
+        try:
+            with _with_network(db_path, write=True) as net:
+                for bid in verified:
+                    if bid in net.nodes:
+                        net.nodes[bid].verified_at = now
+                        net.nodes[bid].updated_at = now
+        except Exception:
+            pass
 
     return {
         "results": verdicts,

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -1571,6 +1571,11 @@ def cmd_verify(args):
               f"{len(stale)} stale, {len(partial)} partial, "
               f"{len(inconclusive)} inconclusive")
 
+    if result.get("retract_failed"):
+        print(f"\n  WARNING: failed to retract: {', '.join(result['retract_failed'])}", file=sys.stderr)
+    if result.get("stamp_failed"):
+        print(f"\n  WARNING: failed to stamp verified_at: {', '.join(result['stamp_failed'])}", file=sys.stderr)
+
     print(f"\nResults: {len(confirmed)} confirmed, {len(stale)} stale, "
           f"{len(partial)} partial, {len(inconclusive)} inconclusive")
 

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -1512,6 +1512,73 @@ def cmd_report(args):
             print(f"  {cost}", file=sys.stderr)
 
 
+def cmd_verify(args):
+    from .llm import reset_cost_tracker, format_cost_summary
+    reset_cost_tracker()
+
+    result = api.verify_belief(
+        args.node_id,
+        trace=getattr(args, "trace", False),
+        retract=getattr(args, "retract", False),
+        dry_run=getattr(args, "dry_run", False),
+        model=getattr(args, "model", "claude") or "claude",
+        timeout=args.timeout,
+        **_backend_kwargs(args),
+    )
+
+    beliefs = result["beliefs_checked"]
+
+    if result["dry_run"]:
+        print(f"--dry-run: {len(beliefs)} belief(s) would be verified:")
+        for b in beliefs:
+            has_src = "yes" if b.get("source") else "NO"
+            print(f"  {b['id']} [source: {has_src}]")
+        return
+
+    markers = {
+        "CONFIRMED": "+", "STALE": "-",
+        "PARTIAL": "~", "INCONCLUSIVE": "?",
+    }
+    verdicts = result["results"]
+
+    confirmed, stale, partial, inconclusive = [], [], [], []
+    for b in beliefs:
+        bid = b["id"]
+        v = verdicts.get(bid, {})
+        verdict = v.get("verdict", "INCONCLUSIVE")
+        reason = v.get("reason", "")
+        quote = v.get("quote")
+        marker = markers.get(verdict, "?")
+
+        print(f"\n  [{marker}] {verdict}: {bid}")
+        if reason:
+            print(f"      {reason}")
+        if quote:
+            print(f'      Quote: "{quote}"')
+
+        if verdict == "CONFIRMED":
+            confirmed.append(bid)
+        elif verdict == "STALE":
+            stale.append(bid)
+        elif verdict == "PARTIAL":
+            partial.append(bid)
+        else:
+            inconclusive.append(bid)
+
+    if result["is_derived"] and getattr(args, "trace", False):
+        total = len(beliefs)
+        print(f"\n  Antecedent summary: {len(confirmed)}/{total} confirmed, "
+              f"{len(stale)} stale, {len(partial)} partial, "
+              f"{len(inconclusive)} inconclusive")
+
+    print(f"\nResults: {len(confirmed)} confirmed, {len(stale)} stale, "
+          f"{len(partial)} partial, {len(inconclusive)} inconclusive")
+
+    cost = format_cost_summary()
+    if cost:
+        print(f"  {cost}", file=sys.stderr)
+
+
 def cmd_list_negative(args):
     result = api.list_negative(
         visible_to=_parse_visible_to(args),
@@ -2594,6 +2661,19 @@ def main():
                    help="LLM model for narrative synthesis (default: structured report)")
     p.add_argument("--timeout", type=int, default=300, help="LLM timeout in seconds (default: 300)")
 
+    # verify
+    p = sub.add_parser("verify", help="Verify beliefs against their source documents")
+    p.add_argument("node_id", help="Belief ID to verify")
+    p.add_argument("--trace", action="store_true",
+                   help="Trace derived beliefs to leaf premises and verify each")
+    p.add_argument("--retract", action="store_true",
+                   help="Retract beliefs with STALE verdicts")
+    p.add_argument("--dry-run", action="store_true",
+                   help="Show what would be verified without calling LLM")
+    p.add_argument("-m", "--model", default="claude",
+                   help="LLM model to use (default: claude)")
+    p.add_argument("--timeout", type=int, default=120, help="LLM timeout in seconds (default: 120)")
+
     p = sub.add_parser("list-negative", help="Find IN beliefs describing problems/defects/risks (LLM-classified)")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
     p.add_argument("-m", "--model", default=None,
@@ -2852,6 +2932,7 @@ def main():
         "list-gated": cmd_list_gated,
         "report-gated": cmd_report_gated,
         "report": cmd_report,
+        "verify": cmd_verify,
         "list-negative": cmd_list_negative,
         "topics": cmd_topics,
         "build-wiki": cmd_build_wiki,

--- a/reasons/verify.py
+++ b/reasons/verify.py
@@ -105,8 +105,11 @@ def parse_verify_response(response):
     for k, v in data.items():
         if not isinstance(v, dict) or "verdict" not in v:
             continue
+        raw_verdict = v["verdict"]
+        if not isinstance(raw_verdict, str):
+            continue
         results[k] = {
-            "verdict": v["verdict"].upper(),
+            "verdict": raw_verdict.upper(),
             "reason": v.get("reason", ""),
             "quote": v.get("quote"),
         }

--- a/reasons/verify.py
+++ b/reasons/verify.py
@@ -1,0 +1,134 @@
+"""Verify beliefs against their source documents.
+
+Reads the actual source file for each belief, sends it with the claim to
+an LLM, and returns CONFIRMED/STALE/PARTIAL/INCONCLUSIVE verdicts with
+verbatim quotes.  Designed for rigorous source-checking, not narrative
+synthesis (see report_belief.py for that).
+"""
+
+import json
+import re
+from pathlib import Path
+
+MAX_SOURCE_CHARS = 30_000
+
+VERIFY_PROMPT = """\
+You are verifying whether beliefs in a knowledge base are supported by their \
+source documents.
+
+For each belief below, the source document text is provided. Evaluate whether \
+the source document actually states or clearly implies the claim.
+
+For each belief, return:
+- **CONFIRMED** — the source document clearly supports this claim
+- **STALE** — the source document does not support or contradicts this claim
+- **PARTIAL** — the source partially supports the claim but key details differ
+- **INCONCLUSIVE** — insufficient source material to determine
+
+Return ONLY a JSON object mapping each belief ID to an object with "verdict", \
+"reason", and "quote" (the most relevant quote from the source, or null):
+
+```json
+{{
+  "belief-id": {{
+    "verdict": "CONFIRMED",
+    "reason": "The source explicitly states this figure",
+    "quote": "exact quote from the source document"
+  }}
+}}
+```
+
+Rules:
+- Be rigorous: a claim that sounds reasonable but isn't in the source is NOT confirmed.
+- The quote must be copied verbatim from the source document.
+- If the source is unavailable, verdict must be INCONCLUSIVE.
+- Focus on what the source document says, not general knowledge.
+
+## Beliefs to verify
+
+{beliefs}"""
+
+
+def read_source(source, db_path=None):
+    """Read a source file, resolving the path via check_stale infrastructure.
+
+    Returns the file content (truncated to MAX_SOURCE_CHARS) or None.
+    """
+    from .check_stale import resolve_source_path
+
+    db_dir = Path(db_path).parent if db_path else None
+    path = resolve_source_path(source, db_dir=db_dir)
+    if not path or not path.exists():
+        return None
+
+    try:
+        content = path.read_text(errors="replace")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    if len(content) > MAX_SOURCE_CHARS:
+        content = content[:MAX_SOURCE_CHARS] + "\n\n[... truncated ...]"
+    return content
+
+
+def format_belief_for_verify(belief, source_content):
+    """Format a belief and its source for the LLM prompt."""
+    lines = [f"### `{belief['id']}`"]
+    lines.append(f"**Claim:** {belief['text']}")
+    if belief.get("source"):
+        lines.append(f"**Source file:** {belief['source']}")
+    if belief.get("source_url"):
+        lines.append(f"**Source URL:** {belief['source_url']}")
+    lines.append("")
+    lines.append("**Source document content:**")
+    lines.append("```")
+    lines.append(source_content or "(source not available)")
+    lines.append("```")
+    return "\n".join(lines)
+
+
+def parse_verify_response(response):
+    """Parse LLM JSON response into verdict dicts.
+
+    Returns dict mapping belief_id -> {"verdict", "reason", "quote"}.
+    """
+    if not response:
+        return {}
+    m = re.search(r"\{.*\}", response, re.DOTALL)
+    if not m:
+        return {}
+    try:
+        data = json.loads(m.group(0))
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    results = {}
+    for k, v in data.items():
+        if not isinstance(v, dict) or "verdict" not in v:
+            continue
+        results[k] = {
+            "verdict": v["verdict"].upper(),
+            "reason": v.get("reason", ""),
+            "quote": v.get("quote"),
+        }
+    return results
+
+
+def verify_beliefs(beliefs_with_sources, model="claude", timeout=120):
+    """Call LLM to verify beliefs against their sources.
+
+    Args:
+        beliefs_with_sources: list of (belief_dict, source_content_or_None)
+        model: LLM model identifier
+        timeout: LLM timeout in seconds
+
+    Returns dict mapping belief_id -> {"verdict", "reason", "quote"}.
+    """
+    from .llm import invoke_model
+
+    beliefs_text = "\n\n---\n\n".join(
+        format_belief_for_verify(b, src)
+        for b, src in beliefs_with_sources
+    )
+    prompt = VERIFY_PROMPT.format(beliefs=beliefs_text)
+    response = invoke_model(prompt, model=model, timeout=timeout)
+    return parse_verify_response(response)

--- a/reasons_lib/verify.py
+++ b/reasons_lib/verify.py
@@ -1,0 +1,2 @@
+"""Backwards-compatibility shim — use ``from reasons.verify`` instead."""
+from reasons.verify import *  # noqa: F401,F403

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,288 @@
+"""Tests for the verify command."""
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from reasons import api
+from reasons.verify import (
+    format_belief_for_verify,
+    parse_verify_response,
+    read_source,
+)
+from reasons.cli import main
+
+
+def run_cli(*args, db_path=None):
+    argv = ["reasons"]
+    if db_path:
+        argv += ["--db", db_path]
+    argv += list(args)
+    stdout, stderr = StringIO(), StringIO()
+    with patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", stdout), \
+         patch.object(sys, "stderr", stderr):
+        try:
+            main()
+        except SystemExit as e:
+            return stdout.getvalue(), stderr.getvalue(), e.code
+    return stdout.getvalue(), stderr.getvalue(), 0
+
+
+def _mock_result(stdout):
+    return type("R", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+
+
+class TestParseVerifyResponse:
+
+    def test_valid_response(self):
+        response = json.dumps({
+            "p1": {"verdict": "CONFIRMED", "reason": "matches", "quote": "exact text"},
+            "p2": {"verdict": "STALE", "reason": "not found", "quote": None},
+        })
+        results = parse_verify_response(response)
+        assert results["p1"]["verdict"] == "CONFIRMED"
+        assert results["p1"]["quote"] == "exact text"
+        assert results["p2"]["verdict"] == "STALE"
+
+    def test_json_in_prose(self):
+        response = 'Here is my analysis:\n' + json.dumps({
+            "p1": {"verdict": "PARTIAL", "reason": "differs", "quote": "close"},
+        }) + '\nDone.'
+        results = parse_verify_response(response)
+        assert results["p1"]["verdict"] == "PARTIAL"
+
+    def test_malformed(self):
+        assert parse_verify_response("not json") == {}
+
+    def test_empty(self):
+        assert parse_verify_response("") == {}
+
+    def test_missing_verdict_skipped(self):
+        response = json.dumps({
+            "p1": {"reason": "no verdict field"},
+            "p2": {"verdict": "confirmed", "reason": "ok", "quote": None},
+        })
+        results = parse_verify_response(response)
+        assert "p1" not in results
+        assert results["p2"]["verdict"] == "CONFIRMED"
+
+    def test_case_insensitive(self):
+        response = json.dumps({
+            "p1": {"verdict": "confirmed", "reason": "ok", "quote": None},
+        })
+        results = parse_verify_response(response)
+        assert results["p1"]["verdict"] == "CONFIRMED"
+
+
+class TestFormatBeliefForVerify:
+
+    def test_basic_format(self):
+        belief = {"id": "p1", "text": "A claim", "source": "doc.md",
+                  "source_url": "https://example.com"}
+        result = format_belief_for_verify(belief, "Source document content here.")
+        assert "### `p1`" in result
+        assert "**Claim:** A claim" in result
+        assert "doc.md" in result
+        assert "https://example.com" in result
+        assert "Source document content here." in result
+
+    def test_no_source(self):
+        belief = {"id": "p1", "text": "A claim", "source": "", "source_url": ""}
+        result = format_belief_for_verify(belief, None)
+        assert "(source not available)" in result
+
+
+class TestReadSource:
+
+    def test_reads_file(self, tmp_path):
+        source_file = tmp_path / "doc.md"
+        source_file.write_text("Important evidence here.")
+        db_path = str(tmp_path / "reasons.db")
+
+        content = read_source("doc.md", db_path=db_path)
+        assert content == "Important evidence here."
+
+    def test_missing_file(self, tmp_path):
+        db_path = str(tmp_path / "reasons.db")
+        content = read_source("nonexistent.md", db_path=db_path)
+        assert content is None
+
+    def test_empty_source(self):
+        content = read_source("")
+        assert content is None
+
+    def test_truncation(self, tmp_path):
+        source_file = tmp_path / "big.md"
+        source_file.write_text("x" * 40_000)
+        db_path = str(tmp_path / "reasons.db")
+
+        content = read_source("big.md", db_path=db_path)
+        assert len(content) < 35_000
+        assert "[... truncated ...]" in content
+
+
+class TestApiVerifyBelief:
+
+    def test_premise_verified(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "doc.md"
+        source_file.write_text("PostgreSQL is the primary database.")
+        api.add_node("p1", "PostgreSQL is the primary database",
+                     source=str(source_file), db_path=db)
+
+        llm_resp = json.dumps({
+            "p1": {"verdict": "CONFIRMED", "reason": "exact match",
+                   "quote": "PostgreSQL is the primary database."},
+        })
+        mock = _mock_result(llm_resp)
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock):
+            result = api.verify_belief("p1", db_path=db)
+
+        assert result["verified"] == ["p1"]
+        assert result["stale"] == []
+        assert result["results"]["p1"]["verdict"] == "CONFIRMED"
+
+    def test_stale_detected(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "doc.md"
+        source_file.write_text("Redis is used for caching only.")
+        api.add_node("p1", "Redis is the primary database",
+                     source=str(source_file), db_path=db)
+
+        llm_resp = json.dumps({
+            "p1": {"verdict": "STALE", "reason": "source says caching only",
+                   "quote": "Redis is used for caching only."},
+        })
+        mock = _mock_result(llm_resp)
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock):
+            result = api.verify_belief("p1", db_path=db)
+
+        assert result["stale"] == ["p1"]
+        assert result["verified"] == []
+
+    def test_retract_stale(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "doc.md"
+        source_file.write_text("No mention of this claim.")
+        api.add_node("p1", "Unsupported claim",
+                     source=str(source_file), db_path=db)
+
+        llm_resp = json.dumps({
+            "p1": {"verdict": "STALE", "reason": "not in source", "quote": None},
+        })
+        mock = _mock_result(llm_resp)
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock):
+            result = api.verify_belief("p1", retract=True, db_path=db)
+
+        assert result["stale"] == ["p1"]
+        node = api.show_node("p1", db_path=db)
+        assert node["truth_value"] == "OUT"
+
+    def test_dry_run(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "doc.md"
+        source_file.write_text("Content.")
+        api.add_node("p1", "A claim", source=str(source_file), db_path=db)
+
+        result = api.verify_belief("p1", dry_run=True, db_path=db)
+
+        assert result["dry_run"] is True
+        assert len(result["beliefs_checked"]) == 1
+        assert result["results"] == {}
+
+    def test_trace_derived(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_a = tmp_path / "a.md"
+        source_a.write_text("Evidence for A.")
+        source_b = tmp_path / "b.md"
+        source_b.write_text("Evidence for B.")
+
+        api.add_node("p-a", "Premise A", source=str(source_a), db_path=db)
+        api.add_node("p-b", "Premise B", source=str(source_b), db_path=db)
+        api.add_node("d1", "Derived from A and B", sl="p-a,p-b", db_path=db)
+
+        llm_resp = json.dumps({
+            "p-a": {"verdict": "CONFIRMED", "reason": "matches", "quote": "Evidence for A."},
+            "p-b": {"verdict": "CONFIRMED", "reason": "matches", "quote": "Evidence for B."},
+        })
+        mock = _mock_result(llm_resp)
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock):
+            result = api.verify_belief("d1", trace=True, db_path=db)
+
+        assert len(result["beliefs_checked"]) == 2
+        assert set(result["verified"]) == {"p-a", "p-b"}
+        assert result["is_derived"] is True
+
+    def test_derived_without_trace(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.add_node("p1", "Premise", db_path=db)
+        api.add_node("d1", "Derived", sl="p1", db_path=db)
+
+        llm_resp = json.dumps({
+            "d1": {"verdict": "INCONCLUSIVE", "reason": "no source", "quote": None},
+        })
+        mock = _mock_result(llm_resp)
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock):
+            result = api.verify_belief("d1", trace=False, db_path=db)
+
+        assert len(result["beliefs_checked"]) == 1
+        assert result["beliefs_checked"][0]["id"] == "d1"
+
+    def test_missing_node_raises(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db_path=db)
+
+        with pytest.raises(KeyError):
+            api.verify_belief("nonexistent", db_path=db)
+
+
+class TestCliVerify:
+
+    def test_help(self):
+        stdout, stderr, code = run_cli("verify", "--help")
+        assert code == 0
+        assert "verify" in stdout.lower()
+
+    def test_dry_run(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "doc.md"
+        source_file.write_text("Content.")
+        api.add_node("p1", "A claim", source=str(source_file), db_path=db)
+
+        stdout, stderr, code = run_cli(
+            "verify", "p1", "--dry-run", db_path=db,
+        )
+
+        assert code == 0
+        assert "dry-run" in stdout
+        assert "p1" in stdout
+
+    def test_basic_verify(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "doc.md"
+        source_file.write_text("The system uses PostgreSQL.")
+        api.add_node("p1", "The system uses PostgreSQL",
+                     source=str(source_file), db_path=db)
+
+        llm_resp = json.dumps({
+            "p1": {"verdict": "CONFIRMED", "reason": "exact match",
+                   "quote": "The system uses PostgreSQL."},
+        })
+        mock = _mock_result(llm_resp)
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock):
+            stdout, stderr, code = run_cli("verify", "p1", db_path=db)
+
+        assert code == 0
+        assert "CONFIRMED" in stdout
+        assert "1 confirmed" in stdout

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -148,6 +148,25 @@ class TestApiVerifyBelief:
         assert result["stale"] == []
         assert result["results"]["p1"]["verdict"] == "CONFIRMED"
 
+    def test_verified_at_stamped(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        source_file = tmp_path / "doc.md"
+        source_file.write_text("PostgreSQL is the primary database.")
+        api.add_node("p1", "PostgreSQL is the primary database",
+                     source=str(source_file), db_path=db)
+
+        llm_resp = json.dumps({
+            "p1": {"verdict": "CONFIRMED", "reason": "exact match",
+                   "quote": "PostgreSQL is the primary database."},
+        })
+        mock = _mock_result(llm_resp)
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock):
+            api.verify_belief("p1", db_path=db)
+
+        node = api.show_node("p1", db_path=db)
+        assert node["verified_at"] is not None
+
     def test_stale_detected(self, tmp_path):
         db = str(tmp_path / "test.db")
         source_file = tmp_path / "doc.md"


### PR DESCRIPTION
## Summary

- New `reasons verify NODE` command reads the actual source file for a belief, sends it with the claim to an LLM, and returns CONFIRMED/STALE/PARTIAL/INCONCLUSIVE verdicts with verbatim quotes
- `--trace` follows derived beliefs to leaf premises and verifies each one
- `--retract` auto-retracts beliefs with STALE verdicts
- `--dry-run` previews what would be verified without LLM cost
- Stamps `verified_at` metadata on CONFIRMED beliefs
- Ported from `redhat-expert/scripts/verify_belief.py` prototype, using existing `resolve_source_path`, `trace_assumptions`, `invoke_model` infrastructure

## Test plan

- [x] `parse_verify_response` — valid JSON, prose-wrapped, malformed, empty, case-insensitive (6 tests)
- [x] `format_belief_for_verify` — with/without source (2 tests)
- [x] `read_source` — reads file, missing file, empty, truncation (4 tests)
- [x] API: premise verified, stale detected, retract stale, dry_run, trace derived, derived without trace, missing node (7 tests)
- [x] CLI: help, dry-run, basic verify (3 tests)
- [x] Full test suite passes (1537 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)