### PR TITLE
Add ALL vs ANY mode to derive for resilient justifications

### DIFF
--- a/reasons/derive.py
+++ b/reasons/derive.py
@@ -51,12 +51,21 @@ Given the existing beliefs and derived conclusions below, propose NEW derived co
 
 - Each proposed conclusion must have at least 2 antecedents
 - Antecedents must be existing belief IDs from the list below
+- **Only include load-bearing antecedents** — if a belief was in scope during your reasoning \
+  but is not essential to the conclusion, do not list it as an antecedent
 - Prefer combining existing derived beliefs (deeper chains) over just grouping base beliefs
 - For outlist-gated beliefs: the antecedent should be a positive claim, the unless should be \
   a negative claim (bug, gap, issue, fragility)
 - Don't propose conclusions that merely restate a single antecedent
 - Don't propose conclusions whose antecedents are unrelated (no forced connections)
 - Each conclusion should represent a genuine emergent property or insight
+- **Classify each derivation as ALL or ANY**:
+  - **ALL**: The conclusion requires all antecedents together (a logical chain where each \
+    step depends on the previous). Retracting any single antecedent should retract the conclusion.
+  - **ANY**: Each antecedent independently supports the conclusion (convergent evidence). \
+    The conclusion should survive as long as at least one antecedent holds.
+  - Most cross-cutting conclusions and convergent observations should be ANY. \
+    Multi-step logical arguments should be ALL.
 
 ## Output Format
 
@@ -65,6 +74,7 @@ For each proposed conclusion, output EXACTLY this format:
 ### DERIVE <belief-id-in-kebab-case>
 <one-line claim text>
 - Antecedents: <comma-separated list of existing belief IDs>
+- Mode: ALL or ANY
 - Label: <brief justification rationale>
 
 For outlist-gated conclusions:
@@ -73,6 +83,7 @@ For outlist-gated conclusions:
 <one-line claim text>
 - Antecedents: <comma-separated list of existing belief IDs>
 - Unless: <comma-separated list of belief IDs that must be OUT>
+- Mode: ALL or ANY
 - Label: <brief justification rationale>
 
 ---
@@ -371,9 +382,11 @@ def parse_proposals(response):
         r"(.+?)\n"
         r"- Antecedents: (.+?)\n"
         r"(?:- Unless: (.+?)\n)?"
+        r"(?:- Mode: (ALL|ANY)\n)?"
         r"- Label: (.+?)(?:\n|$)",
     )
     for match in new_pattern.finditer(response):
+        mode_raw = match.group(6)
         proposal = {
             "kind": match.group(1).lower(),
             "id": match.group(2).strip("`"),
@@ -381,7 +394,8 @@ def parse_proposals(response):
             "antecedents": [a.strip().strip("`") for a in match.group(4).split(",")],
             "unless": [u.strip().strip("`") for u in match.group(5).split(",")]
                       if match.group(5) else [],
-            "label": match.group(6).strip(),
+            "mode": mode_raw.lower() if mode_raw else "all",
+            "label": match.group(7).strip(),
         }
         proposals.append(proposal)
 
@@ -637,6 +651,7 @@ def apply_proposals(valid, db_path="reasons.db"):
                 unless=unless,
                 label=p["label"],
                 source_type="derived",
+                any_mode=p.get("mode") == "any",
                 db_path=db_path,
             )
             results.append((p, result))
@@ -659,11 +674,13 @@ def write_proposals_file(valid, output_path):
 
         for p in valid:
             kind = "DERIVE" if p["kind"] == "derive" else "GATE"
+            mode = p.get("mode", "all").upper()
             f.write(f"### {kind} {p['id']}\n")
             f.write(f"{p['text']}\n")
             f.write(f"- Antecedents: {', '.join(p['antecedents'])}\n")
             if p["unless"]:
                 f.write(f"- Unless: {', '.join(p['unless'])}\n")
+            f.write(f"- Mode: {mode}\n")
             f.write(f"- Label: {p['label']}\n\n")
 
     return output_path

--- a/tests/test_derive.py
+++ b/tests/test_derive.py
@@ -205,6 +205,50 @@ Feature X is production-ready
     assert p["unless"] == ["fact-c"]
 
 
+def test_parse_proposals_with_mode_any():
+    response = """
+### DERIVE resilient-conclusion
+Multiple independent observations support this claim
+- Antecedents: obs-a, obs-b, obs-c
+- Mode: ANY
+- Label: convergent evidence from independent observations
+"""
+    proposals = parse_proposals(response)
+    assert len(proposals) == 1
+    p = proposals[0]
+    assert p["mode"] == "any"
+    assert p["antecedents"] == ["obs-a", "obs-b", "obs-c"]
+
+
+def test_parse_proposals_mode_defaults_all():
+    response = """
+### DERIVE chained-conclusion
+This requires all steps in the logical chain
+- Antecedents: step-a, step-b
+- Label: sequential dependency
+"""
+    proposals = parse_proposals(response)
+    assert len(proposals) == 1
+    assert proposals[0]["mode"] == "all"
+
+
+def test_parse_proposals_gate_with_mode():
+    response = """
+### GATE feature-stable
+Feature is stable when supported by any evidence and no blockers
+- Antecedents: evidence-a, evidence-b
+- Unless: blocker-x
+- Mode: ANY
+- Label: gated on blocker resolution
+"""
+    proposals = parse_proposals(response)
+    assert len(proposals) == 1
+    p = proposals[0]
+    assert p["kind"] == "gate"
+    assert p["mode"] == "any"
+    assert p["unless"] == ["blocker-x"]
+
+
 def test_parse_proposals_multiple():
     response = """
 ### DERIVE first-one
@@ -296,6 +340,25 @@ def test_apply_proposals_with_gate(simple_network):
     # Retract fact-c — gated belief should come back IN
     api.retract_node("fact-c", db_path=simple_network)
     node = api.show_node("gated-belief", db_path=simple_network)
+    assert node["truth_value"] == "IN"
+
+
+def test_apply_proposals_any_mode(simple_network):
+    proposals = [
+        {"id": "any-derived", "text": "Supported by either a or c",
+         "antecedents": ["fact-a", "fact-c"], "unless": [],
+         "kind": "derive", "label": "convergent", "mode": "any"},
+    ]
+    results = apply_proposals(proposals, db_path=simple_network)
+    p, result = results[0]
+    assert result["truth_value"] == "IN"
+
+    node = api.show_node("any-derived", db_path=simple_network)
+    assert len(node["justifications"]) == 2
+    assert all(len(j["antecedents"]) == 1 for j in node["justifications"])
+
+    api.retract_node("fact-a", db_path=simple_network)
+    node = api.show_node("any-derived", db_path=simple_network)
     assert node["truth_value"] == "IN"
 
 
@@ -474,9 +537,11 @@ def test_write_proposals_file_roundtrip(tmp_path):
     """Proposals file can be parsed back by parse_proposals."""
     proposals = [
         {"id": "derived-1", "text": "First conclusion", "kind": "derive",
-         "antecedents": ["fact-a", "fact-b"], "unless": [], "label": "test"},
+         "antecedents": ["fact-a", "fact-b"], "unless": [], "label": "test",
+         "mode": "all"},
         {"id": "gated-1", "text": "Gated conclusion", "kind": "gate",
-         "antecedents": ["fact-a"], "unless": ["fact-c"], "label": "test gate"},
+         "antecedents": ["fact-a"], "unless": ["fact-c"], "label": "test gate",
+         "mode": "any"},
     ]
     out = tmp_path / "proposals.md"
     write_proposals_file(proposals, out)
@@ -486,8 +551,10 @@ def test_write_proposals_file_roundtrip(tmp_path):
     assert len(parsed) == 2
     assert parsed[0]["id"] == "derived-1"
     assert parsed[0]["antecedents"] == ["fact-a", "fact-b"]
+    assert parsed[0]["mode"] == "all"
     assert parsed[1]["id"] == "gated-1"
     assert parsed[1]["unless"] == ["fact-c"]
+    assert parsed[1]["mode"] == "any"
 
 
 def test_accept_applies_proposals(simple_network, tmp_path):


### PR DESCRIPTION
## Summary

Closes #218.

- Derive prompt now instructs the LLM to classify each derivation as ALL (conjunction) or ANY (disjunction) and only include load-bearing antecedents
- Parser captures optional `- Mode: ALL|ANY` line, defaults to ALL for backwards compat
- `apply_proposals` passes `any_mode=True` for ANY proposals, creating separate per-antecedent justifications
- `write_proposals_file` includes Mode line for round-trip through `reasons accept`

## Test plan

- [x] `test_parse_proposals_with_mode_any` — parse ANY mode
- [x] `test_parse_proposals_mode_defaults_all` — absent mode defaults to ALL
- [x] `test_parse_proposals_gate_with_mode` — GATE with ANY mode
- [x] `test_apply_proposals_any_mode` — ANY creates separate justifications, survives single retraction
- [x] `test_write_proposals_file_roundtrip` — mode preserved through write/parse cycle
- [x] Full suite: 1571 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)