### PR TITLE
Add justified defeaters with scope beliefs

### DIFF
--- a/reasons/api.py
+++ b/reasons/api.py
@@ -1024,6 +1024,133 @@ def defeat_justification(
         }
 
 
+def defeat_with_scope(
+    node_id: str,
+    justification_index: int,
+    scope_findings: list[dict],
+    missing_property: str,
+    defeater_type: str = "invalid-inference",
+    defeater_id: str | None = None,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Defeat a justification with a derived defeater backed by scope beliefs.
+
+    Instead of a bare premise defeater, creates scope beliefs (premises
+    describing what each antecedent establishes) and a derived defeater
+    whose SL justification cites them. Challenging any scope belief
+    causes the defeater to go OUT, restoring the original belief.
+
+    Args:
+        node_id: The belief whose justification should be defeated
+        justification_index: Index of the justification to defeat (0-based)
+        scope_findings: List of dicts with keys: antecedent, establishes,
+            does_not_establish
+        missing_property: The property the derived belief claims but no
+            antecedent establishes
+        defeater_type: Type of defeater
+        defeater_id: Custom defeater ID
+        db_path: Path to database
+
+    Returns: {
+        "node_id": str,
+        "justification_index": int,
+        "defeater_id": str,
+        "defeater_type": str,
+        "scope_belief_ids": list[str],
+        "changed": list[str]
+    }
+    """
+    with _with_network(db_path, write=True) as net:
+        if node_id not in net.nodes:
+            raise KeyError(f"Node '{node_id}' not found")
+
+        node = net.nodes[node_id]
+        if not node.justifications:
+            raise ValueError(f"Node '{node_id}' has no justifications to defeat")
+
+        if justification_index < 0 or justification_index >= len(node.justifications):
+            raise IndexError(
+                f"Justification index {justification_index} out of range "
+                f"(node has {len(node.justifications)} justifications)"
+            )
+
+        justification = node.justifications[justification_index]
+
+        if not defeater_id:
+            defeater_id = f"{defeater_type}-{node_id}-j{justification_index}"
+
+        if not scope_findings:
+            raise ValueError("scope_findings must not be empty")
+
+        before = {nid: n.truth_value for nid, n in net.nodes.items()}
+
+        scope_belief_ids = []
+        for sf in scope_findings:
+            ant_id = sf["antecedent"]
+            establishes = sf.get("establishes", "")
+            does_not = sf.get("does_not_establish", "")
+            scope_id = f"scope-{ant_id}-for-{node_id}-j{justification_index}"
+            suffix = 1
+            while scope_id in net.nodes:
+                scope_id = f"scope-{ant_id}-for-{node_id}-j{justification_index}-{suffix}"
+                suffix += 1
+            scope_text = (
+                f"{ant_id} establishes {establishes}"
+                + (f", and does not establish {does_not}" if does_not else "")
+            )
+            net.add_node(
+                id=scope_id,
+                text=scope_text,
+                metadata={
+                    "scope_of": ant_id,
+                    "for_defeater": defeater_id,
+                },
+            )
+            scope_belief_ids.append(scope_id)
+
+        defeater_text = (
+            f"{node_id} claims {missing_property}, but no antecedent establishes it "
+            f"(defeats {node_id} justification {justification_index})"
+        )
+        defeater = net.add_node(
+            id=defeater_id,
+            text=defeater_text,
+            justifications=[
+                Justification(
+                    type="SL",
+                    antecedents=scope_belief_ids,
+                    label=f"scope-defeat of {node_id} j{justification_index}",
+                ),
+            ],
+            metadata={
+                "defeater_type": defeater_type,
+                "defeats_node": node_id,
+                "defeats_justification": justification_index,
+            },
+        )
+
+        if defeater_id not in justification.outlist:
+            justification.outlist.append(defeater_id)
+        defeater.dependents.add(node_id)
+        node.updated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+        changed = net.recompute_all()
+
+        actually_changed = [
+            nid for nid in changed
+            if before.get(nid) != net.nodes[nid].truth_value
+        ]
+
+        return {
+            "node_id": node_id,
+            "justification_index": justification_index,
+            "defeater_id": defeater_id,
+            "defeater_type": defeater_type,
+            "scope_belief_ids": scope_belief_ids,
+            "changed": actually_changed,
+        }
+
+
 def migrate_retract_to_defeaters(
     node_ids: list[str] | None = None,
     dry_run: bool = True,

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -223,6 +223,55 @@ def cmd_defeat_justification(args):
             print(f"  Cascade: {len(went_out)} dependent belief(s) affected")
 
 
+def cmd_defeat_with_scope(args):
+    if getattr(args, "pg", None) or os.environ.get("REASONS_PG_CONNINFO"):
+        print("Error: defeat-with-scope is not supported with --pg", file=sys.stderr)
+        sys.exit(1)
+
+    import json as json_mod
+    scope_path = Path(args.scope_file)
+    if not scope_path.exists():
+        print(f"Error: file not found: {args.scope_file}", file=sys.stderr)
+        sys.exit(1)
+
+    data = json_mod.loads(scope_path.read_text())
+    scope_findings = data.get("scope_findings", [])
+    missing_property = data.get("missing_property", "")
+
+    if not scope_findings:
+        print("Error: scope_findings is empty in the provided file", file=sys.stderr)
+        sys.exit(1)
+    if not missing_property:
+        print("Error: missing_property is empty in the provided file", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        result = api.defeat_with_scope(
+            args.node_id,
+            args.justification_index,
+            scope_findings,
+            missing_property,
+            defeater_type=args.type or "invalid-inference",
+            defeater_id=getattr(args, "defeater_id", None),
+            db_path=args.db,
+        )
+    except (KeyError, ValueError, IndexError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Defeated justification {result['justification_index']} of {result['node_id']}")
+    print(f"  Defeater: {result['defeater_id']} ({result['defeater_type']})")
+    print(f"  Scope beliefs: {len(result['scope_belief_ids'])}")
+    for sid in result["scope_belief_ids"]:
+        print(f"    - {sid}")
+    if result["changed"]:
+        went_out = [nid for nid in result["changed"] if nid != result["node_id"]]
+        if result["node_id"] in result["changed"]:
+            print(f"  {result['node_id']} went OUT")
+        if went_out:
+            print(f"  Cascade: {len(went_out)} dependent belief(s) affected")
+
+
 def cmd_migrate_defeaters(args):
     if getattr(args, "pg", None) or os.environ.get("REASONS_PG_CONNINFO"):
         print("Error: migrate-defeaters is not supported with --pg (no PgApi implementation)", file=sys.stderr)
@@ -1911,6 +1960,25 @@ def cmd_review_beliefs(args):
             except Exception as e:
                 print(f"  ERROR retracting {r['id']}: {e}", file=sys.stderr)
 
+    if args.auto_defeat and not args.dry_run and invalid:
+        print(f"\nDefeating {len(invalid)} invalid belief(s) with scope beliefs...")
+        for r in invalid:
+            scope_findings = r.get("scope_findings", [])
+            missing_property = r.get("missing_property", r.get("comment", "invalid"))
+            try:
+                if scope_findings:
+                    result = api.defeat_with_scope(
+                        r["id"], 0, scope_findings, missing_property,
+                        defeater_type="invalid-inference", db_path=args.db)
+                    print(f"  DEFEATED {r['id']} with {len(result['scope_belief_ids'])} scope belief(s)")
+                else:
+                    api.defeat_justification(
+                        r["id"], 0, r.get("comment", "invalid"),
+                        defeater_type="invalid-inference", db_path=args.db)
+                    print(f"  DEFEATED {r['id']} (bare defeater, no scope findings)")
+            except Exception as e:
+                print(f"  ERROR defeating {r['id']}: {e}", file=sys.stderr)
+
     cost = format_cost_summary()
     if cost:
         print(f"  {cost}", file=sys.stderr)
@@ -2525,6 +2593,16 @@ def main():
                    help="Type of defeater (default: invalid-inference)")
     p.add_argument("--defeater-id", help="Custom defeater belief ID")
 
+    # defeat-with-scope
+    p = sub.add_parser("defeat-with-scope", help="Defeat a justification with scope beliefs as antecedents")
+    p.add_argument("node_id", help="Node whose justification to defeat")
+    p.add_argument("justification_index", type=int, help="Justification index (0-based)")
+    p.add_argument("--scope-file", required=True,
+                   help="JSON file with scope_findings and missing_property")
+    p.add_argument("--type", choices=["invalid-inference", "over-generalizes", "duplicate-of", "superseded-by"],
+                   help="Type of defeater (default: invalid-inference)")
+    p.add_argument("--defeater-id", help="Custom defeater belief ID")
+
     # migrate-defeaters
     p = sub.add_parser("migrate-defeaters", help="Convert string-based retract_reason to graph-native defeaters")
     p.add_argument("node_ids", nargs="*", help="Specific nodes to migrate (default: all candidates)")
@@ -2956,6 +3034,8 @@ def main():
                    help="Report findings without taking action")
     p.add_argument("--auto-retract", action="store_true",
                    help="Retract beliefs found invalid")
+    p.add_argument("--auto-defeat", action="store_true",
+                   help="Defeat invalid beliefs with justified scope defeaters")
     p.add_argument("-o", "--output", default=None,
                    help="Write findings to markdown file")
     p.add_argument("--visible-to", metavar="TAG,TAG",
@@ -3138,6 +3218,7 @@ def main():
         "mark-duplicate": cmd_mark_duplicate,
         "mark-superseded": cmd_mark_superseded,
         "defeat-justification": cmd_defeat_justification,
+        "defeat-with-scope": cmd_defeat_with_scope,
         "migrate-defeaters": cmd_migrate_defeaters,
         "what-if": cmd_what_if,
         "status": cmd_status,

--- a/reasons/review.py
+++ b/reasons/review.py
@@ -41,7 +41,9 @@ Return ONLY a JSON array. For each belief, one object:
     "sufficient": true,
     "necessary": false,
     "unnecessary_antecedents": ["ant-id-1"],
-    "comment": "brief explanation"
+    "comment": "brief explanation",
+    "scope_findings": [],
+    "missing_property": ""
   }}
 ]
 ```
@@ -54,6 +56,16 @@ Rules:
 - "comment" should be a single sentence explaining the most important finding.
 - Be rigorous: a conclusion that sounds reasonable but doesn't follow
   strictly from the antecedents is NOT valid.
+- When "valid" is false, you MUST populate "scope_findings" and
+  "missing_property". For each antecedent you examined, add an entry to
+  "scope_findings" with:
+    - "antecedent": the antecedent belief ID
+    - "establishes": what that antecedent actually establishes
+    - "does_not_establish": what the derived belief claims but this
+      antecedent does not cover
+  Set "missing_property" to the property the derived belief claims but
+  no antecedent establishes. These fields enable structured defeaters
+  that can be audited through the graph.
 
 ## Beliefs to review
 
@@ -129,6 +141,8 @@ def parse_review_response(response):
                 "necessary": item.get("necessary", True),
                 "unnecessary_antecedents": item.get("unnecessary_antecedents", []),
                 "comment": item.get("comment", ""),
+                "scope_findings": item.get("scope_findings", []),
+                "missing_property": item.get("missing_property", ""),
             })
         if results:
             return results

--- a/tests/test_defeat_with_scope.py
+++ b/tests/test_defeat_with_scope.py
@@ -1,0 +1,241 @@
+"""Tests for justified defeaters with scope beliefs."""
+
+import pytest
+from reasons import api
+
+
+def test_defeat_with_scope_basic(tmp_path):
+    """Test basic scope-belief defeat mechanism."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("premise-a", "A establishes safety", db_path=str(db))
+    api.add_node("premise-b", "B establishes correctness", db_path=str(db))
+    api.add_node("belief", "System is safe, correct, and traceable",
+                 sl="premise-a,premise-b", db_path=str(db))
+
+    node = api.show_node("belief", db_path=str(db))
+    assert node["truth_value"] == "IN"
+
+    result = api.defeat_with_scope(
+        "belief", 0,
+        scope_findings=[
+            {"antecedent": "premise-a", "establishes": "safety",
+             "does_not_establish": "traceability"},
+            {"antecedent": "premise-b", "establishes": "correctness",
+             "does_not_establish": "traceability"},
+        ],
+        missing_property="traceability",
+        db_path=str(db),
+    )
+
+    assert result["node_id"] == "belief"
+    assert result["justification_index"] == 0
+    assert len(result["scope_belief_ids"]) == 2
+    assert "belief" in result["changed"]
+
+    node = api.show_node("belief", db_path=str(db))
+    assert node["truth_value"] == "OUT"
+
+
+def test_scope_beliefs_are_premises(tmp_path):
+    """Verify scope beliefs are created as IN premises with correct metadata."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1 text", db_path=str(db))
+    api.add_node("derived", "Derived text", sl="p1", db_path=str(db))
+
+    result = api.defeat_with_scope(
+        "derived", 0,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Y"},
+        ],
+        missing_property="Y",
+        db_path=str(db),
+    )
+
+    scope_id = result["scope_belief_ids"][0]
+    scope = api.show_node(scope_id, db_path=str(db))
+    assert scope["truth_value"] == "IN"
+    assert scope["justifications"] == []
+    assert scope["metadata"]["scope_of"] == "p1"
+    assert scope["metadata"]["for_defeater"] == result["defeater_id"]
+    assert "establishes X" in scope["text"]
+    assert "does not establish Y" in scope["text"]
+
+
+def test_defeater_is_derived(tmp_path):
+    """Verify the defeater is a derived node with SL justification."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("d1", "D1", sl="p1", db_path=str(db))
+
+    result = api.defeat_with_scope(
+        "d1", 0,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Y"},
+        ],
+        missing_property="Y",
+        db_path=str(db),
+    )
+
+    defeater = api.show_node(result["defeater_id"], db_path=str(db))
+    assert defeater["truth_value"] == "IN"
+    assert len(defeater["justifications"]) == 1
+    j = defeater["justifications"][0]
+    assert j["type"] == "SL"
+    assert j["antecedents"] == result["scope_belief_ids"]
+    assert defeater["metadata"]["defeats_node"] == "d1"
+    assert defeater["metadata"]["defeats_justification"] == 0
+
+
+def test_challenge_scope_restores_target(tmp_path):
+    """Challenging a scope belief should restore the original belief."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("p2", "P2", db_path=str(db))
+    api.add_node("target", "Target", sl="p1,p2", db_path=str(db))
+
+    result = api.defeat_with_scope(
+        "target", 0,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Z"},
+            {"antecedent": "p2", "establishes": "Y", "does_not_establish": "Z"},
+        ],
+        missing_property="Z",
+        db_path=str(db),
+    )
+
+    assert api.show_node("target", db_path=str(db))["truth_value"] == "OUT"
+
+    scope_id = result["scope_belief_ids"][0]
+    api.retract_node(scope_id, db_path=str(db))
+
+    assert api.show_node(scope_id, db_path=str(db))["truth_value"] == "OUT"
+    defeater = api.show_node(result["defeater_id"], db_path=str(db))
+    assert defeater["truth_value"] == "OUT"
+    assert api.show_node("target", db_path=str(db))["truth_value"] == "IN"
+
+
+def test_defeat_with_scope_in_export(tmp_path):
+    """Verify scope beliefs and justified defeater survive export/import."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("d1", "D1", sl="p1", db_path=str(db))
+
+    result = api.defeat_with_scope(
+        "d1", 0,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Y"},
+        ],
+        missing_property="Y",
+        db_path=str(db),
+    )
+
+    export = api.export_network(db_path=str(db))
+    scope_id = result["scope_belief_ids"][0]
+    assert scope_id in export["nodes"]
+    assert result["defeater_id"] in export["nodes"]
+
+    defeater_data = export["nodes"][result["defeater_id"]]
+    assert len(defeater_data["justifications"]) == 1
+    assert defeater_data["justifications"][0]["antecedents"] == [scope_id]
+
+    db2 = tmp_path / "test2.db"
+    api.init_db(str(db2))
+    import json
+    json_path = tmp_path / "export.json"
+    json_path.write_text(json.dumps(export))
+    api.import_json(str(json_path), db_path=str(db2))
+
+    d1 = api.show_node("d1", db_path=str(db2))
+    assert d1["truth_value"] == "OUT"
+
+
+def test_defeat_with_scope_errors(tmp_path):
+    """Test error cases for defeat_with_scope."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("d1", "D1", sl="p1", db_path=str(db))
+
+    with pytest.raises(KeyError, match="not found"):
+        api.defeat_with_scope("nonexistent", 0, [{"antecedent": "p1",
+            "establishes": "X"}], "Y", db_path=str(db))
+
+    with pytest.raises(ValueError, match="no justifications"):
+        api.defeat_with_scope("p1", 0, [{"antecedent": "p1",
+            "establishes": "X"}], "Y", db_path=str(db))
+
+    with pytest.raises(IndexError, match="out of range"):
+        api.defeat_with_scope("d1", 5, [{"antecedent": "p1",
+            "establishes": "X"}], "Y", db_path=str(db))
+
+    with pytest.raises(ValueError, match="scope_findings must not be empty"):
+        api.defeat_with_scope("d1", 0, [], "Y", db_path=str(db))
+
+
+def test_scope_ids_are_unique(tmp_path):
+    """Multiple defeats on same node don't collide on scope belief IDs."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("d1", "D1", sl="p1", db_path=str(db))
+
+    r1 = api.defeat_with_scope(
+        "d1", 0,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Y"},
+        ],
+        missing_property="Y",
+        defeater_id="defeater-1",
+        db_path=str(db),
+    )
+
+    api.add_justification("d1", sl="p1", db_path=str(db))
+
+    r2 = api.defeat_with_scope(
+        "d1", 1,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Z"},
+        ],
+        missing_property="Z",
+        defeater_id="defeater-2",
+        db_path=str(db),
+    )
+
+    all_ids = set(r1["scope_belief_ids"] + r2["scope_belief_ids"])
+    assert len(all_ids) == 2
+
+
+def test_cascade_through_scope_defeat(tmp_path):
+    """Defeating a belief cascades to its dependents."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("d1", "D1", sl="p1", db_path=str(db))
+    api.add_node("d2", "D2 depends on D1", sl="d1", db_path=str(db))
+
+    assert api.show_node("d2", db_path=str(db))["truth_value"] == "IN"
+
+    result = api.defeat_with_scope(
+        "d1", 0,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Y"},
+        ],
+        missing_property="Y",
+        db_path=str(db),
+    )
+
+    assert api.show_node("d1", db_path=str(db))["truth_value"] == "OUT"
+    assert api.show_node("d2", db_path=str(db))["truth_value"] == "OUT"


### PR DESCRIPTION
## Summary

- Adds `defeat_with_scope()` API function that creates scope belief premises and a derived defeater with SL justification citing them, per the Fable review's recommendation on #231
- Scope beliefs describe what each antecedent establishes — they're small, concrete, independently challengeable premises
- Challenging any scope belief causes the defeater to go OUT, restoring the original belief
- Adds `--auto-defeat` flag to `review-beliefs` CLI (separate from `--auto-retract`)
- Adds `defeat-with-scope` CLI subcommand for manual use with a JSON scope file
- Extends review prompt to emit `scope_findings` and `missing_property` for invalid beliefs

Closes #231

## Test plan

- [x] 8 new tests in `test_defeat_with_scope.py` all pass
- [x] All 1572 existing tests pass
- [ ] Run `review-beliefs --auto-defeat` on a small set and verify scope beliefs + justified defeaters are created
- [ ] Challenge a scope belief and verify the target restores to IN

🤖 Generated with [Claude Code](https://claude.com/claude-code)