### PR TITLE
Add classify-defeaters command (#239)

### DIFF
--- a/reasons/api.py
+++ b/reasons/api.py
@@ -1340,18 +1340,20 @@ def classify_defeat_reason_types(
     nodes = network.get("nodes", {})
 
     candidates = []
+    skipped = []
     for nid, node in nodes.items():
         meta = node.get("metadata") or {}
         if not meta.get("defeats_node"):
             continue
         if meta.get("defeat_reason_type"):
+            skipped.append({"id": nid, "reason": "already classified"})
             continue
         if defeater_type_filter and meta.get("defeater_type") != defeater_type_filter:
+            skipped.append({"id": nid, "reason": f"defeater_type '{meta.get('defeater_type')}' != '{defeater_type_filter}'"})
             continue
         candidates.append(nid)
 
     classified = []
-    skipped = []
     errors = []
 
     for nid in candidates:

--- a/reasons/api.py
+++ b/reasons/api.py
@@ -1312,6 +1312,72 @@ def migrate_retract_to_defeaters(
         return {"migrated": migrated, "skipped": skipped, "errors": errors}
 
 
+def classify_defeat_reason_types(
+    defeater_type_filter: str | None = None,
+    model: str = "claude",
+    timeout: int = 300,
+    dry_run: bool = True,
+    db_path: str = DEFAULT_DB,
+) -> dict:
+    """Classify unclassified defeaters by logical failure mode via LLM.
+
+    Finds defeater nodes (those with defeats_node metadata) that have no
+    defeat_reason_type, sends each to an LLM for classification, and
+    writes the result to metadata.
+
+    Args:
+        defeater_type_filter: Only classify defeaters with this defeater_type
+        model: LLM model for classification
+        timeout: LLM timeout in seconds
+        dry_run: If True, classify but don't write to db
+        db_path: Path to database
+
+    Returns: {"classified": [...], "skipped": [...], "errors": [...]}
+    """
+    from .review import classify_defeat_reason
+
+    network = export_network(db_path=db_path)
+    nodes = network.get("nodes", {})
+
+    candidates = []
+    for nid, node in nodes.items():
+        meta = node.get("metadata") or {}
+        if not meta.get("defeats_node"):
+            continue
+        if meta.get("defeat_reason_type"):
+            continue
+        if defeater_type_filter and meta.get("defeater_type") != defeater_type_filter:
+            continue
+        candidates.append(nid)
+
+    classified = []
+    skipped = []
+    errors = []
+
+    for nid in candidates:
+        node = nodes[nid]
+        meta = node.get("metadata") or {}
+        defeated_id = meta.get("defeats_node", "")
+        defeated = nodes.get(defeated_id, {})
+
+        reason_type = classify_defeat_reason(
+            node.get("text", ""),
+            defeated.get("text", ""),
+            model, timeout,
+        )
+
+        if not reason_type:
+            errors.append({"id": nid, "reason": "classification returned empty"})
+            continue
+
+        classified.append({"id": nid, "defeat_reason_type": reason_type})
+
+        if not dry_run:
+            set_metadata(nid, "defeat_reason_type", reason_type, db_path=db_path)
+
+    return {"classified": classified, "skipped": skipped, "errors": errors}
+
+
 def challenge(
     target_id: str,
     reason: str,

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -319,6 +319,43 @@ def cmd_migrate_defeaters(args):
         print("No candidates found")
 
 
+def cmd_classify_defeaters(args):
+    if getattr(args, "pg", None) or os.environ.get("REASONS_PG_CONNINFO"):
+        print("Error: classify-defeaters is not supported with --pg", file=sys.stderr)
+        sys.exit(1)
+
+    dry_run = not args.apply
+    result = api.classify_defeat_reason_types(
+        defeater_type_filter=getattr(args, "type", None),
+        model=args.model,
+        timeout=args.timeout,
+        dry_run=dry_run,
+        db_path=args.db,
+    )
+
+    if dry_run:
+        print("Dry run — no changes applied")
+        print()
+
+    if result["classified"]:
+        print(f"{'Would classify' if dry_run else 'Classified'}: {len(result['classified'])}")
+        for c in result["classified"]:
+            print(f"  {c['id']}: {c['defeat_reason_type']}")
+
+    if result["skipped"]:
+        print(f"Skipped: {len(result['skipped'])}")
+        for s in result["skipped"]:
+            print(f"  {s['id']}: {s['reason']}")
+
+    if result["errors"]:
+        print(f"Errors: {len(result['errors'])}")
+        for e in result["errors"]:
+            print(f"  {e['id']}: {e['reason']}")
+
+    if not result["classified"] and not result["skipped"] and not result["errors"]:
+        print("No unclassified defeaters found")
+
+
 def cmd_assert(args):
     try:
         result = api.assert_node(args.node_id, **_backend_kwargs(args))
@@ -2684,6 +2721,13 @@ def main():
     p.add_argument("node_ids", nargs="*", help="Specific nodes to migrate (default: all candidates)")
     p.add_argument("--apply", action="store_true", help="Apply changes (default is dry-run)")
 
+    # classify-defeaters
+    p = sub.add_parser("classify-defeaters", help="Classify unclassified defeaters by logical failure mode via LLM")
+    p.add_argument("--model", "-m", required=True, help="LLM model for classification")
+    p.add_argument("--apply", action="store_true", help="Apply changes (default is dry-run)")
+    p.add_argument("--type", help="Only classify defeaters with this defeater_type")
+    p.add_argument("--timeout", type=int, default=300, help="LLM timeout in seconds (default: 300)")
+
     # what-if
     p = sub.add_parser("what-if", help="Simulate retracting or asserting a node (read-only)")
     p.add_argument("action", choices=["retract", "assert"], help="Action to simulate")
@@ -3303,6 +3347,7 @@ def main():
         "defeat-justification": cmd_defeat_justification,
         "defeat-with-scope": cmd_defeat_with_scope,
         "migrate-defeaters": cmd_migrate_defeaters,
+        "classify-defeaters": cmd_classify_defeaters,
         "what-if": cmd_what_if,
         "status": cmd_status,
         "show": cmd_show,

--- a/reasons/review.py
+++ b/reasons/review.py
@@ -127,6 +127,8 @@ def classify_defeat_reason(defeater_text, defeated_text, model, timeout):
         print(f"  WARN: classification failed: {e}", file=sys.stderr)
         return ""
     result = result.strip().lower()
+    if result in DEFEAT_REASON_TYPES:
+        return result
     for t in DEFEAT_REASON_TYPES:
         if t in result:
             return t

--- a/reasons/review.py
+++ b/reasons/review.py
@@ -82,6 +82,57 @@ Rules:
 {beliefs}"""
 
 
+DEFEAT_REASON_TYPES = [
+    "unsupported-conjunct",
+    "over-generalizes",
+    "false-causal-claim",
+    "internal-contradiction",
+    "circular-reasoning",
+    "missing-bridge",
+    "scope-mismatch",
+]
+
+CLASSIFY_DEFEAT_REASON_PROMPT = """\
+You are classifying the logical failure mode of a defeat verdict in a \
+Truth Maintenance System. The defeater explains why a derived belief's \
+justification is invalid.
+
+Classify the failure mode as exactly one of:
+- unsupported-conjunct: conclusion claims a property no antecedent establishes
+- over-generalizes: conclusion universalizes from bounded evidence
+- false-causal-claim: conclusion asserts causation from co-occurrence
+- internal-contradiction: conclusion contradicts its own antecedents
+- circular-reasoning: antecedent presupposes the conclusion
+- missing-bridge: gap between subsystems not connected by antecedents
+- scope-mismatch: antecedents cover a narrower scope than conclusion claims
+
+Defeater text: {defeater_text}
+Defeated belief: {defeated_text}
+
+Respond with exactly one type from the list above, nothing else."""
+
+
+def classify_defeat_reason(defeater_text, defeated_text, model, timeout):
+    """Classify a defeater's logical failure mode via LLM.
+
+    Returns one of the DEFEAT_REASON_TYPES or empty string on failure.
+    """
+    prompt = CLASSIFY_DEFEAT_REASON_PROMPT.format(
+        defeater_text=defeater_text,
+        defeated_text=defeated_text,
+    )
+    try:
+        result = invoke_model(prompt, model=model, timeout=timeout)
+    except Exception as e:
+        print(f"  WARN: classification failed: {e}", file=sys.stderr)
+        return ""
+    result = result.strip().lower()
+    for t in DEFEAT_REASON_TYPES:
+        if t in result:
+            return t
+    return ""
+
+
 def format_belief_for_review(node_id, nodes):
     """Format one derived belief with antecedent texts for LLM review."""
     node = nodes.get(node_id)

--- a/tests/test_classify_defeaters.py
+++ b/tests/test_classify_defeaters.py
@@ -1,0 +1,149 @@
+"""Tests for classify-defeaters command."""
+
+from unittest.mock import patch
+
+from reasons import api
+from reasons.review import classify_defeat_reason, DEFEAT_REASON_TYPES
+
+
+class TestClassifyDefeatReason:
+
+    def test_returns_valid_type(self):
+        mock_result = type("R", (), {
+            "returncode": 0, "stdout": "unsupported-conjunct", "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = classify_defeat_reason("defeater text", "defeated text",
+                                            "claude", 300)
+        assert result == "unsupported-conjunct"
+
+    def test_extracts_type_from_prose(self):
+        mock_result = type("R", (), {
+            "returncode": 0,
+            "stdout": "The failure mode is over-generalizes because...",
+            "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = classify_defeat_reason("defeater text", "defeated text",
+                                            "claude", 300)
+        assert result == "over-generalizes"
+
+    def test_returns_empty_on_unrecognized(self):
+        mock_result = type("R", (), {
+            "returncode": 0, "stdout": "I cannot classify this",
+            "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = classify_defeat_reason("defeater text", "defeated text",
+                                            "claude", 300)
+        assert result == ""
+
+    def test_returns_empty_on_error(self):
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", side_effect=Exception("timeout")):
+            result = classify_defeat_reason("defeater text", "defeated text",
+                                            "claude", 300)
+        assert result == ""
+
+
+class TestClassifyDefeatReasonTypes:
+
+    def _setup_db(self, tmp_path):
+        db = tmp_path / "test.db"
+        api.init_db(str(db))
+        api.add_node("p1", "P1", db_path=str(db))
+        api.add_node("d1", "D1 is safe and traceable", sl="p1", db_path=str(db))
+        api.defeat_justification(
+            "d1", 0, "traceability not established",
+            defeater_type="migrated-retraction", db_path=str(db))
+        return str(db)
+
+    def test_dry_run_classifies_without_writing(self, tmp_path):
+        db = self._setup_db(tmp_path)
+        mock_result = type("R", (), {
+            "returncode": 0, "stdout": "unsupported-conjunct", "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = api.classify_defeat_reason_types(
+                model="claude", dry_run=True, db_path=db)
+
+        assert len(result["classified"]) == 1
+        assert result["classified"][0]["defeat_reason_type"] == "unsupported-conjunct"
+
+        defeater_id = result["classified"][0]["id"]
+        node = api.show_node(defeater_id, db_path=db)
+        assert "defeat_reason_type" not in node["metadata"]
+
+    def test_apply_writes_metadata(self, tmp_path):
+        db = self._setup_db(tmp_path)
+        mock_result = type("R", (), {
+            "returncode": 0, "stdout": "scope-mismatch", "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = api.classify_defeat_reason_types(
+                model="claude", dry_run=False, db_path=db)
+
+        assert len(result["classified"]) == 1
+        defeater_id = result["classified"][0]["id"]
+        node = api.show_node(defeater_id, db_path=db)
+        assert node["metadata"]["defeat_reason_type"] == "scope-mismatch"
+
+    def test_skips_already_classified(self, tmp_path):
+        db = self._setup_db(tmp_path)
+        mock_result = type("R", (), {
+            "returncode": 0, "stdout": "scope-mismatch", "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            api.classify_defeat_reason_types(
+                model="claude", dry_run=False, db_path=db)
+            result = api.classify_defeat_reason_types(
+                model="claude", dry_run=True, db_path=db)
+
+        assert len(result["classified"]) == 0
+
+    def test_filters_by_defeater_type(self, tmp_path):
+        db = self._setup_db(tmp_path)
+        mock_result = type("R", (), {
+            "returncode": 0, "stdout": "unsupported-conjunct", "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = api.classify_defeat_reason_types(
+                defeater_type_filter="invalid-inference",
+                model="claude", dry_run=True, db_path=db)
+        assert len(result["classified"]) == 0
+
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = api.classify_defeat_reason_types(
+                defeater_type_filter="migrated-retraction",
+                model="claude", dry_run=True, db_path=db)
+        assert len(result["classified"]) == 1
+
+    def test_skips_non_defeater_nodes(self, tmp_path):
+        db = tmp_path / "test.db"
+        api.init_db(str(db))
+        api.add_node("p1", "P1", db_path=str(db))
+        api.add_node("p2", "P2", db_path=str(db))
+
+        result = api.classify_defeat_reason_types(
+            model="claude", dry_run=True, db_path=str(db))
+        assert len(result["classified"]) == 0
+
+    def test_errors_on_classification_failure(self, tmp_path):
+        db = self._setup_db(tmp_path)
+        mock_result = type("R", (), {
+            "returncode": 0, "stdout": "I don't know", "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = api.classify_defeat_reason_types(
+                model="claude", dry_run=True, db_path=db)
+        assert len(result["classified"]) == 0
+        assert len(result["errors"]) == 1
+
+
+class TestDefeatReasonTypes:
+
+    def test_all_types_valid(self):
+        assert len(DEFEAT_REASON_TYPES) == 7
+        for t in DEFEAT_REASON_TYPES:
+            assert "-" in t

--- a/tests/test_classify_defeaters.py
+++ b/tests/test_classify_defeaters.py
@@ -28,6 +28,17 @@ class TestClassifyDefeatReason:
                                             "claude", 300)
         assert result == "over-generalizes"
 
+    def test_exact_match_preferred(self):
+        mock_result = type("R", (), {
+            "returncode": 0,
+            "stdout": "scope-mismatch",
+            "stderr": ""})()
+        with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
+             patch("reasons.llm.subprocess.run", return_value=mock_result):
+            result = classify_defeat_reason("defeater text", "defeated text",
+                                            "claude", 300)
+        assert result == "scope-mismatch"
+
     def test_returns_empty_on_unrecognized(self):
         mock_result = type("R", (), {
             "returncode": 0, "stdout": "I cannot classify this",
@@ -100,6 +111,7 @@ class TestClassifyDefeatReasonTypes:
                 model="claude", dry_run=True, db_path=db)
 
         assert len(result["classified"]) == 0
+        assert any(s["reason"] == "already classified" for s in result["skipped"])
 
     def test_filters_by_defeater_type(self, tmp_path):
         db = self._setup_db(tmp_path)
@@ -111,6 +123,7 @@ class TestClassifyDefeatReasonTypes:
                 defeater_type_filter="invalid-inference",
                 model="claude", dry_run=True, db_path=db)
         assert len(result["classified"]) == 0
+        assert any("migrated-retraction" in s["reason"] for s in result["skipped"])
 
         with patch("reasons.llm.shutil.which", return_value="/usr/bin/claude"), \
              patch("reasons.llm.subprocess.run", return_value=mock_result):


### PR DESCRIPTION
## Summary

- Adds `reasons classify-defeaters` CLI command to backfill `defeat_reason_type` on existing defeaters via LLM classification
- Adds `CLASSIFY_DEFEAT_REASON_PROMPT` and `classify_defeat_reason()` to `review.py` for single-defeater classification
- Adds `classify_defeat_reason_types()` API function that finds unclassified defeaters, classifies each via LLM, and writes metadata
- Supports `--type` filter (e.g. `migrated-retraction`), dry-run by default, `--apply` to write

## Test plan

- [x] 4 tests for `classify_defeat_reason()` — valid type, prose extraction, unrecognized, error handling
- [x] 6 tests for `classify_defeat_reason_types()` — dry-run, apply, skip classified, filter by type, skip non-defeaters, classification failure
- [x] 1 test for `DEFEAT_REASON_TYPES` constant
- [x] All 11 tests pass

Closes #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)