### PR TITLE
Add defeat-reason-type metadata (#234)

### DIFF
--- a/reasons/api.py
+++ b/reasons/api.py
@@ -988,6 +988,7 @@ def defeat_justification(
     reason: str,
     defeater_type: str = "invalid-inference",
     defeater_id: str | None = None,
+    defeat_reason_type: str = "",
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """Defeat a justification by adding a defeater belief to its outlist.
@@ -1002,6 +1003,7 @@ def defeat_justification(
         reason: Explanation of why the justification is invalid
         defeater_type: Type of defeater (invalid-inference, over-generalizes, etc.)
         defeater_id: Custom defeater ID (default: {type}-{node_id}-j{index})
+        defeat_reason_type: Logical failure mode classification
         db_path: Path to database
 
     Returns: {
@@ -1009,6 +1011,7 @@ def defeat_justification(
         "justification_index": int,
         "defeater_id": str,
         "defeater_type": str,
+        "defeat_reason_type": str,
         "changed": list[str]
     }
     """
@@ -1035,14 +1038,18 @@ def defeat_justification(
 
         before = {nid: n.truth_value for nid, n in net.nodes.items()}
 
+        meta = {
+            "defeater_type": defeater_type,
+            "defeats_node": node_id,
+            "defeats_justification": justification_index,
+        }
+        if defeat_reason_type:
+            meta["defeat_reason_type"] = defeat_reason_type
+
         defeater = net.add_node(
             id=defeater_id,
             text=defeater_text,
-            metadata={
-                "defeater_type": defeater_type,
-                "defeats_node": node_id,
-                "defeats_justification": justification_index,
-            },
+            metadata=meta,
         )
 
         if defeater_id not in justification.outlist:
@@ -1062,6 +1069,7 @@ def defeat_justification(
             "justification_index": justification_index,
             "defeater_id": defeater_id,
             "defeater_type": defeater_type,
+            "defeat_reason_type": defeat_reason_type,
             "changed": actually_changed,
         }
 
@@ -1073,6 +1081,7 @@ def defeat_with_scope(
     missing_property: str,
     defeater_type: str = "invalid-inference",
     defeater_id: str | None = None,
+    defeat_reason_type: str = "",
     db_path: str = DEFAULT_DB,
 ) -> dict:
     """Defeat a justification with a derived defeater backed by scope beliefs.
@@ -1091,6 +1100,7 @@ def defeat_with_scope(
             antecedent establishes
         defeater_type: Type of defeater
         defeater_id: Custom defeater ID
+        defeat_reason_type: Logical failure mode classification
         db_path: Path to database
 
     Returns: {
@@ -1098,6 +1108,7 @@ def defeat_with_scope(
         "justification_index": int,
         "defeater_id": str,
         "defeater_type": str,
+        "defeat_reason_type": str,
         "scope_belief_ids": list[str],
         "changed": list[str]
     }
@@ -1154,6 +1165,14 @@ def defeat_with_scope(
             f"{node_id} claims {missing_property}, but no antecedent establishes it "
             f"(defeats {node_id} justification {justification_index})"
         )
+        defeater_meta = {
+            "defeater_type": defeater_type,
+            "defeats_node": node_id,
+            "defeats_justification": justification_index,
+        }
+        if defeat_reason_type:
+            defeater_meta["defeat_reason_type"] = defeat_reason_type
+
         defeater = net.add_node(
             id=defeater_id,
             text=defeater_text,
@@ -1164,11 +1183,7 @@ def defeat_with_scope(
                     label=f"scope-defeat of {node_id} j{justification_index}",
                 ),
             ],
-            metadata={
-                "defeater_type": defeater_type,
-                "defeats_node": node_id,
-                "defeats_justification": justification_index,
-            },
+            metadata=defeater_meta,
         )
 
         if defeater_id not in justification.outlist:
@@ -1188,6 +1203,7 @@ def defeat_with_scope(
             "justification_index": justification_index,
             "defeater_id": defeater_id,
             "defeater_type": defeater_type,
+            "defeat_reason_type": defeat_reason_type,
             "scope_belief_ids": scope_belief_ids,
             "changed": actually_changed,
         }

--- a/reasons/build_wiki.py
+++ b/reasons/build_wiki.py
@@ -92,12 +92,14 @@ def _format_node(node_id, node_detail, node_to_page, all_details=None):
         if defeaters:
             for d_id, d_meta, d_text in defeaters:
                 d_type = d_meta.get("defeater_type", "defeater")
+                r_type = d_meta.get("defeat_reason_type", "")
+                label = f"{d_type}, {r_type}" if r_type else d_type
                 page = node_to_page.get(d_id)
                 if page:
                     link = f"[{d_id}]({page}#{d_id})"
                 else:
                     link = d_id
-                lines.append(f"**Defeated by:** {link} ({d_type})")
+                lines.append(f"**Defeated by:** {link} ({label})")
             lines.append("")
 
     lines.append(node_detail["text"])

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -207,14 +207,18 @@ def cmd_defeat_justification(args):
             args.reason,
             defeater_type=args.type or "invalid-inference",
             defeater_id=getattr(args, "defeater_id", None),
+            defeat_reason_type=getattr(args, "reason_type", None) or "",
             db_path=args.db,
         )
     except (KeyError, ValueError, IndexError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
+    dtype = result['defeater_type']
+    rtype = result.get('defeat_reason_type', '')
+    label = f"{dtype}, {rtype}" if rtype else dtype
     print(f"Defeated justification {result['justification_index']} of {result['node_id']}")
-    print(f"  Defeater: {result['defeater_id']} ({result['defeater_type']})")
+    print(f"  Defeater: {result['defeater_id']} ({label})")
     if result["changed"]:
         went_out = [nid for nid in result["changed"] if nid != result["node_id"]]
         if result["node_id"] in result["changed"]:
@@ -245,6 +249,8 @@ def cmd_defeat_with_scope(args):
         print("Error: missing_property is empty in the provided file", file=sys.stderr)
         sys.exit(1)
 
+    reason_type = getattr(args, "reason_type", None) or data.get("defeat_reason_type", "")
+
     try:
         result = api.defeat_with_scope(
             args.node_id,
@@ -253,6 +259,7 @@ def cmd_defeat_with_scope(args):
             missing_property,
             defeater_type=args.type or "invalid-inference",
             defeater_id=getattr(args, "defeater_id", None),
+            defeat_reason_type=reason_type,
             db_path=args.db,
         )
     except (KeyError, ValueError, IndexError) as e:
@@ -260,7 +267,10 @@ def cmd_defeat_with_scope(args):
         sys.exit(1)
 
     print(f"Defeated justification {result['justification_index']} of {result['node_id']}")
-    print(f"  Defeater: {result['defeater_id']} ({result['defeater_type']})")
+    dtype = result['defeater_type']
+    rtype = result.get('defeat_reason_type', '')
+    label = f"{dtype}, {rtype}" if rtype else dtype
+    print(f"  Defeater: {result['defeater_id']} ({label})")
     print(f"  Scope beliefs: {len(result['scope_belief_ids'])}")
     for sid in result["scope_belief_ids"]:
         print(f"    - {sid}")
@@ -2016,17 +2026,22 @@ def cmd_review_beliefs(args):
         for r in invalid:
             scope_findings = r.get("scope_findings", [])
             missing_property = r.get("missing_property", r.get("comment", "invalid"))
+            reason_type = r.get("defeat_reason_type", "")
             try:
                 if scope_findings:
                     result = api.defeat_with_scope(
                         r["id"], 0, scope_findings, missing_property,
-                        defeater_type="invalid-inference", db_path=args.db)
-                    print(f"  DEFEATED {r['id']} with {len(result['scope_belief_ids'])} scope belief(s)")
+                        defeater_type="invalid-inference",
+                        defeat_reason_type=reason_type, db_path=args.db)
+                    rt = f" [{reason_type}]" if reason_type else ""
+                    print(f"  DEFEATED {r['id']} with {len(result['scope_belief_ids'])} scope belief(s){rt}")
                 else:
                     api.defeat_justification(
                         r["id"], 0, r.get("comment", "invalid"),
-                        defeater_type="invalid-inference", db_path=args.db)
-                    print(f"  DEFEATED {r['id']} (bare defeater, no scope findings)")
+                        defeater_type="invalid-inference",
+                        defeat_reason_type=reason_type, db_path=args.db)
+                    rt = f" [{reason_type}]" if reason_type else ""
+                    print(f"  DEFEATED {r['id']} (bare defeater, no scope findings){rt}")
             except Exception as e:
                 print(f"  ERROR defeating {r['id']}: {e}", file=sys.stderr)
 
@@ -2642,6 +2657,11 @@ def main():
     p.add_argument("reason", help="Why this justification is invalid")
     p.add_argument("--type", choices=["invalid-inference", "over-generalizes", "duplicate-of", "superseded-by"],
                    help="Type of defeater (default: invalid-inference)")
+    p.add_argument("--reason-type", dest="reason_type",
+                   choices=["unsupported-conjunct", "over-generalizes", "false-causal-claim",
+                            "internal-contradiction", "circular-reasoning", "missing-bridge",
+                            "scope-mismatch"],
+                   help="Logical failure mode classification")
     p.add_argument("--defeater-id", help="Custom defeater belief ID")
 
     # defeat-with-scope
@@ -2652,6 +2672,11 @@ def main():
                    help="JSON file with scope_findings and missing_property")
     p.add_argument("--type", choices=["invalid-inference", "over-generalizes", "duplicate-of", "superseded-by"],
                    help="Type of defeater (default: invalid-inference)")
+    p.add_argument("--reason-type", dest="reason_type",
+                   choices=["unsupported-conjunct", "over-generalizes", "false-causal-claim",
+                            "internal-contradiction", "circular-reasoning", "missing-bridge",
+                            "scope-mismatch"],
+                   help="Logical failure mode classification")
     p.add_argument("--defeater-id", help="Custom defeater belief ID")
 
     # migrate-defeaters

--- a/reasons/export_markdown.py
+++ b/reasons/export_markdown.py
@@ -85,8 +85,9 @@ def export_markdown(network: Network, repos: dict[str, str] | None = None) -> st
                 o_node = network.nodes.get(o)
                 if o_node and o_node.metadata.get("defeats_node") == node.id:
                     dtype = o_node.metadata.get("defeater_type", "defeater")
+                    rtype = o_node.metadata.get("defeat_reason_type", "")
                     if o not in [d[0] for d in all_defeaters]:
-                        all_defeaters.append((o, dtype))
+                        all_defeaters.append((o, dtype, rtype))
                 elif o not in all_unless:
                     all_unless.append(o)
         if all_deps:
@@ -94,8 +95,9 @@ def export_markdown(network: Network, repos: dict[str, str] | None = None) -> st
         if all_unless:
             lines.append(f"- Unless: {', '.join(all_unless)}")
         if all_defeaters:
-            for d_id, d_type in all_defeaters:
-                lines.append(f"- Defeated by: {d_id} ({d_type})")
+            for d_id, d_type, r_type in all_defeaters:
+                label = f"{d_type}, {r_type}" if r_type else d_type
+                lines.append(f"- Defeated by: {d_id} ({label})")
 
         # Retraction reason — from retract --reason or imported stale_reason
         retract_reason = node.metadata.get("retract_reason") or node.metadata.get("stale_reason")

--- a/reasons/review.py
+++ b/reasons/review.py
@@ -43,7 +43,8 @@ Return ONLY a JSON array. For each belief, one object:
     "unnecessary_antecedents": ["ant-id-1"],
     "comment": "brief explanation",
     "scope_findings": [],
-    "missing_property": ""
+    "missing_property": "",
+    "defeat_reason_type": ""
   }}
 ]
 ```
@@ -66,6 +67,15 @@ Rules:
   Set "missing_property" to the property the derived belief claims but
   no antecedent establishes. These fields enable structured defeaters
   that can be audited through the graph.
+- When "valid" is false, also set "defeat_reason_type" to classify
+  the logical failure mode. Use exactly one of:
+    - "unsupported-conjunct": conclusion claims a property no antecedent establishes
+    - "over-generalizes": conclusion universalizes from bounded evidence
+    - "false-causal-claim": conclusion asserts causation from co-occurrence
+    - "internal-contradiction": conclusion contradicts its own antecedents
+    - "circular-reasoning": antecedent presupposes the conclusion
+    - "missing-bridge": gap between subsystems not connected by antecedents
+    - "scope-mismatch": antecedents cover a narrower scope than conclusion claims
 
 ## Beliefs to review
 
@@ -143,6 +153,7 @@ def parse_review_response(response):
                 "comment": item.get("comment", ""),
                 "scope_findings": item.get("scope_findings", []),
                 "missing_property": item.get("missing_property", ""),
+                "defeat_reason_type": item.get("defeat_reason_type", ""),
             })
         if results:
             return results

--- a/tests/test_build_wiki.py
+++ b/tests/test_build_wiki.py
@@ -220,6 +220,33 @@ class TestFormatNode:
                               all_details=all_details)
         assert "**Defeated by:** def-1 (defeater)" in result
 
+    def test_defeated_by_with_reason_type(self):
+        defeater_detail = {
+            "text": "This defeats target-node",
+            "truth_value": "IN",
+            "justifications": [],
+            "dependents": [],
+            "metadata": {
+                "defeats_node": "target-node",
+                "defeater_type": "invalid-inference",
+                "defeat_reason_type": "scope-mismatch",
+            },
+        }
+        target_detail = {
+            "text": "A defeated belief",
+            "truth_value": "OUT",
+            "justifications": [{"antecedents": ["base"], "outlist": ["defeater-1"]}],
+            "dependents": [],
+        }
+        all_details = {
+            "target-node": target_detail,
+            "defeater-1": defeater_detail,
+        }
+        node_to_page = {"defeater-1": "misc.md"}
+        result = _format_node("target-node", target_detail, node_to_page,
+                              all_details=all_details)
+        assert "**Defeated by:** [defeater-1](misc.md#defeater-1) (invalid-inference, scope-mismatch)" in result
+
     def test_no_defeaters_without_all_details(self):
         detail = {
             "text": "A belief",

--- a/tests/test_defeat_with_scope.py
+++ b/tests/test_defeat_with_scope.py
@@ -239,3 +239,67 @@ def test_cascade_through_scope_defeat(tmp_path):
 
     assert api.show_node("d1", db_path=str(db))["truth_value"] == "OUT"
     assert api.show_node("d2", db_path=str(db))["truth_value"] == "OUT"
+
+
+def test_defeat_reason_type_stored(tmp_path):
+    """defeat_reason_type is stored in metadata and returned."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("d1", "D1", sl="p1", db_path=str(db))
+
+    result = api.defeat_with_scope(
+        "d1", 0,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Y"},
+        ],
+        missing_property="Y",
+        defeat_reason_type="unsupported-conjunct",
+        db_path=str(db),
+    )
+
+    assert result["defeat_reason_type"] == "unsupported-conjunct"
+    defeater = api.show_node(result["defeater_id"], db_path=str(db))
+    assert defeater["metadata"]["defeat_reason_type"] == "unsupported-conjunct"
+
+
+def test_defeat_reason_type_omitted(tmp_path):
+    """defeat_reason_type defaults to empty and is not stored when empty."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("d1", "D1", sl="p1", db_path=str(db))
+
+    result = api.defeat_with_scope(
+        "d1", 0,
+        scope_findings=[
+            {"antecedent": "p1", "establishes": "X", "does_not_establish": "Y"},
+        ],
+        missing_property="Y",
+        db_path=str(db),
+    )
+
+    assert result["defeat_reason_type"] == ""
+    defeater = api.show_node(result["defeater_id"], db_path=str(db))
+    assert "defeat_reason_type" not in defeater["metadata"]
+
+
+def test_defeat_justification_reason_type(tmp_path):
+    """defeat_justification stores defeat_reason_type in metadata."""
+    db = tmp_path / "test.db"
+    api.init_db(str(db))
+
+    api.add_node("p1", "P1", db_path=str(db))
+    api.add_node("d1", "D1", sl="p1", db_path=str(db))
+
+    result = api.defeat_justification(
+        "d1", 0, "overclaims scope",
+        defeat_reason_type="scope-mismatch",
+        db_path=str(db),
+    )
+
+    assert result["defeat_reason_type"] == "scope-mismatch"
+    defeater = api.show_node(result["defeater_id"], db_path=str(db))
+    assert defeater["metadata"]["defeat_reason_type"] == "scope-mismatch"

--- a/tests/test_export_markdown.py
+++ b/tests/test_export_markdown.py
@@ -113,3 +113,18 @@ class TestExportMarkdown:
         md = export_markdown(net)
         assert "- Defeated by: defeater-1 (rebuttal)" in md
         assert "- Unless: blocker" in md
+
+    def test_defeater_with_reason_type(self):
+        net = Network()
+        net.add_node("base", "Base premise")
+        net.add_node("derived", "Derived belief", justifications=[
+            Justification(type="SL", antecedents=["base"], outlist=["defeater-1"])
+        ])
+        net.add_node("defeater-1", "Defeats derived", metadata={
+            "defeater_type": "invalid-inference",
+            "defeat_reason_type": "unsupported-conjunct",
+            "defeats_node": "derived",
+        })
+        net.recompute_all()
+        md = export_markdown(net)
+        assert "- Defeated by: defeater-1 (invalid-inference, unsupported-conjunct)" in md

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -198,6 +198,23 @@ class TestParseReviewResponse:
         assert results[0]["necessary"] is True
         assert results[0]["unnecessary_antecedents"] == []
         assert results[0]["comment"] == ""
+        assert results[0]["defeat_reason_type"] == ""
+
+    def test_defeat_reason_type_parsed(self):
+        response = json.dumps([{
+            "id": "derived-ab",
+            "valid": False,
+            "sufficient": True,
+            "necessary": True,
+            "unnecessary_antecedents": [],
+            "comment": "overclaims",
+            "scope_findings": [{"antecedent": "p1", "establishes": "X"}],
+            "missing_property": "Y",
+            "defeat_reason_type": "unsupported-conjunct",
+        }])
+        results = parse_review_response(response)
+        assert len(results) == 1
+        assert results[0]["defeat_reason_type"] == "unsupported-conjunct"
 
     def test_skips_items_without_id(self):
         response = json.dumps([


### PR DESCRIPTION
## Summary

- Adds `defeat_reason_type` metadata field to classify *why* an inference failed, distinct from `defeater_type` which classifies the mechanism
- Threads through the full pipeline: review prompt → parser → API (`defeat_with_scope`, `defeat_justification`) → CLI (`--reason-type` flag, `--auto-defeat` passthrough) → rendering (export markdown + wiki)
- Seven valid types: `unsupported-conjunct`, `over-generalizes`, `false-causal-claim`, `internal-contradiction`, `circular-reasoning`, `missing-bridge`, `scope-mismatch`

## Test plan

- [x] 3 new tests in `test_defeat_with_scope.py` — stored in metadata, returned in result, omitted when empty
- [x] 1 new test in `test_review.py` — parsed from LLM response, defaults to empty
- [x] 1 new test in `test_export_markdown.py` — rendered as `(type, reason-type)`
- [x] 1 new test in `test_build_wiki.py` — rendered in wiki defeated-by line
- [x] All 113 tests pass

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)