### PR TITLE
Add --parallel option to review-justifications

### DIFF
--- a/reasons/api.py
+++ b/reasons/api.py
@@ -3020,6 +3020,7 @@ def review_justifications(
     timeout: int = 300,
     min_antecedents: int = 2,
     on_batch: Callable | None = None,
+    parallel: int = 0,
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """Review SL justifications for ALL vs ANY misclassification.
@@ -3049,7 +3050,8 @@ def review_justifications(
     total_candidates = len(candidates)
 
     results = _review(nodes, belief_ids=belief_ids, model=model, timeout=timeout,
-                      min_antecedents=min_antecedents, on_batch=on_batch)
+                      min_antecedents=min_antecedents, on_batch=on_batch,
+                      parallel=parallel)
 
     convert_any = sum(1 for r in results if r.get("classification") == "ANY")
     convert_mixed = sum(1 for r in results if r.get("classification") == "MIXED")

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -1793,6 +1793,7 @@ def cmd_review_justifications(args):
         model=model,
         timeout=args.timeout,
         min_antecedents=args.min_antecedents,
+        parallel=args.parallel,
         db_path=args.db,
     )
 
@@ -2810,6 +2811,8 @@ def main():
                    help="Model to use (default: claude)")
     p.add_argument("--timeout", type=int, default=600,
                    help="LLM timeout in seconds (default: 600)")
+    p.add_argument("--parallel", type=int, default=0,
+                   help="Number of concurrent LLM workers (default: 0 = sequential)")
     p.add_argument("-o", "--output", default=None,
                    help="Write findings to markdown file")
 

--- a/reasons/review_justifications.py
+++ b/reasons/review_justifications.py
@@ -95,9 +95,22 @@ def parse_justification_review(response):
     return []
 
 
+def _process_batch(batch, nodes, model, timeout):
+    """Process a single batch of beliefs through the LLM."""
+    beliefs_text = "\n\n".join(
+        format_belief_for_review(nid, nodes) for nid in batch
+    )
+    prompt = REVIEW_JUSTIFICATIONS_PROMPT.format(beliefs=beliefs_text)
+    response = invoke_model(prompt, model=model, timeout=timeout)
+    results = parse_justification_review(response)
+    if not results and batch:
+        print(f"  WARN: batch returned no parseable results", file=sys.stderr)
+    return results
+
+
 def review_justifications(nodes, belief_ids=None, model="claude", timeout=300,
                           batch_size=REVIEW_BATCH_SIZE, min_antecedents=2,
-                          on_batch=None):
+                          on_batch=None, parallel=0):
     """Review SL justifications for ALL vs ANY classification.
 
     Args:
@@ -128,31 +141,44 @@ def review_justifications(nodes, belief_ids=None, model="claude", timeout=300,
     if not belief_ids:
         return []
 
-    all_results = []
-    total_batches = (len(belief_ids) + batch_size - 1) // batch_size
-
+    batches = []
     for i in range(0, len(belief_ids), batch_size):
-        batch = belief_ids[i:i + batch_size]
-        batch_num = i // batch_size + 1
-        print(f"  Reviewing batch {batch_num}/{total_batches} "
-              f"({len(batch)} beliefs)...", file=sys.stderr)
+        batches.append(belief_ids[i:i + batch_size])
 
-        beliefs_text = "\n\n".join(
-            format_belief_for_review(nid, nodes) for nid in batch
-        )
-        prompt = REVIEW_JUSTIFICATIONS_PROMPT.format(beliefs=beliefs_text)
+    all_results = []
+    total_batches = len(batches)
 
-        try:
-            response = invoke_model(prompt, model=model, timeout=timeout)
-            results = parse_justification_review(response)
-            if not results and batch:
-                print(f"  WARN: batch {batch_num} returned no parseable results",
-                      file=sys.stderr)
-            all_results.extend(results)
-            if on_batch is not None:
-                on_batch(all_results)
-        except Exception as e:
-            print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
+    if parallel > 0:
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        with ThreadPoolExecutor(max_workers=parallel) as executor:
+            futures = {
+                executor.submit(
+                    _process_batch, batch, nodes, model, timeout
+                ): batch_num
+                for batch_num, batch in enumerate(batches, 1)
+            }
+            for future in as_completed(futures):
+                batch_num = futures[future]
+                try:
+                    results = future.result()
+                    all_results.extend(results)
+                    print(f"  Batch {batch_num}/{total_batches} complete "
+                          f"({len(results)} results)", file=sys.stderr)
+                    if on_batch is not None:
+                        on_batch(all_results)
+                except Exception as e:
+                    print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
+    else:
+        for batch_num, batch in enumerate(batches, 1):
+            print(f"  Reviewing batch {batch_num}/{total_batches} "
+                  f"({len(batch)} beliefs)...", file=sys.stderr)
+            try:
+                results = _process_batch(batch, nodes, model, timeout)
+                all_results.extend(results)
+                if on_batch is not None:
+                    on_batch(all_results)
+            except Exception as e:
+                print(f"  WARN: batch {batch_num} failed: {e}", file=sys.stderr)
 
     return all_results
 

--- a/tests/test_review_justifications.py
+++ b/tests/test_review_justifications.py
@@ -167,6 +167,35 @@ class TestReviewJustifications:
         assert len(results) == 1
         assert results[0]["id"] == "multi"
 
+    def test_parallel(self):
+        nodes = {
+            "d1": {
+                "truth_value": "IN",
+                "justifications": [{"type": "SL", "antecedents": ["a", "b"]}],
+                "text": "derived 1",
+            },
+            "d2": {
+                "truth_value": "IN",
+                "justifications": [{"type": "SL", "antecedents": ["a", "c"]}],
+                "text": "derived 2",
+            },
+            "a": {"truth_value": "IN", "text": "A", "justifications": []},
+            "b": {"truth_value": "IN", "text": "B", "justifications": []},
+            "c": {"truth_value": "IN", "text": "C", "justifications": []},
+        }
+
+        def mock_invoke(prompt, model=None, timeout=None):
+            if "derived 1" in prompt:
+                return json.dumps([{"id": "d1", "classification": "ANY"}])
+            return json.dumps([{"id": "d2", "classification": "ALL"}])
+
+        with patch("reasons.review_justifications.invoke_model",
+                   side_effect=mock_invoke):
+            results = review_justifications(nodes, batch_size=1, parallel=2)
+        ids = {r["id"] for r in results}
+        assert ids == {"d1", "d2"}
+        assert len(results) == 2
+
     def test_respects_min_antecedents(self):
         nodes = {
             "two-ant": {


### PR DESCRIPTION
## Summary
- Extracts per-batch LLM work into `_process_batch()` helper
- Adds `--parallel N` option using `ThreadPoolExecutor` + `as_completed`, matching the existing pattern in `review-premises`, `repair-premises`, and `build-wiki`
- Default `0` = sequential (no behavior change)

## Test plan
- [x] New `test_parallel` test with `batch_size=1, parallel=2` verifies concurrent execution produces correct results
- [x] All 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)