### PR TITLE
Add designated supporting justification tracking

### DIFF
--- a/reasons/__init__.py
+++ b/reasons/__init__.py
@@ -33,6 +33,7 @@ class Node:
     text: str
     truth_value: str = "IN"  # IN or OUT
     justifications: list[Justification] = field(default_factory=list)
+    supporting_justification: int | None = None  # index into justifications list
     dependents: set[str] = field(default_factory=set)  # reverse index
     source: str = ""
     source_url: str = ""

--- a/reasons/api.py
+++ b/reasons/api.py
@@ -635,6 +635,7 @@ def show_node(node_id: str, visible_to: list[str] | None = None, db_path: str = 
             "id": node.id,
             "text": node.text,
             "truth_value": node.truth_value,
+            "supporting_justification": node.supporting_justification,
             "source": node.source,
             "source_url": node.source_url,
             "source_hash": node.source_hash,
@@ -1235,6 +1236,7 @@ def export_network(visible_to: list[str] | None = None, db_path: str = DEFAULT_D
             nid: {
                 "text": n.text,
                 "truth_value": n.truth_value,
+                "supporting_justification": n.supporting_justification,
                 "justifications": [
                     {"type": j.type, "antecedents": j.antecedents, "outlist": j.outlist, "label": j.label}
                     for j in n.justifications
@@ -2528,8 +2530,13 @@ def _node_depth(nid, net, memo=None):
         memo[nid] = 0
         return 0
     memo[nid] = 0  # cycle guard
+    si = node.supporting_justification
+    if si is not None and 0 <= si < len(node.justifications):
+        justifications = [node.justifications[si]]
+    else:
+        justifications = node.justifications
     max_d = 0
-    for j in node.justifications:
+    for j in justifications:
         for a in j.antecedents:
             max_d = max(max_d, _node_depth(a, net, memo))
     memo[nid] = max_d + 1

--- a/reasons/build_wiki.py
+++ b/reasons/build_wiki.py
@@ -103,10 +103,23 @@ def _format_node(node_id, node_detail, node_to_page, all_details=None):
     lines.append(node_detail["text"])
     lines.append("")
 
-    antecedents = set()
-    for j in node_detail.get("justifications", []):
-        for a in j.get("antecedents", []):
-            antecedents.add(a)
+    justifications = node_detail.get("justifications", [])
+    si = node_detail.get("supporting_justification")
+    if si is not None and 0 <= si < len(justifications):
+        designated = justifications[si]
+        antecedents = set(designated.get("antecedents", []))
+        other_antecedents = set()
+        for idx, j in enumerate(justifications):
+            if idx != si:
+                for a in j.get("antecedents", []):
+                    if a not in antecedents:
+                        other_antecedents.add(a)
+    else:
+        antecedents = set()
+        other_antecedents = set()
+        for j in justifications:
+            for a in j.get("antecedents", []):
+                antecedents.add(a)
 
     if antecedents:
         links = []
@@ -116,7 +129,17 @@ def _format_node(node_id, node_detail, node_to_page, all_details=None):
                 links.append(f"[{a}]({page}#{a})")
             else:
                 links.append(a)
-        lines.append(f"**Depends on:** {', '.join(links)}")
+        label = "**Depends on (active):**" if other_antecedents else "**Depends on:**"
+        lines.append(f"{label} {', '.join(links)}")
+    if other_antecedents:
+        links = []
+        for a in sorted(other_antecedents):
+            page = node_to_page.get(a)
+            if page:
+                links.append(f"[{a}]({page}#{a})")
+            else:
+                links.append(a)
+        lines.append(f"**Depends on (other):** {', '.join(links)}")
 
     dependents = node_detail.get("dependents", [])
     if dependents:
@@ -171,10 +194,15 @@ def _format_beliefs_for_prompt(node_ids, node_details):
         lines.append(f"Status: {detail['truth_value']}")
         lines.append(f"Text: {detail['text']}")
 
-        antecedents = set()
-        for j in detail.get("justifications", []):
-            for a in j.get("antecedents", []):
-                antecedents.add(a)
+        justifications = detail.get("justifications", [])
+        si = detail.get("supporting_justification")
+        if si is not None and 0 <= si < len(justifications):
+            antecedents = set(justifications[si].get("antecedents", []))
+        else:
+            antecedents = set()
+            for j in justifications:
+                for a in j.get("antecedents", []):
+                    antecedents.add(a)
         if antecedents:
             lines.append(f"Depends on: {', '.join(sorted(antecedents))}")
 

--- a/reasons/derive.py
+++ b/reasons/derive.py
@@ -121,8 +121,15 @@ def _get_depth(node_id, nodes, derived, memo=None):
         memo[node_id] = 0
         return 0
     memo[node_id] = 0  # cycle guard
+    node_data = derived[node_id]
+    all_justifications = node_data.get("justifications", [])
+    si = node_data.get("supporting_justification")
+    if si is not None and 0 <= si < len(all_justifications):
+        justifications = [all_justifications[si]]
+    else:
+        justifications = all_justifications
     max_d = 0
-    for j in derived[node_id].get("justifications", []):
+    for j in justifications:
         for a in j.get("antecedents", []):
             max_d = max(max_d, _get_depth(a, nodes, derived, memo))
     memo[node_id] = max_d + 1

--- a/reasons/export_card.py
+++ b/reasons/export_card.py
@@ -14,8 +14,13 @@ def _node_depth(nid, nodes, memo=None):
         memo[nid] = 0
         return 0
     memo[nid] = 0
+    si = node.supporting_justification
+    if si is not None and 0 <= si < len(node.justifications):
+        justifications = [node.justifications[si]]
+    else:
+        justifications = node.justifications
     max_d = 0
-    for j in node.justifications:
+    for j in justifications:
         for a in j.antecedents:
             max_d = max(max_d, _node_depth(a, nodes, memo))
     memo[nid] = max_d + 1

--- a/reasons/network.py
+++ b/reasons/network.py
@@ -648,6 +648,7 @@ class Network:
                     self.nodes[out_id].dependents.discard(node_id)
 
         node.justifications = []
+        node.supporting_justification = None
 
         # A premise is IN by default
         changed = []
@@ -813,22 +814,31 @@ class Network:
             return steps
 
         if node.truth_value == "IN":
-            # Find the valid justification
-            for j in node.justifications:
-                if self._justification_valid(j):
-                    step = {
-                        "node": node_id,
-                        "truth_value": "IN",
-                        "reason": f"{j.type} justification valid",
-                        "antecedents": list(j.antecedents),
-                        "label": j.label,
-                    }
-                    if j.outlist:
-                        step["outlist"] = list(j.outlist)
-                    steps.append(step)
-                    for ant_id in j.antecedents:
-                        steps.extend(self.explain(ant_id, _visited, _path))
-                    break
+            # Use designated supporting justification when available
+            j = None
+            si = node.supporting_justification
+            if si is not None and 0 <= si < len(node.justifications):
+                candidate = node.justifications[si]
+                if self._justification_valid(candidate):
+                    j = candidate
+            if j is None:
+                for candidate in reversed(node.justifications):
+                    if self._justification_valid(candidate):
+                        j = candidate
+                        break
+            if j is not None:
+                step = {
+                    "node": node_id,
+                    "truth_value": "IN",
+                    "reason": f"{j.type} justification valid",
+                    "antecedents": list(j.antecedents),
+                    "label": j.label,
+                }
+                if j.outlist:
+                    step["outlist"] = list(j.outlist)
+                steps.append(step)
+                for ant_id in j.antecedents:
+                    steps.extend(self.explain(ant_id, _visited, _path))
         else:
             # All justifications invalid — explain why
             for j in node.justifications:
@@ -916,14 +926,17 @@ class Network:
     def _compute_truth(self, node: Node) -> str:
         """Compute truth value from justifications.
 
-        A node is IN if ANY justification is valid.
+        A node is IN if ANY justification is valid.  Prefers the newest
+        (last-added) valid justification as the designated support.
         """
         if not node.justifications:
             return node.truth_value  # premise — keep current value
 
-        for j in node.justifications:
-            if self._justification_valid(j):
+        for i in range(len(node.justifications) - 1, -1, -1):
+            if self._justification_valid(node.justifications[i]):
+                node.supporting_justification = i
                 return "IN"
+        node.supporting_justification = None
         return "OUT"
 
     def _justification_valid(self, j: Justification) -> bool:

--- a/reasons/storage.py
+++ b/reasons/storage.py
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS nodes (
     id TEXT PRIMARY KEY,
     text TEXT NOT NULL,
     truth_value TEXT NOT NULL DEFAULT 'IN',
+    supporting_justification INTEGER DEFAULT NULL,
     source TEXT DEFAULT '',
     source_url TEXT DEFAULT '',
     source_hash TEXT DEFAULT '',
@@ -90,6 +91,8 @@ class Storage:
         for col in ("created_at", "updated_at", "reviewed_at", "verified_at", "retracted_at"):
             if col not in cols:
                 self.conn.execute(f"ALTER TABLE nodes ADD COLUMN {col} TEXT DEFAULT ''")
+        if "supporting_justification" not in cols:
+            self.conn.execute("ALTER TABLE nodes ADD COLUMN supporting_justification INTEGER DEFAULT NULL")
         if self._is_new:
             now = datetime.now(timezone.utc).isoformat(timespec="seconds")
             project_name = self._project_name or self.db_path.stem
@@ -120,13 +123,15 @@ class Storage:
 
             for node in network.nodes.values():
                 self.conn.execute(
-                    "INSERT INTO nodes (id, text, truth_value, source, source_url, source_hash, date, metadata_json, "
+                    "INSERT INTO nodes (id, text, truth_value, supporting_justification, "
+                    "source, source_url, source_hash, date, metadata_json, "
                     "created_at, updated_at, reviewed_at, verified_at, retracted_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         node.id,
                         node.text,
                         node.truth_value,
+                        node.supporting_justification,
                         node.source,
                         node.source_url,
                         node.source_hash,
@@ -195,18 +200,29 @@ class Storage:
         cols = [c[1] for c in self.conn.execute("PRAGMA table_info(nodes)").fetchall()]
         has_source_url = "source_url" in cols
         has_timestamps = "created_at" in cols
+        has_supporting = "supporting_justification" in cols
         if has_timestamps:
-            cursor = self.conn.execute(
-                "SELECT id, text, truth_value, source, source_url, source_hash, date, metadata_json, "
-                "created_at, updated_at, reviewed_at, verified_at, retracted_at FROM nodes"
-            )
+            if has_supporting:
+                cursor = self.conn.execute(
+                    "SELECT id, text, truth_value, supporting_justification, "
+                    "source, source_url, source_hash, date, metadata_json, "
+                    "created_at, updated_at, reviewed_at, verified_at, retracted_at FROM nodes"
+                )
+            else:
+                cursor = self.conn.execute(
+                    "SELECT id, text, truth_value, NULL, "
+                    "source, source_url, source_hash, date, metadata_json, "
+                    "created_at, updated_at, reviewed_at, verified_at, retracted_at FROM nodes"
+                )
         elif has_source_url:
             cursor = self.conn.execute(
-                "SELECT id, text, truth_value, source, source_url, source_hash, date, metadata_json FROM nodes"
+                "SELECT id, text, truth_value, NULL, "
+                "source, source_url, source_hash, date, metadata_json FROM nodes"
             )
         else:
             cursor = self.conn.execute(
-                "SELECT id, text, truth_value, source, '', source_hash, date, metadata_json FROM nodes"
+                "SELECT id, text, truth_value, NULL, "
+                "source, '', source_hash, date, metadata_json FROM nodes"
             )
         node_rows = cursor.fetchall()
 
@@ -227,16 +243,19 @@ class Storage:
         # Build nodes directly (bypass add_node to preserve exact state)
         for row in node_rows:
             if has_timestamps:
-                nid, text, truth_value, source, source_url, source_hash, date, meta_json, \
-                    created_at, updated_at, reviewed_at, verified_at, retracted_at = row
+                nid, text, truth_value, supporting_j, source, source_url, source_hash, \
+                    date, meta_json, created_at, updated_at, reviewed_at, verified_at, \
+                    retracted_at = row
             else:
-                nid, text, truth_value, source, source_url, source_hash, date, meta_json = row
+                nid, text, truth_value, supporting_j, source, source_url, source_hash, \
+                    date, meta_json = row
                 created_at = updated_at = reviewed_at = verified_at = retracted_at = ""
             node = Node(
                 id=nid,
                 text=text,
                 truth_value=truth_value,
                 justifications=justifications_by_node.get(nid, []),
+                supporting_justification=supporting_j,
                 source=source,
                 source_url=source_url or "",
                 source_hash=source_hash,


### PR DESCRIPTION
## Summary

- Adds `supporting_justification` field to `Node` that tracks which justification (by index) is the active support for each IN node
- `_compute_truth` now iterates newest-first, so the most recently added valid justification is preferred
- `explain` follows the designated justification instead of re-scanning all justifications
- Depth computation uses only the designated justification's antecedents
- Wiki generator shows "Depends on (active)" vs "Depends on (other)" when multiple justifications exist
- SQLite schema updated with backward-compatible migration

Closes #227

## Test plan

- [x] All 1564 existing tests pass
- [ ] Create a node with two justifications, verify `supporting_justification` points to the newest valid one
- [ ] Defeat the newest justification, verify fallback to the older one
- [ ] Verify `explain` follows the designated justification
- [ ] Save and load, verify the field round-trips through SQLite
- [ ] Regenerate wiki, verify designated justification is marked

🤖 Generated with [Claude Code](https://claude.com/claude-code)