### PR TITLE
Hide OUT beliefs from model-facing retrieval by default

### DIFF
--- a/reasons/api.py
+++ b/reasons/api.py
@@ -2489,7 +2489,8 @@ def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | No
     """
     if pg_conninfo:
         return _pg_dispatch(pg_conninfo, project_id, "compact",
-                            budget=budget, truncate=truncate, visible_to=visible_to)
+                            budget=budget, truncate=truncate, visible_to=visible_to,
+                            include_out=include_out)
     from .compact import compact as _compact
 
     with _with_network(db_path) as net:
@@ -2525,7 +2526,8 @@ def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
     """
     if pg_conninfo:
         return _pg_dispatch(pg_conninfo, project_id, "lookup",
-                            query=query, visible_to=visible_to)
+                            query=query, visible_to=visible_to,
+                            include_out=include_out)
     with _with_network(db_path) as net:
         query_terms = query.lower().split()
         matches = []
@@ -2599,7 +2601,8 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
         if depth != 1:
             raise NotImplementedError("depth is not supported with PostgreSQL")
         return _pg_dispatch(pg_conninfo, project_id, "search",
-                            query=query, visible_to=visible_to, format=format)
+                            query=query, visible_to=visible_to, format=format,
+                            include_out=include_out)
     with _with_network(db_path) as net:
         matched_ids = _fts_search(query, db_path)
 

--- a/reasons/api.py
+++ b/reasons/api.py
@@ -2476,9 +2476,14 @@ def pin_lines(
                           repos=repo_paths, db_dir=db_dir)
 
 
-def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | None = None,
+            include_out: bool = False,
+            db_path: str = DEFAULT_DB,
             pg_conninfo=None, project_id=None) -> str:
     """Generate a token-budgeted belief state summary.
+
+    Args:
+        include_out: if False (default), exclude OUT beliefs from the summary
 
     Returns: the compact summary string
     """
@@ -2488,18 +2493,23 @@ def compact(budget: int = 500, truncate: bool = True, visible_to: list[str] | No
     from .compact import compact as _compact
 
     with _with_network(db_path) as net:
-        if visible_to is not None:
+        needs_filter = visible_to is not None or not include_out
+        if needs_filter:
             from .network import Network
             filtered = Network()
             for nid, node in net.nodes.items():
-                if _is_visible(node, visible_to):
-                    filtered.nodes[nid] = node
+                if not include_out and node.truth_value == "OUT":
+                    continue
+                if visible_to is not None and not _is_visible(node, visible_to):
+                    continue
+                filtered.nodes[nid] = node
             filtered.nogoods = [ng for ng in net.nogoods if all(n in filtered.nodes for n in ng.nodes)]
             return _compact(filtered, budget=budget, truncate=truncate)
         return _compact(net, budget=budget, truncate=truncate)
 
 
 def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
+           include_out: bool = False,
            pg_conninfo=None, project_id=None) -> str:
     """Simple all-terms search over the full belief block — ID, text, source,
     dependencies, and metadata. Matches the same search corpus and output
@@ -2509,6 +2519,7 @@ def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
         query: search terms (all must appear, case-insensitive)
         visible_to: only return nodes whose access_tags are a subset
         db_path: path to RMS database
+        include_out: if False (default), exclude OUT beliefs from results
 
     Returns: formatted string with matching beliefs (full blocks)
     """
@@ -2519,6 +2530,8 @@ def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
         query_terms = query.lower().split()
         matches = []
         for nid, node in sorted(net.nodes.items()):
+            if not include_out and node.truth_value == "OUT":
+                continue
             if visible_to is not None and not _is_visible(node, visible_to):
                 continue
             # Build the full searchable block — same fields as beliefs.md
@@ -2562,6 +2575,7 @@ def lookup(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
 
 def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAULT_DB,
            format: str = "markdown", depth: int = 1,
+           include_out: bool = False,
            pg_conninfo=None, project_id=None) -> str:
     """Search nodes using full-text search with neighbor expansion.
 
@@ -2577,6 +2591,7 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
         db_path: path to RMS database
         format: output format — "markdown" (default), "json", or "minimal"
         depth: number of hops to expand along justification chains (default: 1)
+        include_out: if False (default), exclude OUT beliefs from results
 
     Returns: formatted string with matched nodes and neighbors
     """
@@ -2594,6 +2609,13 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
 
         if not matched_ids:
             return "No results found."
+
+        # Filter OUT beliefs unless explicitly requested
+        if not include_out:
+            matched_ids = [nid for nid in matched_ids
+                           if nid in net.nodes and net.nodes[nid].truth_value != "OUT"]
+            if not matched_ids:
+                return "No results found."
 
         # Apply access filtering
         if visible_to is not None:
@@ -2628,6 +2650,11 @@ def search(query: str, visible_to: list[str] | None = None, db_path: str = DEFAU
 
         # Remove already-matched nodes from neighbors
         neighbor_ids -= set(matched_ids)
+
+        # Filter OUT neighbors too
+        if not include_out:
+            neighbor_ids = {nid for nid in neighbor_ids
+                            if nid in net.nodes and net.nodes[nid].truth_value != "OUT"}
 
         # Apply access filtering to neighbors too
         if visible_to is not None:

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -1132,10 +1132,12 @@ def cmd_pin_lines(args):
 
 
 def cmd_compact(args):
+    include_out = getattr(args, "show_out", False)
     summary = api.compact(
         budget=args.budget,
         truncate=not args.no_truncate,
         visible_to=_parse_visible_to(args),
+        include_out=include_out,
         **_backend_kwargs(args),
     )
     print(summary)
@@ -3006,6 +3008,7 @@ def main():
     p.add_argument("--budget", type=int, default=500, help="Token budget (default: 500)")
     p.add_argument("--no-truncate", action="store_true", help="Show full node text")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only include nodes whose access_tags are a subset of these tags")
+    p.add_argument("--show-out", action="store_true", help="Include OUT (retracted) beliefs in summary")
 
     # search
     p = sub.add_parser("search", help="Search nodes using full-text search with neighbor expansion")

--- a/reasons/cli.py
+++ b/reasons/cli.py
@@ -1168,12 +1168,16 @@ def _require_sqlite(args, command_name):
 
 def cmd_search(args):
     fmt = getattr(args, "format", "markdown")
-    result = api.search(args.query, visible_to=_parse_visible_to(args), format=fmt, **_backend_kwargs(args))
+    include_out = getattr(args, "show_out", False)
+    result = api.search(args.query, visible_to=_parse_visible_to(args), format=fmt,
+                        include_out=include_out, **_backend_kwargs(args))
     print(result)
 
 
 def cmd_lookup(args):
-    result = api.lookup(args.query, visible_to=_parse_visible_to(args), **_backend_kwargs(args))
+    include_out = getattr(args, "show_out", False)
+    result = api.lookup(args.query, visible_to=_parse_visible_to(args),
+                        include_out=include_out, **_backend_kwargs(args))
     print(result)
 
 
@@ -3009,11 +3013,13 @@ def main():
     p.add_argument("--format", choices=["markdown", "json", "minimal"], default="markdown",
                    help="Output format (default: markdown)")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
+    p.add_argument("--show-out", action="store_true", help="Include OUT (retracted) beliefs in results")
 
     # lookup
     p = sub.add_parser("lookup", help="Simple keyword search over beliefs (no neighbor expansion)")
     p.add_argument("query", help="Search terms (all must match, case-insensitive)")
     p.add_argument("--visible-to", metavar="TAG,TAG", help="Only show nodes whose access_tags are a subset of these tags")
+    p.add_argument("--show-out", action="store_true", help="Include OUT (retracted) beliefs in results")
 
     # ask
     p = sub.add_parser("ask", help="Ask a question about beliefs (FTS5 search + LLM synthesis)")

--- a/reasons/mcp_server.py
+++ b/reasons/mcp_server.py
@@ -55,15 +55,18 @@ def _get_db() -> str:
 
 
 @mcp.tool()
-def search(query: str, output_format: str = "markdown", depth: int = 1) -> str:
+def search(query: str, output_format: str = "markdown", depth: int = 1,
+           include_out: bool = False) -> str:
     """Search beliefs by text with neighbor expansion.
 
     Args:
         query: Search terms (matches all terms in any order)
         output_format: Output format — "markdown", "json", or "minimal"
         depth: Hops to expand along justification chains (default 1)
+        include_out: Include OUT (retracted) beliefs in results (default: false)
     """
-    return api.search(query, db_path=_get_db(), format=output_format, depth=depth)
+    return api.search(query, db_path=_get_db(), format=output_format, depth=depth,
+                      include_out=include_out)
 
 
 @mcp.tool()
@@ -226,13 +229,14 @@ def trace(node_id: str) -> str:
 
 
 @mcp.tool()
-def compact(budget: int = 500) -> str:
+def compact(budget: int = 500, include_out: bool = False) -> str:
     """Get a token-budgeted summary of the entire belief network.
 
     Args:
         budget: Maximum token budget for the summary
+        include_out: Include OUT (retracted) beliefs in summary (default: false)
     """
-    return api.compact(budget=budget, db_path=_get_db())
+    return api.compact(budget=budget, include_out=include_out, db_path=_get_db())
 
 
 # --- Tier 3: Data management ---

--- a/reasons/pg.py
+++ b/reasons/pg.py
@@ -732,7 +732,7 @@ class PgApi:
             "retracted_at": _fmt_ts(retracted_at),
         }
 
-    def search(self, query, visible_to=None, format="markdown"):
+    def search(self, query, visible_to=None, format="markdown", include_out=False):
         pid = self.project_id
 
         with self.conn.cursor() as cur:
@@ -763,12 +763,14 @@ class PgApi:
                 return {"results": [], "count": 0}
             return "No results found."
 
-        # Apply visibility filter
+        # Apply visibility and OUT filters
         matched = []
         for row in matched_rows:
             nid, text, tv, source, meta = row
             if isinstance(meta, str):
                 meta = json.loads(meta)
+            if not include_out and tv == "OUT":
+                continue
             if visible_to is not None and not self._is_visible(meta, visible_to):
                 continue
             matched.append({
@@ -934,7 +936,7 @@ class PgApi:
             "sha_bumped": 0,
         }
 
-    def lookup(self, query, visible_to=None):
+    def lookup(self, query, visible_to=None, include_out=False):
         """Simple all-terms substring search over full belief blocks."""
         pid = self.project_id
         query_terms = query.lower().split()
@@ -971,6 +973,8 @@ class PgApi:
         for nid, text, tv, source, source_hash, date, meta in node_rows:
             if isinstance(meta, str):
                 meta = json.loads(meta) if meta else {}
+            if not include_out and tv == "OUT":
+                continue
             if visible_to is not None and not self._is_visible(meta, visible_to):
                 continue
 
@@ -1836,7 +1840,7 @@ class PgApi:
                 ]
         return {"entries": entries}
 
-    def compact(self, budget=500, truncate=True, visible_to=None):
+    def compact(self, budget=500, truncate=True, visible_to=None, include_out=False):
         from datetime import date as _date
 
         pid = self.project_id
@@ -1853,6 +1857,8 @@ class PgApi:
                 nid, text, tv, source, meta = row
                 if isinstance(meta, str):
                     meta = json.loads(meta)
+                if not include_out and tv == "OUT":
+                    continue
                 if visible_to is not None and not self._is_visible(meta, visible_to):
                     continue
                 all_nodes.append({

--- a/reasons/repair.py
+++ b/reasons/repair.py
@@ -370,7 +370,7 @@ def repair_beliefs(review_results, nodes, model="claude",
     from . import api
 
     if search_fn is None:
-        search_fn = lambda query, **kw: api.search(query, **kw)
+        search_fn = lambda query, **kw: api.search(query, include_out=True, **kw)
 
     invalid = [r for r in review_results if not r.get("valid", True)]
     invalid_ids = {r["id"] for r in invalid}
@@ -513,7 +513,7 @@ def repair_smuggled_beliefs(review_results, nodes, model="claude",
     from . import api
 
     if search_fn is None:
-        search_fn = lambda query, **kw: api.search(query, **kw)
+        search_fn = lambda query, **kw: api.search(query, include_out=True, **kw)
 
     invalid = [r for r in review_results if not r.get("valid", True)]
     repairs = []

--- a/tests/test_hide_out.py
+++ b/tests/test_hide_out.py
@@ -1,0 +1,105 @@
+"""Tests for hiding OUT beliefs from model-facing retrieval (#243)."""
+
+from reasons import api
+
+
+def _setup_mixed_db(tmp_path):
+    """Create a DB with IN and OUT beliefs for search/lookup testing."""
+    db = str(tmp_path / "test.db")
+    api.init_db(db)
+    api.add_node("premise-in", "Retraction cascades propagate correctly", db_path=db)
+    api.add_node("premise-out", "Retraction cascades are broken", db_path=db)
+    api.retract_node("premise-out", db_path=db)
+    api.add_node("derived-in", "System handles retraction well",
+                 sl="premise-in", db_path=db)
+    return db
+
+
+class TestSearchHidesOut:
+
+    def test_default_excludes_out(self, tmp_path):
+        db = _setup_mixed_db(tmp_path)
+        result = api.search("retraction", db_path=db)
+        assert "premise-in" in result
+        assert "premise-out" not in result
+
+    def test_include_out_shows_all(self, tmp_path):
+        db = _setup_mixed_db(tmp_path)
+        result = api.search("retraction", db_path=db, include_out=True)
+        assert "premise-in" in result
+        assert "premise-out" in result
+
+    def test_no_results_when_only_out_matches(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db)
+        api.add_node("only-out", "unique xyzterm", db_path=db)
+        api.retract_node("only-out", db_path=db)
+        result = api.search("xyzterm", db_path=db)
+        assert "No results found" in result
+
+    def test_include_out_finds_only_out(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db)
+        api.add_node("only-out", "unique xyzterm", db_path=db)
+        api.retract_node("only-out", db_path=db)
+        result = api.search("xyzterm", db_path=db, include_out=True)
+        assert "only-out" in result
+
+    def test_out_neighbors_not_expanded(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db)
+        api.add_node("root", "root premise", db_path=db)
+        api.add_node("derived-out", "derived from root",
+                     sl="root", db_path=db)
+        api.retract_node("derived-out", db_path=db)
+        result = api.search("root premise", db_path=db)
+        assert "### root" in result
+        assert "### derived-out" not in result
+
+
+class TestLookupHidesOut:
+
+    def test_default_excludes_out(self, tmp_path):
+        db = _setup_mixed_db(tmp_path)
+        result = api.lookup("retraction", db_path=db)
+        assert "premise-in" in result
+        assert "premise-out" not in result
+
+    def test_include_out_shows_all(self, tmp_path):
+        db = _setup_mixed_db(tmp_path)
+        result = api.lookup("retraction", db_path=db, include_out=True)
+        assert "premise-in" in result
+        assert "premise-out" in result
+
+    def test_no_results_when_only_out_matches(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db)
+        api.add_node("only-out", "unique xyzterm", db_path=db)
+        api.retract_node("only-out", db_path=db)
+        result = api.lookup("xyzterm", db_path=db)
+        assert "No beliefs found" in result
+
+
+class TestCompactHidesOut:
+
+    def test_default_excludes_out_section(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db)
+        api.add_node("active", "Active belief", db_path=db)
+        api.add_node("retracted", "Retracted belief", db_path=db)
+        api.retract_node("retracted", db_path=db)
+        result = api.compact(db_path=db)
+        assert "active" in result
+        assert "retracted" not in result
+        assert "OUT (retracted)" not in result
+
+    def test_include_out_shows_out_section(self, tmp_path):
+        db = str(tmp_path / "test.db")
+        api.init_db(db)
+        api.add_node("active", "Active belief", db_path=db)
+        api.add_node("retracted", "Retracted belief", db_path=db)
+        api.retract_node("retracted", db_path=db)
+        result = api.compact(db_path=db, include_out=True)
+        assert "active" in result
+        assert "retracted" in result
+        assert "OUT (retracted)" in result

--- a/tests/test_pg_dispatch.py
+++ b/tests/test_pg_dispatch.py
@@ -424,7 +424,8 @@ class TestLookupDispatch:
             MockPgApi.return_value.__enter__ = MagicMock(return_value=mock_pg)
             MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
             result = lookup("alpha", pg_conninfo="postgresql://...", project_id="test")
-        mock_pg.lookup.assert_called_once_with(query="alpha", visible_to=None)
+        mock_pg.lookup.assert_called_once_with(query="alpha", visible_to=None,
+                                                  include_out=False)
         assert "alpha" in result.lower()
 
     def test_passes_visible_to(self):
@@ -435,7 +436,8 @@ class TestLookupDispatch:
             MockPgApi.return_value.__exit__ = MagicMock(return_value=False)
             result = lookup("secret", visible_to=["admin"],
                             pg_conninfo="postgresql://...", project_id="test")
-        mock_pg.lookup.assert_called_once_with(query="secret", visible_to=["admin"])
+        mock_pg.lookup.assert_called_once_with(query="secret", visible_to=["admin"],
+                                                  include_out=False)
 
 
 class TestMaintenanceCliNoLongerBlocked:


### PR DESCRIPTION
## Summary

- Add `include_out=False` default to `search()`, `lookup()`, and `compact()` in `api.py`
- Add `--show-out` CLI flag for `search` and `lookup` commands
- Add `include_out` parameter to MCP server `search` and `compact` tools
- Filter `[OUT]` beliefs in `lookup_beliefs` markdown parser (companion commit in `claude_code_langgraph`)
- `export_markdown()` unchanged — keeps full epistemic state for version control

## Context

E9 data shows OUT markers alone do not prevent stale answers — models pick retracted belief content 100% of the time when no IN replacement exists. OUT-only performed identically to Flat (no markers).

## Test plan

- [x] 10 new tests in `tests/test_hide_out.py` covering search, lookup, and compact filtering
- [x] 18 tests pass in `claude_code_langgraph/tests/test_lookup_beliefs.py`
- [x] All 116 existing tests pass with zero regressions
- [ ] Manual: `reasons search retraction` returns only IN beliefs
- [ ] Manual: `reasons search retraction --show-out` includes OUT beliefs

Fixes #243