### PR TITLE
Add graph-native justification defeaters

### DIFF
--- a/reasons/api.py
+++ b/reasons/api.py
@@ -1023,6 +1023,109 @@ def defeat_justification(
         }
 
 
+def migrate_retract_to_defeaters(
+    node_ids: list[str] | None = None,
+    dry_run: bool = True,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Convert string-based retract_reason entries to graph-native defeaters.
+
+    Finds OUT nodes with retract_reason metadata whose justifications would
+    be satisfied if not for the _retracted flag. For each, creates a defeater
+    node on the first satisfied justification and clears the retract metadata.
+
+    Returns: {"migrated": [...], "skipped": [...], "errors": [...]}
+    """
+    with _with_network(db_path, write=not dry_run) as net:
+        candidates = node_ids or list(net.nodes.keys())
+        migrated = []
+        skipped = []
+        errors = []
+
+        for nid in candidates:
+            if nid not in net.nodes:
+                errors.append({"id": nid, "reason": "not found"})
+                continue
+
+            node = net.nodes[nid]
+            if node.truth_value != "OUT":
+                continue
+            retract_reason = (node.metadata or {}).get("retract_reason")
+            if not retract_reason:
+                continue
+            if not node.justifications:
+                skipped.append({"id": nid, "reason": "premise (no justifications)"})
+                continue
+
+            # Find first justification that would be satisfied
+            satisfied_idx = None
+            for i, j in enumerate(node.justifications):
+                inlist_ok = all(
+                    a in net.nodes and net.nodes[a].truth_value == "IN"
+                    for a in j.antecedents
+                )
+                outlist_ok = all(
+                    o not in net.nodes or net.nodes[o].truth_value == "OUT"
+                    for o in j.outlist
+                )
+                if inlist_ok and outlist_ok:
+                    satisfied_idx = i
+                    break
+
+            if satisfied_idx is None:
+                skipped.append({"id": nid, "reason": "no satisfied justification"})
+                continue
+
+            if dry_run:
+                migrated.append({
+                    "id": nid,
+                    "retract_reason": retract_reason,
+                    "justification_index": satisfied_idx,
+                })
+                continue
+
+            # Apply: inline defeat logic (can't call defeat_justification
+            # because it opens its own _with_network context)
+            defeater_id = f"migrated-retraction-{nid}-j{satisfied_idx}"
+            defeater_text = (
+                f"{retract_reason} (defeats {nid} justification {satisfied_idx})"
+            )
+
+            defeater = net.add_node(
+                id=defeater_id,
+                text=defeater_text,
+                metadata={
+                    "defeater_type": "migrated-retraction",
+                    "defeats_node": nid,
+                    "defeats_justification": satisfied_idx,
+                },
+            )
+
+            justification = node.justifications[satisfied_idx]
+            if defeater_id not in justification.outlist:
+                justification.outlist.append(defeater_id)
+            defeater.dependents.add(nid)
+            node.updated_at = datetime.now(timezone.utc).isoformat(
+                timespec="seconds"
+            )
+
+            # Clear the string-based retract metadata
+            node.metadata.pop("retract_reason", None)
+            node.metadata.pop("_retracted", None)
+
+            migrated.append({
+                "id": nid,
+                "defeater_id": defeater_id,
+                "retract_reason": retract_reason,
+                "justification_index": satisfied_idx,
+            })
+
+        if not dry_run and migrated:
+            net.recompute_all()
+
+        return {"migrated": migrated, "skipped": skipped, "errors": errors}
+
+
 def challenge(
     target_id: str,
     reason: str,

--- a/reasons/api.py
+++ b/reasons/api.py
@@ -939,6 +939,96 @@ def mark_superseded(
         }
 
 
+def defeat_justification(
+    node_id: str,
+    justification_index: int,
+    reason: str,
+    defeater_type: str = "invalid-inference",
+    defeater_id: str | None = None,
+    db_path: str = DEFAULT_DB,
+    pg_conninfo=None, project_id=None,
+) -> dict:
+    """Defeat a justification by adding a defeater belief to its outlist.
+
+    Creates a defeater belief (premise node) and adds it to the specified
+    justification's outlist, causing the belief to go OUT via graph-native
+    TMS semantics rather than metadata strings.
+
+    Args:
+        node_id: The belief whose justification should be defeated
+        justification_index: Index of the justification to defeat (0-based)
+        reason: Explanation of why the justification is invalid
+        defeater_type: Type of defeater (invalid-inference, over-generalizes, etc.)
+        defeater_id: Custom defeater ID (default: {type}-{node_id}-j{index})
+        db_path: Path to database
+
+    Returns: {
+        "node_id": str,
+        "justification_index": int,
+        "defeater_id": str,
+        "defeater_type": str,
+        "changed": list[str]
+    }
+    """
+    if pg_conninfo:
+        return _pg_dispatch(pg_conninfo, project_id, "defeat_justification",
+                            node_id=node_id, justification_index=justification_index,
+                            reason=reason, defeater_type=defeater_type,
+                            defeater_id=defeater_id)
+
+    with _with_network(db_path, write=True) as net:
+        if node_id not in net.nodes:
+            raise KeyError(f"Node '{node_id}' not found")
+
+        node = net.nodes[node_id]
+        if not node.justifications:
+            raise ValueError(f"Node '{node_id}' has no justifications to defeat")
+
+        if justification_index < 0 or justification_index >= len(node.justifications):
+            raise IndexError(
+                f"Justification index {justification_index} out of range "
+                f"(node has {len(node.justifications)} justifications)"
+            )
+
+        justification = node.justifications[justification_index]
+
+        if not defeater_id:
+            defeater_id = f"{defeater_type}-{node_id}-j{justification_index}"
+
+        defeater_text = f"{reason} (defeats {node_id} justification {justification_index})"
+
+        defeater = net.add_node(
+            id=defeater_id,
+            text=defeater_text,
+            metadata={
+                "defeater_type": defeater_type,
+                "defeats_node": node_id,
+                "defeats_justification": justification_index,
+            },
+        )
+
+        before = {nid: n.truth_value for nid, n in net.nodes.items()}
+
+        justification.outlist.append(defeater_id)
+        defeater.dependents.add(node_id)
+        node.updated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+        changed = net.recompute_all()
+
+        actually_changed = [
+            nid for nid in changed
+            if before.get(nid) != net.nodes[nid].truth_value
+        ]
+
+        return {
+            "node_id": node_id,
+            "justification_index": justification_index,
+            "defeater_id": defeater_id,
+            "defeater_type": defeater_type,
+            "changed": actually_changed,
+        }
+
+
 def challenge(
     target_id: str,
     reason: str,

--- a/reasons/api.py
+++ b/reasons/api.py
@@ -990,6 +990,8 @@ def defeat_justification(
 
         defeater_text = f"{reason} (defeats {node_id} justification {justification_index})"
 
+        before = {nid: n.truth_value for nid, n in net.nodes.items()}
+
         defeater = net.add_node(
             id=defeater_id,
             text=defeater_text,
@@ -999,8 +1001,6 @@ def defeat_justification(
                 "defeats_justification": justification_index,
             },
         )
-
-        before = {nid: n.truth_value for nid, n in net.nodes.items()}
 
         if defeater_id not in justification.outlist:
             justification.outlist.append(defeater_id)

--- a/reasons/api.py
+++ b/reasons/api.py
@@ -946,7 +946,6 @@ def defeat_justification(
     defeater_type: str = "invalid-inference",
     defeater_id: str | None = None,
     db_path: str = DEFAULT_DB,
-    pg_conninfo=None, project_id=None,
 ) -> dict:
     """Defeat a justification by adding a defeater belief to its outlist.
 
@@ -970,12 +969,6 @@ def defeat_justification(
         "changed": list[str]
     }
     """
-    if pg_conninfo:
-        return _pg_dispatch(pg_conninfo, project_id, "defeat_justification",
-                            node_id=node_id, justification_index=justification_index,
-                            reason=reason, defeater_type=defeater_type,
-                            defeater_id=defeater_id)
-
     with _with_network(db_path, write=True) as net:
         if node_id not in net.nodes:
             raise KeyError(f"Node '{node_id}' not found")
@@ -1009,7 +1002,8 @@ def defeat_justification(
 
         before = {nid: n.truth_value for nid, n in net.nodes.items()}
 
-        justification.outlist.append(defeater_id)
+        if defeater_id not in justification.outlist:
+            justification.outlist.append(defeater_id)
         defeater.dependents.add(node_id)
         node.updated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
 

--- a/reasons/build_wiki.py
+++ b/reasons/build_wiki.py
@@ -50,7 +50,7 @@ def _page_name(label):
     return safe or "other"
 
 
-def _format_node(node_id, node_detail, node_to_page):
+def _format_node(node_id, node_detail, node_to_page, all_details=None):
     """Render one node as markdown with cross-reference links."""
     lines = []
     lines.append(f"### {node_id}")
@@ -78,6 +78,27 @@ def _format_node(node_id, node_detail, node_to_page):
             link = new_id
         lines.append(f"**Superseded by:** {link}")
         lines.append("")
+
+    # Render defeaters from outlist
+    if all_details:
+        defeaters = []
+        for j in node_detail.get("justifications", []):
+            for o in j.get("outlist", []):
+                o_detail = all_details.get(o)
+                if o_detail:
+                    o_meta = o_detail.get("metadata") or {}
+                    if o_meta.get("defeats_node") == node_id:
+                        defeaters.append((o, o_meta, o_detail.get("text", "")))
+        if defeaters:
+            for d_id, d_meta, d_text in defeaters:
+                d_type = d_meta.get("defeater_type", "defeater")
+                page = node_to_page.get(d_id)
+                if page:
+                    link = f"[{d_id}]({page}#{d_id})"
+                else:
+                    link = d_id
+                lines.append(f"**Defeated by:** {link} ({d_type})")
+            lines.append("")
 
     lines.append(node_detail["text"])
     lines.append("")
@@ -288,7 +309,7 @@ def build_wiki(node_details, groups, output_dir, model="", timeout=300,
             for nid in sorted(nids):
                 detail = node_details.get(nid)
                 if detail:
-                    page_lines.append(_format_node(nid, detail, node_to_page))
+                    page_lines.append(_format_node(nid, detail, node_to_page, all_details=node_details))
         page_text = "\n".join(page_lines)
         page_text = _linkify(page_text, page_file, node_to_page,
                              node_details.keys())

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -217,7 +217,6 @@ def cmd_defeat_justification(args):
     print(f"  Defeater: {result['defeater_id']} ({result['defeater_type']})")
     if result["changed"]:
         went_out = [nid for nid in result["changed"] if nid != result["node_id"]]
-        went_in = []  # Defeating a justification shouldn't restore anything
         if result["node_id"] in result["changed"]:
             print(f"  {result['node_id']} went OUT")
         if went_out:

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -196,6 +196,31 @@ def cmd_mark_superseded(args):
             print(f"  Cascade: {len(went_out)} dependent belief(s) went OUT")
 
 
+def cmd_defeat_justification(args):
+    try:
+        result = api.defeat_justification(
+            args.node_id,
+            args.justification_index,
+            args.reason,
+            defeater_type=args.type or "invalid-inference",
+            defeater_id=getattr(args, "defeater_id", None),
+            **_backend_kwargs(args),
+        )
+    except (KeyError, ValueError, IndexError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Defeated justification {result['justification_index']} of {result['node_id']}")
+    print(f"  Defeater: {result['defeater_id']} ({result['defeater_type']})")
+    if result["changed"]:
+        went_out = [nid for nid in result["changed"] if nid != result["node_id"]]
+        went_in = []  # Defeating a justification shouldn't restore anything
+        if result["node_id"] in result["changed"]:
+            print(f"  {result['node_id']} went OUT")
+        if went_out:
+            print(f"  Cascade: {len(went_out)} dependent belief(s) affected")
+
+
 def cmd_assert(args):
     try:
         result = api.assert_node(args.node_id, **_backend_kwargs(args))
@@ -2452,6 +2477,15 @@ def main():
     p.add_argument("old_id", help="Obsolete node to retract")
     p.add_argument("--by", dest="new_id", required=True, help="Replacement node ID")
 
+    # defeat-justification
+    p = sub.add_parser("defeat-justification", help="Defeat a justification by adding a defeater to its outlist")
+    p.add_argument("node_id", help="Node whose justification to defeat")
+    p.add_argument("justification_index", type=int, help="Justification index (0-based)")
+    p.add_argument("reason", help="Why this justification is invalid")
+    p.add_argument("--type", choices=["invalid-inference", "over-generalizes", "duplicate-of", "superseded-by"],
+                   help="Type of defeater (default: invalid-inference)")
+    p.add_argument("--defeater-id", help="Custom defeater belief ID")
+
     # what-if
     p = sub.add_parser("what-if", help="Simulate retracting or asserting a node (read-only)")
     p.add_argument("action", choices=["retract", "assert"], help="Action to simulate")
@@ -3059,6 +3093,7 @@ def main():
         "assert": cmd_assert,
         "mark-duplicate": cmd_mark_duplicate,
         "mark-superseded": cmd_mark_superseded,
+        "defeat-justification": cmd_defeat_justification,
         "what-if": cmd_what_if,
         "status": cmd_status,
         "show": cmd_show,

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -197,6 +197,9 @@ def cmd_mark_superseded(args):
 
 
 def cmd_defeat_justification(args):
+    if getattr(args, "pg", None) or os.environ.get("REASONS_PG_CONNINFO"):
+        print("Error: defeat-justification is not supported with --pg (no PgApi implementation)", file=sys.stderr)
+        sys.exit(1)
     try:
         result = api.defeat_justification(
             args.node_id,
@@ -204,7 +207,7 @@ def cmd_defeat_justification(args):
             args.reason,
             defeater_type=args.type or "invalid-inference",
             defeater_id=getattr(args, "defeater_id", None),
-            **_backend_kwargs(args),
+            db_path=args.db,
         )
     except (KeyError, ValueError, IndexError) as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -224,6 +224,43 @@ def cmd_defeat_justification(args):
             print(f"  Cascade: {len(went_out)} dependent belief(s) affected")
 
 
+def cmd_migrate_defeaters(args):
+    if getattr(args, "pg", None) or os.environ.get("REASONS_PG_CONNINFO"):
+        print("Error: migrate-defeaters is not supported with --pg (no PgApi implementation)", file=sys.stderr)
+        sys.exit(1)
+
+    node_ids = getattr(args, "node_ids", None) or None
+    dry_run = not args.apply
+
+    result = api.migrate_retract_to_defeaters(
+        node_ids=node_ids, dry_run=dry_run, db_path=args.db,
+    )
+
+    if dry_run:
+        print("Dry run — no changes applied")
+        print()
+
+    if result["migrated"]:
+        print(f"{'Would migrate' if dry_run else 'Migrated'}: {len(result['migrated'])}")
+        for m in result["migrated"]:
+            defeater = m.get("defeater_id", f"migrated-retraction-{m['id']}-j{m['justification_index']}")
+            print(f"  {m['id']} j{m['justification_index']} -> {defeater}")
+            print(f"    Reason: {m['retract_reason']}")
+
+    if result["skipped"]:
+        print(f"Skipped: {len(result['skipped'])}")
+        for s in result["skipped"]:
+            print(f"  {s['id']}: {s['reason']}")
+
+    if result["errors"]:
+        print(f"Errors: {len(result['errors'])}")
+        for e in result["errors"]:
+            print(f"  {e['id']}: {e['reason']}")
+
+    if not result["migrated"] and not result["skipped"] and not result["errors"]:
+        print("No candidates found")
+
+
 def cmd_assert(args):
     try:
         result = api.assert_node(args.node_id, **_backend_kwargs(args))
@@ -2489,6 +2526,11 @@ def main():
                    help="Type of defeater (default: invalid-inference)")
     p.add_argument("--defeater-id", help="Custom defeater belief ID")
 
+    # migrate-defeaters
+    p = sub.add_parser("migrate-defeaters", help="Convert string-based retract_reason to graph-native defeaters")
+    p.add_argument("node_ids", nargs="*", help="Specific nodes to migrate (default: all candidates)")
+    p.add_argument("--apply", action="store_true", help="Apply changes (default is dry-run)")
+
     # what-if
     p = sub.add_parser("what-if", help="Simulate retracting or asserting a node (read-only)")
     p.add_argument("action", choices=["retract", "assert"], help="Action to simulate")
@@ -3097,6 +3139,7 @@ def main():
         "mark-duplicate": cmd_mark_duplicate,
         "mark-superseded": cmd_mark_superseded,
         "defeat-justification": cmd_defeat_justification,
+        "migrate-defeaters": cmd_migrate_defeaters,
         "what-if": cmd_what_if,
         "status": cmd_status,
         "show": cmd_show,

--- a/reasons/export_markdown.py
+++ b/reasons/export_markdown.py
@@ -76,17 +76,26 @@ def export_markdown(network: Network, repos: dict[str, str] | None = None) -> st
         # Collect all antecedents across justifications as depends_on
         all_deps = []
         all_unless = []
+        all_defeaters = []
         for j in node.justifications:
             for a in j.antecedents:
                 if a not in all_deps:
                     all_deps.append(a)
             for o in j.outlist:
-                if o not in all_unless:
+                o_node = network.nodes.get(o)
+                if o_node and o_node.metadata.get("defeats_node") == node.id:
+                    dtype = o_node.metadata.get("defeater_type", "defeater")
+                    if o not in [d[0] for d in all_defeaters]:
+                        all_defeaters.append((o, dtype))
+                elif o not in all_unless:
                     all_unless.append(o)
         if all_deps:
             lines.append(f"- Depends on: {', '.join(all_deps)}")
         if all_unless:
             lines.append(f"- Unless: {', '.join(all_unless)}")
+        if all_defeaters:
+            for d_id, d_type in all_defeaters:
+                lines.append(f"- Defeated by: {d_id} ({d_type})")
 
         # Retraction reason — from retract --reason or imported stale_reason
         retract_reason = node.metadata.get("retract_reason") or node.metadata.get("stale_reason")

--- a/tests/test_build_wiki.py
+++ b/tests/test_build_wiki.py
@@ -175,6 +175,61 @@ class TestFormatNode:
         assert "Duplicate of" not in result
         assert "Superseded by" not in result
 
+    def test_defeated_by_metadata(self):
+        defeater_detail = {
+            "text": "This defeats target-node",
+            "truth_value": "IN",
+            "justifications": [],
+            "dependents": [],
+            "metadata": {
+                "defeats_node": "target-node",
+                "defeater_type": "invalid-inference",
+            },
+        }
+        target_detail = {
+            "text": "A defeated belief",
+            "truth_value": "OUT",
+            "justifications": [{"antecedents": ["base"], "outlist": ["defeater-1"]}],
+            "dependents": [],
+        }
+        all_details = {
+            "target-node": target_detail,
+            "defeater-1": defeater_detail,
+        }
+        node_to_page = {"defeater-1": "misc.md"}
+        result = _format_node("target-node", target_detail, node_to_page,
+                              all_details=all_details)
+        assert "**Defeated by:** [defeater-1](misc.md#defeater-1) (invalid-inference)" in result
+
+    def test_defeated_by_no_page(self):
+        defeater_detail = {
+            "text": "This defeats target-node",
+            "truth_value": "IN",
+            "justifications": [],
+            "dependents": [],
+            "metadata": {"defeats_node": "target-node", "defeater_type": "defeater"},
+        }
+        target_detail = {
+            "text": "A defeated belief",
+            "truth_value": "OUT",
+            "justifications": [{"antecedents": [], "outlist": ["def-1"]}],
+            "dependents": [],
+        }
+        all_details = {"target-node": target_detail, "def-1": defeater_detail}
+        result = _format_node("target-node", target_detail, {},
+                              all_details=all_details)
+        assert "**Defeated by:** def-1 (defeater)" in result
+
+    def test_no_defeaters_without_all_details(self):
+        detail = {
+            "text": "A belief",
+            "truth_value": "OUT",
+            "justifications": [{"antecedents": [], "outlist": ["some-defeater"]}],
+            "dependents": [],
+        }
+        result = _format_node("test-node", detail, {})
+        assert "Defeated by" not in result
+
 
 class TestBuildWiki:
 

--- a/tests/test_defeat_justification.py
+++ b/tests/test_defeat_justification.py
@@ -1,0 +1,248 @@
+"""Tests for graph-native justification defeaters."""
+
+import pytest
+from reasons import api
+
+
+def test_defeat_justification_basic(tmp_path):
+    """Test basic justification defeat mechanism."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    # Add premises and derived belief
+    api.add_node("premise-a", "Premise A", db_path=str(db))
+    api.add_node("premise-b", "Premise B", db_path=str(db))
+    api.add_node("belief", "Derived from A and B", sl="premise-a,premise-b", db_path=str(db))
+
+    # Verify belief is IN
+    node = api.show_node("belief", db_path=str(db))
+    assert node["truth_value"] == "IN"
+
+    # Defeat the justification
+    result = api.defeat_justification(
+        "belief", 0, "Over-generalizes",
+        defeater_type="over-generalizes",
+        db_path=str(db)
+    )
+
+    assert result["node_id"] == "belief"
+    assert result["justification_index"] == 0
+    assert result["defeater_type"] == "over-generalizes"
+    assert "over-generalizes-belief-j0" == result["defeater_id"]
+    assert "belief" in result["changed"]
+
+    # Verify belief went OUT
+    node = api.show_node("belief", db_path=str(db))
+    assert node["truth_value"] == "OUT"
+
+    # Verify defeater exists and is IN
+    defeater = api.show_node(result["defeater_id"], db_path=str(db))
+    assert defeater["truth_value"] == "IN"
+    assert defeater["metadata"]["defeater_type"] == "over-generalizes"
+    assert defeater["metadata"]["defeats_node"] == "belief"
+    assert defeater["metadata"]["defeats_justification"] == 0
+
+
+def test_defeat_justification_added_to_outlist(tmp_path):
+    """Test that defeater is added to justification's outlist."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p", "Premise", db_path=str(db))
+    api.add_node("b", "Belief", sl="p", db_path=str(db))
+
+    # Defeat the justification
+    result = api.defeat_justification(
+        "b", 0, "Invalid inference",
+        db_path=str(db)
+    )
+
+    # Check justification's outlist
+    node = api.show_node("b", db_path=str(db))
+    assert len(node["justifications"]) == 1
+    assert result["defeater_id"] in node["justifications"][0]["outlist"]
+
+
+def test_defeat_restoration_on_retract(tmp_path):
+    """Test that retracting defeater restores the belief."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p", "Premise", db_path=str(db))
+    api.add_node("b", "Belief", sl="p", db_path=str(db))
+
+    # Defeat
+    result = api.defeat_justification("b", 0, "Test defeat", db_path=str(db))
+    defeater_id = result["defeater_id"]
+
+    # Verify OUT
+    node = api.show_node("b", db_path=str(db))
+    assert node["truth_value"] == "OUT"
+
+    # Retract defeater
+    retract_result = api.retract_node(defeater_id, db_path=str(db))
+
+    # Verify belief restored to IN
+    node = api.show_node("b", db_path=str(db))
+    assert node["truth_value"] == "IN"
+    assert "b" in retract_result["changed"]
+
+
+def test_defeat_cascade_to_dependents(tmp_path):
+    """Test that defeating cascades to dependent beliefs."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    # Chain: p -> b1 -> b2
+    api.add_node("p", "Premise", db_path=str(db))
+    api.add_node("b1", "Belief 1", sl="p", db_path=str(db))
+    api.add_node("b2", "Belief 2", sl="b1", db_path=str(db))
+
+    # All should be IN
+    assert api.show_node("b1", db_path=str(db))["truth_value"] == "IN"
+    assert api.show_node("b2", db_path=str(db))["truth_value"] == "IN"
+
+    # Defeat b1's justification
+    result = api.defeat_justification("b1", 0, "Test", db_path=str(db))
+
+    # Both b1 and b2 should go OUT
+    assert "b1" in result["changed"]
+    assert "b2" in result["changed"]
+    assert api.show_node("b1", db_path=str(db))["truth_value"] == "OUT"
+    assert api.show_node("b2", db_path=str(db))["truth_value"] == "OUT"
+
+
+def test_defeat_multiple_justifications(tmp_path):
+    """Test defeating specific justification when node has multiple."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "Premise 1", db_path=str(db))
+    api.add_node("p2", "Premise 2", db_path=str(db))
+    api.add_node("b", "Belief", sl="p1", db_path=str(db))
+
+    # Add second justification
+    api.add_justification("b", sl="p2", db_path=str(db))
+
+    # Belief has 2 justifications
+    node = api.show_node("b", db_path=str(db))
+    assert len(node["justifications"]) == 2
+    assert node["truth_value"] == "IN"
+
+    # Defeat first justification
+    result = api.defeat_justification("b", 0, "First is invalid", db_path=str(db))
+
+    # Belief should still be IN (second justification is still valid)
+    node = api.show_node("b", db_path=str(db))
+    assert node["truth_value"] == "IN"
+
+    # Defeat second justification
+    result2 = api.defeat_justification("b", 1, "Second is invalid", db_path=str(db))
+
+    # Now belief should be OUT (no valid justifications)
+    node = api.show_node("b", db_path=str(db))
+    assert node["truth_value"] == "OUT"
+
+
+def test_defeat_custom_id(tmp_path):
+    """Test custom defeater ID."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p", "Premise", db_path=str(db))
+    api.add_node("b", "Belief", sl="p", db_path=str(db))
+
+    # Use custom defeater ID
+    result = api.defeat_justification(
+        "b", 0, "Custom defeat",
+        defeater_id="my-custom-defeater",
+        db_path=str(db)
+    )
+
+    assert result["defeater_id"] == "my-custom-defeater"
+
+    # Verify custom ID works
+    defeater = api.show_node("my-custom-defeater", db_path=str(db))
+    assert defeater["truth_value"] == "IN"
+
+
+def test_defeat_errors(tmp_path):
+    """Test error handling."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p", "Premise", db_path=str(db))
+    api.add_node("b", "Belief", sl="p", db_path=str(db))
+
+    # Node doesn't exist
+    with pytest.raises(KeyError, match="not found"):
+        api.defeat_justification("missing", 0, "Test", db_path=str(db))
+
+    # Node has no justifications
+    with pytest.raises(ValueError, match="no justifications"):
+        api.defeat_justification("p", 0, "Test", db_path=str(db))
+
+    # Index out of range
+    with pytest.raises(IndexError, match="out of range"):
+        api.defeat_justification("b", 5, "Test", db_path=str(db))
+
+
+def test_defeater_types(tmp_path):
+    """Test different defeater types."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p", "Premise", db_path=str(db))
+
+    for dtype in ["invalid-inference", "over-generalizes", "duplicate-of", "superseded-by"]:
+        belief_id = f"belief-{dtype}"
+        api.add_node(belief_id, f"Belief {dtype}", sl="p", db_path=str(db))
+
+        result = api.defeat_justification(
+            belief_id, 0, f"Test {dtype}",
+            defeater_type=dtype,
+            db_path=str(db)
+        )
+
+        assert result["defeater_type"] == dtype
+        defeater = api.show_node(result["defeater_id"], db_path=str(db))
+        assert defeater["metadata"]["defeater_type"] == dtype
+
+
+def test_defeater_in_export(tmp_path):
+    """Test that defeaters are preserved in export."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p", "Premise", db_path=str(db))
+    api.add_node("b", "Belief", sl="p", db_path=str(db))
+
+    result = api.defeat_justification(
+        "b", 0, "Test defeat",
+        defeater_type="over-generalizes",
+        db_path=str(db)
+    )
+
+    # Export and verify
+    data = api.export_network(db_path=str(db))
+
+    # Defeater should be in export
+    defeater = data["nodes"][result["defeater_id"]]
+    assert defeater["metadata"]["defeater_type"] == "over-generalizes"
+    assert defeater["metadata"]["defeats_node"] == "b"
+
+    # Belief's justification should have defeater in outlist
+    belief = data["nodes"]["b"]
+    assert result["defeater_id"] in belief["justifications"][0]["outlist"]
+
+
+def test_premise_defeat(tmp_path):
+    """Test that premises can't be defeated (they have no justifications)."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("premise", "A premise", db_path=str(db))
+
+    # Premises have no justifications
+    with pytest.raises(ValueError, match="no justifications"):
+        api.defeat_justification("premise", 0, "Test", db_path=str(db))

--- a/tests/test_export_markdown.py
+++ b/tests/test_export_markdown.py
@@ -81,3 +81,35 @@ class TestExportMarkdown:
         ])
         md = export_markdown(net)
         assert "- Depends on: a, b" in md
+
+    def test_defeater_in_outlist(self):
+        net = Network()
+        net.add_node("base", "Base premise")
+        net.add_node("derived", "Derived belief", justifications=[
+            Justification(type="SL", antecedents=["base"], outlist=["defeater-1"])
+        ])
+        net.add_node("defeater-1", "Defeats derived", metadata={
+            "defeater_type": "invalid-inference",
+            "defeats_node": "derived",
+        })
+        net.recompute_all()
+        md = export_markdown(net)
+        assert "- Defeated by: defeater-1 (invalid-inference)" in md
+        assert "Unless" not in md
+
+    def test_mixed_outlist_defeater_and_regular(self):
+        net = Network()
+        net.add_node("base", "Base premise")
+        net.add_node("blocker", "Regular outlist node")
+        net.add_node("derived", "Derived belief", justifications=[
+            Justification(type="SL", antecedents=["base"],
+                          outlist=["defeater-1", "blocker"])
+        ])
+        net.add_node("defeater-1", "Defeats derived", metadata={
+            "defeater_type": "rebuttal",
+            "defeats_node": "derived",
+        })
+        net.recompute_all()
+        md = export_markdown(net)
+        assert "- Defeated by: defeater-1 (rebuttal)" in md
+        assert "- Unless: blocker" in md

--- a/tests/test_migrate_defeaters.py
+++ b/tests/test_migrate_defeaters.py
@@ -1,0 +1,144 @@
+"""Tests for migrate-defeaters command."""
+
+import pytest
+from reasons import api
+
+
+def test_basic_migration(tmp_path):
+    """OUT node with retract_reason + satisfied justification gets defeated via outlist."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+    api.add_node("base", "Base belief", db_path=db)
+    api.add_node("derived", "Derived belief", sl="base", db_path=db)
+
+    assert api.show_node("derived", db_path=db)["truth_value"] == "IN"
+    api.retract_node("derived", reason="Invalid reasoning", db_path=db)
+    assert api.show_node("derived", db_path=db)["truth_value"] == "OUT"
+
+    result = api.migrate_retract_to_defeaters(dry_run=False, db_path=db)
+
+    assert len(result["migrated"]) == 1
+    assert result["migrated"][0]["id"] == "derived"
+    assert result["migrated"][0]["defeater_id"] == "migrated-retraction-derived-j0"
+
+    node = api.show_node("derived", db_path=db)
+    assert node["truth_value"] == "OUT"
+    assert "retract_reason" not in node["metadata"]
+
+    defeater = api.show_node("migrated-retraction-derived-j0", db_path=db)
+    assert defeater["metadata"]["defeater_type"] == "migrated-retraction"
+    assert defeater["metadata"]["defeats_node"] == "derived"
+
+
+def test_dry_run(tmp_path):
+    """Dry run returns candidates without modifying anything."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+    api.add_node("base", "Base belief", db_path=db)
+    api.add_node("derived", "Derived belief", sl="base", db_path=db)
+    api.retract_node("derived", reason="Invalid", db_path=db)
+
+    result = api.migrate_retract_to_defeaters(dry_run=True, db_path=db)
+
+    assert len(result["migrated"]) == 1
+    assert result["migrated"][0]["id"] == "derived"
+    assert "defeater_id" not in result["migrated"][0]
+
+    node = api.show_node("derived", db_path=db)
+    assert "retract_reason" in node["metadata"]
+    assert node["metadata"]["retract_reason"] == "Invalid"
+
+
+def test_skip_unsatisfied_justification(tmp_path):
+    """OUT node where antecedent is also OUT should be skipped."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+    api.add_node("base", "Base belief", db_path=db)
+    api.add_node("derived", "Derived belief", sl="base", db_path=db)
+
+    api.retract_node("base", db_path=db)
+    assert api.show_node("derived", db_path=db)["truth_value"] == "OUT"
+
+    api.set_metadata("derived", "retract_reason", "Some reason", db_path=db)
+
+    result = api.migrate_retract_to_defeaters(dry_run=False, db_path=db)
+
+    assert len(result["migrated"]) == 0
+    assert any(s["id"] == "derived" for s in result["skipped"])
+
+
+def test_skip_no_retract_reason(tmp_path):
+    """OUT node without retract_reason is not a migration candidate."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+    api.add_node("base", "Base belief", db_path=db)
+    api.add_node("derived", "Derived belief", sl="base", db_path=db)
+    api.retract_node("base", db_path=db)
+
+    result = api.migrate_retract_to_defeaters(dry_run=False, db_path=db)
+
+    assert len(result["migrated"]) == 0
+
+
+def test_metadata_cleared(tmp_path):
+    """Retract_reason and _retracted metadata are cleared after migration."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+    api.add_node("base", "Base belief", db_path=db)
+    api.add_node("derived", "Derived belief", sl="base", db_path=db)
+    api.retract_node("derived", reason="Old reason", db_path=db)
+
+    api.migrate_retract_to_defeaters(dry_run=False, db_path=db)
+
+    node = api.show_node("derived", db_path=db)
+    assert "retract_reason" not in node["metadata"]
+    assert "_retracted" not in node["metadata"]
+
+
+def test_reversibility(tmp_path):
+    """Retracting the migrated defeater restores the original belief to IN."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+    api.add_node("base", "Base belief", db_path=db)
+    api.add_node("derived", "Derived belief", sl="base", db_path=db)
+    api.retract_node("derived", reason="Wrong", db_path=db)
+
+    api.migrate_retract_to_defeaters(dry_run=False, db_path=db)
+    assert api.show_node("derived", db_path=db)["truth_value"] == "OUT"
+
+    api.retract_node("migrated-retraction-derived-j0", db_path=db)
+    assert api.show_node("derived", db_path=db)["truth_value"] == "IN"
+
+
+def test_node_ids_filter(tmp_path):
+    """Only specified node_ids are migrated when filter is provided."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+    api.add_node("base", "Base belief", db_path=db)
+    api.add_node("d1", "Derived 1", sl="base", db_path=db)
+    api.add_node("d2", "Derived 2", sl="base", db_path=db)
+    api.retract_node("d1", reason="Reason 1", db_path=db)
+    api.retract_node("d2", reason="Reason 2", db_path=db)
+
+    result = api.migrate_retract_to_defeaters(
+        node_ids=["d1"], dry_run=False, db_path=db
+    )
+
+    assert len(result["migrated"]) == 1
+    assert result["migrated"][0]["id"] == "d1"
+
+    node_d2 = api.show_node("d2", db_path=db)
+    assert "retract_reason" in node_d2["metadata"]
+
+
+def test_error_on_missing_node(tmp_path):
+    """Missing node_ids are reported in errors."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+
+    result = api.migrate_retract_to_defeaters(
+        node_ids=["nonexistent"], dry_run=False, db_path=db
+    )
+
+    assert len(result["errors"]) == 1
+    assert result["errors"][0]["id"] == "nonexistent"


### PR DESCRIPTION
## Summary

- Adds defeat-justification CLI command and api.defeat_justification() for defeating individual justifications via TMS outlist semantics
- Creates a defeater premise node, adds it to the target justification outlist, and recomputes truth values with cascade propagation
- Replaces string-based retraction with graph-native defeaters that are reversible (retract the defeater to restore the belief)

Closes #228

## Usage

```bash
reasons defeat-justification <node-id> <justification-index> "reason" [--type invalid-inference] [--defeater-id custom-id]
```

## Test plan

- [ ] Run pytest tests/test_defeat_justification.py
- [ ] Verify defeater creates a premise node with correct metadata
- [ ] Verify defeated belief goes OUT via outlist mechanism
- [ ] Verify cascade propagation to dependents
- [ ] Verify retracting the defeater restores the original belief (reversibility)
- [ ] Verify error handling for missing nodes, premises, out-of-range indices